### PR TITLE
Make error pages optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 sudo: required
 dist: trusty
+notifications:
+  email: false
 addons:
   apt:
     packages:

--- a/public/404.html
+++ b/public/404.html
@@ -6,6 +6,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>404 Not Found</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            color: black;
+            text-align: center;
+            font-size: 1.25rem;
+        }
+
+        h1 a {
+            text-decoration: none;
+            color: black;
+        }
+
+        a {
+            color: #0366d6;
+        }
+    </style>
 </head>
 
 <body>

--- a/public/50x.html
+++ b/public/50x.html
@@ -6,6 +6,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>50x Service Unavailable</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            color: black;
+            text-align: center;
+            font-size: 1.25rem;
+        }
+
+        h1 a {
+            text-decoration: none;
+            color: black;
+        }
+
+        a {
+            color: #0366d6;
+        }
+    </style>
 </head>
 
 <body>

--- a/public/assets/main.css
+++ b/public/assets/main.css
@@ -1,5 +1,15 @@
 body {
-  font-family: Arial, Helvetica, sans-serif;
-  color: slategray;
+  font-family: sans-serif;
+  color: black;
   text-align: center;
+  font-size: 1.2rem;
+}
+
+h1 a {
+  text-decoration: none;
+  color: black;
+}
+
+a {
+  color: #0366d6;
 }

--- a/public/assets/main.js
+++ b/public/assets/main.js
@@ -1,1 +1,1 @@
-(() => console.log("Hello world!"))()
+(() => console.log("Static Web Server running!"))()

--- a/public/index.html
+++ b/public/index.html
@@ -5,14 +5,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>My awesome static web page!</title>
+    <title>Static Web Server - A blazing fast static files-serving web server powered by Rust Iron.</title>
     <link rel="stylesheet" href="/assets/main.css">
     <link rel="shortcut icon" href="/assets/favicon.ico">
 </head>
 
 <body>
-    <p>My awesome static web page!</p>
-
+    <h1>Static Web Server</h1>
+    <p>A blazing fast static files-serving web server powered by <a href="https://github.com/iron/iron"
+            target="_blank">Rust Iron</a>.</p>
+    <p><a href="https://github.com/joseluisq/static-web-server/" target="_blank">View on GitHub</a></p>
     <script src="/assets/main.js"></script>
 </body>
 

--- a/src/error_page.rs
+++ b/src/error_page.rs
@@ -9,19 +9,33 @@ use std::path::Path;
 
 /// Custom Error pages middleware for Iron
 pub struct ErrorPage {
-    /// HTML file content for 50x errors.
-    pub page50x: std::string::String,
     /// HTML file content for 404 errors.
-    pub page404: std::string::String,
+    pub page404: String,
+    /// HTML file content for 50x errors.
+    pub page50x: String,
 }
 
 impl ErrorPage {
     /// Create a new instance of `ErrorPage` middleware with a given html pages.
-    pub fn new<P: AsRef<Path>>(page_50x_path: P, page_404_path: P) -> ErrorPage {
-        let page50x = fs::read_to_string(page_50x_path).unwrap();
-        let page404 = fs::read_to_string(page_404_path).unwrap();
+    pub fn new<P: AsRef<Path>>(page_404_path: P, page_50x_path: P) -> ErrorPage {
+        let page404: String;
+        let page50x: String;
 
-        ErrorPage { page50x, page404 }
+        if Path::new(&page_404_path.as_ref()).exists() {
+            page404 = fs::read_to_string(page_404_path).unwrap();
+        } else {
+            page404 = String::from("<h2>404</h2><p>Content could not found</p>");
+        }
+
+        if Path::new(&page_50x_path.as_ref()).exists() {
+            page50x = fs::read_to_string(page_50x_path).unwrap();
+        } else {
+            page50x = String::from(
+                "<h2>50x</h2><p>Service is temporarily unavailable due an unexpected error</p>",
+            );
+        }
+
+        ErrorPage { page404, page50x }
     }
 }
 

--- a/src/staticfiles.rs
+++ b/src/staticfiles.rs
@@ -45,8 +45,8 @@ impl StaticFiles {
         chain.link_after(GzipMiddleware);
         chain.link_after(Logger);
         chain.link_after(ErrorPage::new(
-            self.opts.page_50x_path.as_str(),
             self.opts.page_404_path.as_str(),
+            self.opts.page_50x_path.as_str(),
         ));
         chain
     }


### PR DESCRIPTION
This PR makes optional the error pages feature introducing default response HTML messages for 400 and 50x errors.

 Resolves #6