### PR TITLE
Use jemalloc as global allocator only on Linux Musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +335,27 @@ dependencies = [
  "rustc-serialize",
  "time",
  "url",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
 ]
 
 [[package]]
@@ -920,6 +947,7 @@ dependencies = [
  "iron-cors",
  "iron-test",
  "iron_staticfile_middleware",
+ "jemallocator",
  "log 0.4.8",
  "nix",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ edition = "2018"
 include = ["src/**/*", "Cargo.toml", "Cargo.lock"]
 
 [dependencies]
-jemallocator = "0.3.2"
 iron = "0.6"
 log = "0.4"
 chrono = "0.4"
@@ -33,6 +32,9 @@ hyper-native-tls = "0.3"
 nix = "0.14"
 signal = "0.7"
 iron-cors = "0.8"
+
+[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
+version = "0.3"
 
 [dev-dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2018"
 include = ["src/**/*", "Cargo.toml", "Cargo.lock"]
 
 [dependencies]
+jemallocator = "0.3.2"
 iron = "0.6"
 log = "0.4"
 chrono = "0.4"
@@ -40,4 +41,6 @@ iron-test = "0.6"
 tempdir = "0.3"
 
 [profile.release]
-lto = true
+lto = "fat"
+codegen-units = 1
+panic = "abort"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(all(target_env = "musl", target_pointer_width = "64"))]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
A performance improvement which introduces [jemalloc](https://github.com/jemalloc/jemalloc) as default Musl's allocator.
This PR is motivated by awesome description shared by [ripgrep](https://github.com/BurntSushi/ripgrep/blob/master/crates/core/main.rs#L23-L41).

Because this project is a web server which target is mainly `musl x86_x64`, I believe that [jemalloc]([jemalloc](https://github.com/jemalloc/jemalloc) ) is a suitable option for such use case.
Making it clear that this doesn't affect the `darwin` target.  

Here a very simple and quick benchmark:

**Computer specs**

```sh
Operating System: Arch Linux
Kernel Version: 5.7.6-arch1-1
OS Type: 64-bit
Processors: 4 × Intel® Core™ i7-6500U CPU @ 2.50GHz
Memory: 7.6 GiB of RAM
```

**v1.9.2 (default musl allocator)**

```sh
~> wrk --latency -t12 -c100 -d10s http://localhost:8787/

Running 10s test @ http://localhost:8787/
  12 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.85ms    1.01ms  52.70ms   96.81%
    Req/Sec     7.19k     3.10k   14.14k    78.20%
  Latency Distribution
     50%  753.00us
     75%    0.93ms
     90%    1.26ms
     99%    3.71ms
  357858 requests in 10.08s, 347.42MB read
Requests/sec:  35491.35
Transfer/sec:     34.46MB
```

**With jemalloc enabled as default musl allocator (v1.9.2)**

```sh
~> wrk --latency -t12 -c100 -d10s http://localhost:8787/

Running 10s test @ http://localhost:8787/
  12 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   662.31us    1.07ms  80.90ms   97.88%
    Req/Sec    10.74k     2.25k   18.65k    74.00%
  Latency Distribution
     50%  546.00us
     75%  732.00us
     90%    1.00ms
     99%    2.83ms
  427965 requests in 10.05s, 415.49MB read
Requests/sec:  42572.32
Transfer/sec:     41.33MB
```

The perfomance improvement is not huge but relevant. Which represents 18.14% more requests/sec enabling jemalloc.