### PR TITLE
Add support for termination signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,16 +157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
-dependencies = [
- "nix",
- "winapi",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,7 +306,7 @@ dependencies = [
 [[package]]
 name = "iron_staticfile_middleware"
 version = "0.2.0"
-source = "git+https://github.com/joseluisq/iron-staticfile-middleware.git#562b241a80a7e216ccdbe1d4d603f1a0b621d5b1"
+source = "git+https://github.com/joseluisq/iron-staticfile-middleware.git#4e02bc6eda9cf88bf4b7866581ae83efda7f3110"
 dependencies = [
  "iron",
  "log 0.4.8",
@@ -431,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.17.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 dependencies = [
  "bitflags",
  "cc",
@@ -863,6 +853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f6ce83b159ab6984d2419f495134972b48754d13ff2e3f8c998339942b56ed9"
+dependencies = [
+ "libc",
+ "nix",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,14 +879,15 @@ name = "static-web-server"
 version = "1.5.0"
 dependencies = [
  "chrono",
- "ctrlc",
  "env_logger",
  "flate2",
  "hyper-native-tls",
  "iron",
  "iron_staticfile_middleware",
  "log 0.4.8",
+ "nix",
  "openssl",
+ "signal",
  "structopt",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +427,19 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
 ]
 
 [[package]]
@@ -856,6 +879,7 @@ name = "static-web-server"
 version = "1.5.0"
 dependencies = [
  "chrono",
+ "ctrlc",
  "env_logger",
  "flate2",
  "hyper-native-tls",
@@ -1079,6 +1103,12 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ structopt = "0.3"
 flate2 = "1.0"
 iron_staticfile_middleware = { git = "https://github.com/joseluisq/iron-staticfile-middleware.git" }
 hyper-native-tls = "0.3"
+ctrlc = "3.1"
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ structopt = "0.3"
 flate2 = "1.0"
 iron_staticfile_middleware = { git = "https://github.com/joseluisq/iron-staticfile-middleware.git" }
 hyper-native-tls = "0.3"
-ctrlc = "3.1"
+nix = "0.14"
+signal = "0.7"
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/Makefile
+++ b/Makefile
@@ -225,3 +225,10 @@ prod.release.dockerfiles:
 	# Update docker files to latest tag per platform
 	./docker/version.sh v$(PKG_TAG)
 .ONESHELL: prod.release.dockerfiles
+
+loadtest:
+	@echo "GET http://localhost:1234" | \
+		vegeta -cpus=12 attack -workers=10 -duration=5s -connections=10000 -rate=200 -http2=false > results.bin
+	@cat results.bin | vegeta report -type='hist[0,2ms,4ms,6ms]'
+	@cat results.bin | vegeta plot > plot.html
+.PHONY: loadtest

--- a/src/signal_manager.rs
+++ b/src/signal_manager.rs
@@ -1,0 +1,56 @@
+use nix::errno::Errno;
+use nix::libc::c_int;
+use nix::sys::signal::{SIGCHLD, SIGINT, SIGTERM};
+use nix::sys::wait::WaitStatus::{Exited, Signaled, StillAlive};
+use nix::sys::wait::{waitpid, WaitPidFlag};
+use nix::Error;
+use signal::trap::Trap;
+
+/// It waits for an incoming Termination Signal like Ctrl+C (SIGINT), SIGTERM, etc
+pub fn wait_for_signal<F>(f: F)
+where
+    F: Fn(signal::Signal),
+{
+    let signal_trap = Trap::trap(&[SIGTERM, SIGINT, SIGCHLD]);
+
+    for sig in signal_trap {
+        match sig {
+            SIGCHLD => {
+                // Current std::process::Command ip does not have a way to find
+                // process id, so we just wait until we have no children
+                loop {
+                    match waitpid(None, Some(WaitPidFlag::WNOHANG)) {
+                        Ok(Exited(pid, status)) => {
+                            println!("{} exited with status {}", pid, status);
+                            continue;
+                        }
+                        Ok(Signaled(pid, sig, _)) => {
+                            println!("{} killed by {}", pid, sig as c_int);
+                            continue;
+                        }
+                        Ok(StillAlive) => {
+                            break;
+                        }
+                        Ok(status) => {
+                            println!("Temporary status {:?}", status);
+                            continue;
+                        }
+                        Err(Error::Sys(Errno::ECHILD)) => {
+                            return;
+                        }
+                        Err(e) => {
+                            panic!("Error {:?}", e);
+                        }
+                    }
+                }
+            }
+
+            sig => f(sig),
+        }
+    }
+}
+
+/// It casts a `signal::Signal` to `i32`
+pub fn signal_to_int(sig: signal::Signal) -> i32 {
+    sig as c_int
+}


### PR DESCRIPTION
It handles termination signals like Ctrl+C (SIGINT), SIGTERM, etc. Resolves #13.

**Example:**

```sh
~> docker run --rm -p 1234:80 -it static-web-server:alpine
# 2020-03-04T08:19:58 [INFO] - Static HTTP Server `my-static-server` is running on [::]:80
# ^C
# 2020-03-04T08:20:00 [WARN] - SIGINT 2 caught. HTTP Server execution exited.
```