### PR TITLE
HTTP redirect server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - First-class [Docker](https://docs.docker.com/get-started/overview/) support. [Scratch](https://hub.docker.com/_/scratch) and latest [Alpine Linux](https://hub.docker.com/_/alpine) Docker images available.
 - Server configurable via environment variables or CLI arguments.
 - MacOs binary support (`x86_64-apple-darwin`) thanks to [Rust Linux / Darwin Builder](https://github.com/joseluisq/rust-linux-darwin-builder).
+- Additional HTTP redirect server for redirecting HTTP traffic to HTTPS site.
 
 ## Releases
 
@@ -47,6 +48,8 @@ Server can be configured either via environment variables or their equivalent co
 | `SERVER_TLS` | Enables TLS/SSL support. Make sure also to adjust current server port. | Default `false` |
 | `SERVER_TLS_PKCS12` | A cryptographic identity [PKCS #12](https://docs.rs/native-tls/0.2.3/native_tls/struct.Identity.html#method.from_pkcs12) bundle file path containing a [X509 certificate](https://en.wikipedia.org/wiki/X.509) along with its corresponding private key and chain of certificates to a trusted root. | Default empty |
 | `SERVER_TLS_PKCS12_PASSWD` | A specified password to decrypt the private key. | Default empty |
+| `SERVER_TLS_REDIRECT_FROM` | Host port for redirecting HTTP requests to HTTPS. This option enables the HTTP redirect feature | Default empty (disabled) |
+| `SERVER_TLS_REDIRECT_HOST` | Host name of HTTPS site for redirecting HTTP requests to. | Default host address |
 | `SERVER_CORS_ALLOW_ORIGINS` | Specify a CORS list of allowed origin hosts separated by comas with no whitespaces. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host. See [Iron CORS crate](https://docs.rs/iron-cors/0.8.0/iron_cors/#mode-1-whitelist). | Default empty (which means CORS is disabled) |
 
 ### Command-line arguments
@@ -92,6 +95,13 @@ OPTIONS:
             corresponding private key and chain of certificates to a trusted root [env: SERVER_TLS_PKCS12=]  [default: ]
         --tls-pkcs12-passwd <tls-pkcs12-passwd>
             A specified password to decrypt the private key [env: SERVER_TLS_PKCS12_PASSWD=]  [default: ]
+
+        --tls-redirect-from <tls-redirect-from>
+            Host port for redirecting HTTP requests to HTTPS. This option enables the HTTP redirect feature [env:
+            SERVER_TLS_REDIRECT_FROM=]
+        --tls-redirect-host <tls-redirect-host>
+            Host name of HTTPS site for redirecting HTTP requests to. Defaults to host address [env:
+            SERVER_TLS_REDIRECT_HOST=]
 ```
 
 ## TLS/SSL

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,12 @@ pub struct Options {
     #[structopt(long, default_value = "", env = "SERVER_TLS_PKCS12_PASSWD")]
     /// A specified password to decrypt the private key.
     pub tls_pkcs12_passwd: String,
+    #[structopt(long, env = "SERVER_TLS_REDIRECT_FROM")]
+    /// Host port for redirecting HTTP requests to HTTPS. This option enables the HTTP redirect feature.
+    pub tls_redirect_from: Option<u16>,
+    #[structopt(long, env = "SERVER_TLS_REDIRECT_HOST")]
+    /// Host name of HTTPS site for redirecting HTTP requests to. Defaults to host address.
+    pub tls_redirect_host: Option<String>,
     #[structopt(long, default_value = "error", env = "SERVER_LOG_LEVEL")]
     /// Specify a logging level in lower case.
     pub log_level: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ extern crate log;
 
 use crate::config::Options;
 use hyper_native_tls::NativeTlsServer;
-use iron::prelude::*;
+use iron::{prelude::*, Listening};
 use staticfiles::*;
 use structopt::StructOpt;
 
@@ -19,12 +19,21 @@ mod logger;
 mod signal_manager;
 mod staticfiles;
 
-fn on_server_running(server_name: &str, proto: &str, addr: &str) {
+/// Struct for holding a reference to a running iron server instance
+#[derive(Debug)]
+struct RunningServer {
+    listening: Listening,
+    server_type: String,
+}
+
+fn on_server_running(server_name: &str, running_servers: &Vec<RunningServer>) {
     // Notify when server is running
-    logger::log_server(&format!(
-        "Static {} Server \"{}\" is listening on {}",
-        proto, server_name, addr
-    ));
+    running_servers.iter().for_each(|server| {
+        logger::log_server(&format!(
+            "{} Server \"{}\" is listening on {}",
+            server.server_type, server_name, server.listening.socket
+        ))
+    });
 
     // Wait for incoming signals (E.g Ctrl+C (SIGINT), SIGTERM, etc
     signal_manager::wait_for_signal(|sig: signal::Signal| {
@@ -42,7 +51,6 @@ fn main() {
     logger::init(&opts.log_level);
 
     let addr = &format!("{}{}{}", opts.host, ":", opts.port);
-    let proto = if opts.tls { "HTTPS" } else { "HTTP" };
 
     // Configure & launch the HTTP server
 
@@ -54,19 +62,29 @@ fn main() {
         cors_allow_origins: opts.cors_allow_origins,
     });
 
+    let mut running_servers = Vec::new();
     if opts.tls {
+        // Launch static HTTPS server
         let ssl = NativeTlsServer::new(opts.tls_pkcs12, &opts.tls_pkcs12_passwd).unwrap();
 
         match Iron::new(files.handle()).https(addr, ssl) {
-            Result::Ok(_) => on_server_running(&opts.name, &proto, addr),
+            Result::Ok(listening) => running_servers.push(RunningServer {
+                listening,
+                server_type: "Static HTTPS".to_string(),
+            }),
             Result::Err(err) => panic!("{:?}", err),
         }
     } else {
+        // Launch static HTTP server
         match Iron::new(files.handle()).http(addr) {
-            Result::Ok(_) => on_server_running(&opts.name, &proto, addr),
+            Result::Ok(listening) => running_servers.push(RunningServer {
+                listening,
+                server_type: "Static HTTP".to_string(),
+            }),
             Result::Err(err) => panic!("{:?}", err),
         }
     }
+    on_server_running(&opts.name, &running_servers);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
It is a common use case that a web server that delivers content as HTTPS also supports redirecting from the HTTP protocol. This PR introduces a corresponding feature "HTTP redirect server" and contains the following changes:
- Restructure launch of servers    
  This change enables the possibility of launching multiple Iron server
  instances, which is required for implementing the redirect HTTP server.
- Add redirect HTTP server
  When using TLS/SSL, it may be desired to run an additional HTTP server
  that redirects all requests to the TLS/SSL version of the website as a
  convenience for the users.
  This server is disabled by default and can be enabled using the
  tls_redirect_from option. The HTTPS host for the redirect can be set
  through the tls_redirect_dest option.

Feel free to comment any flaws of the implementation, I'm happy to improve it.

This closes #25.