### PR TITLE
Support inheriting TCP listener from parent process via fd0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
+name = "listenfd"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492158e732f2e2de81c592f0a2427e57e12cd3d59877378fe7af624b6bbe0ca1"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +869,7 @@ dependencies = [
  "humansize",
  "hyper",
  "jemallocator",
+ "listenfd",
  "mime_guess",
  "nix",
  "num_cpus",
@@ -1115,6 +1127,15 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "uuid"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
+dependencies = [
+ "cfg-if 0.1.10",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pin-project = "1.0"
 tokio-rustls = { version = "0.22" }
 humansize = "1.1"
 time = "0.1"
+listenfd = "0.3.3"
 
 [target.'cfg(not(windows))'.dependencies.nix]
 version = "0.14"

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,9 @@ pub struct Config {
     /// socket listener on the specified file descriptor number (usually zero). Requires that the
     /// parent process (e.g. inetd, launchd, or systemd) binds an address and port on behalf of
     /// static-web-server, before arranging for the resulting file descriptor to be inherited by
-    /// static-web-server. Cannot be used in conjunction with the port and host arguments.
+    /// static-web-server. Cannot be used in conjunction with the port and host arguments. The
+    /// included systemd unit file utilises this feature to increase security by allowing the
+    /// static-web-server to be sandboxed more completely.
     pub fd: Option<usize>,
 
     #[structopt(

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,19 @@ pub struct Config {
 
     #[structopt(
         long,
+        short = "f",
+        env = "SERVER_LISTEN_FD",
+        conflicts_with_all(&["host", "port"])
+    )]
+    /// Instead of binding to a TCP port, accept incoming connections to an already-bound TCP
+    /// socket listener on the specified file descriptor number (usually zero). Requires that the
+    /// parent process (e.g. inetd, launchd, or systemd) binds an address and port on behalf of
+    /// static-web-server, before arranging for the resulting file descriptor to be inherited by
+    /// static-web-server. Cannot be used in conjunction with the port and host arguments.
+    pub fd: Option<usize>,
+
+    #[structopt(
+        long,
         short = "n",
         default_value = "1",
         env = "SERVER_THREADS_MULTIPLIER"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,3 +1,4 @@
+use std::io;
 use tracing::Level;
 use tracing_subscriber::fmt::format::FmtSpan;
 
@@ -7,6 +8,7 @@ use crate::Result;
 pub fn init(level: &str) -> Result {
     let level = level.parse::<Level>()?;
     match tracing_subscriber::fmt()
+        .with_writer(io::stderr)
         .with_max_level(level)
         .with_span_events(FmtSpan::CLOSE)
         .try_init()

--- a/systemd/etc_default_static-web-server
+++ b/systemd/etc_default_static-web-server
@@ -1,0 +1,5 @@
+SERVER_ROOT=/var/www/html
+SERVER_HTTP2_TLS=true
+SERVER_HTTP2_TLS_CERT=/etc/static-web-server/example_org_fullchain.pem
+SERVER_HTTP2_TLS_KEY=/etc/static-web-server/example_org_privkey.pem
+SERVER_LOG_LEVEL=warn

--- a/systemd/static-web-server.service
+++ b/systemd/static-web-server.service
@@ -1,0 +1,107 @@
+# Example systemd service unit file (see systemd.service(5) man page) for use
+# with the --fd option of static-web-server.  This allows e.g. binding the
+# server to a TCP port number 0 - 1023 without running the server as root,
+# and/or running sws in an isolated network name space.
+#
+# This also allows sws to be started on-demand.  If sws is restart (e.g. after
+# updating its SSL certificates, or reconfiguring its content directory), new
+# inbound connections will be queued until sws is up and running again.
+#
+# A comprehensive description can be found in:
+# http://0pointer.de/blog/projects/socket-activation.html
+# ...and the linked articles.
+
+[Unit]
+Description=Static Web Server
+Wants=static-web-server.socket
+After=static-web-server.socket
+
+# The options below reflect a reasonably comprehensive sandboxing based on the
+# features available in systemd v247.  Newer versions of systemd may offer
+# additional options for sandboxing.
+#
+# The options below focus on security, when making changes to this unit file
+# you may wish to evaluated the output of:
+# systemd-analyze security static-web-server.service
+#
+# Beyond the limits used here, additional limits can be placed on CPU, memory,
+# and disk I/O, as well as network traffic filters (via eBPF and other
+# mechanisms), and implemented for this server using the systemd override
+# facilities.  See systemd.resource-control(5) for details.
+
+[Service]
+Type=simple
+
+# An example environment file for static-web-server is included in the file:
+# systemd/etc_default_static-web-server
+EnvironmentFile=/etc/default/static-web-server
+
+# File descriptor 0 corresponds to the standard input...
+ExecStart=/usr/local/bin/static-web-server --fd 0
+
+# ...so the following line attaches fd 0 of the static web server process to
+# the socket defined by the corresponding `static-web-server.socket` unit file.
+# Each instance of static-web-server currently only supports listening on a
+# single socket.
+StandardInput=fd:static-web-server.socket
+
+# Debug and tracing output goes to stderr, and can be viewed with e.g.
+# `journalctl -u static-web-server.service`.
+StandardError=journal
+
+Restart=always
+RestartSec=5
+DynamicUser=true
+SupplementaryGroups=www-data
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+CapabilityBoundingSet=
+RestrictNamespaces=true
+
+#RestrictAddressFamilies=none
+# ☟ workaround to implement ☝in older versions of systemd.
+#   see: https://github.com/systemd/systemd/issues/15753
+RestrictAddressFamilies=AF_UNIX
+RestrictAddressFamilies=~AF_UNIX
+
+PrivateDevices=true
+PrivateUsers=true
+PrivateNetwork=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProcSubset=pid
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+RestrictRealtime=true
+LockPersonality=true
+RemoveIPC=true
+MemoryDenyWriteExecute=true
+UMask=077
+ProtectHostname=true
+
+# Restrict the use of exotic system calls (bugs in seldom-used syscalls are a
+# historical source of kernel vulnerabilities)...
+SystemCallFilter=@system-service
+# ... It may be possible to restrict this further.  e.g.
+#SystemCallFilter=@signal @basic-io @io-event @network-io @process statx fstat sched_getaffinity getrandom
+# but a process to discover the set of system calls used (e.g. as part of the
+# unit tests) will probably be needed to avoid regressions e.g. due to changes
+# in crates which are used by static-web-server. The following may be useful to
+# record system calls performed:
+# "/usr/bin/strace --summary-only -o sws.syscallstats -- static-web-server [...]"
+# You can view the sets of system calls defined by systemd using:
+# "systemd-analyze syscall-filter"
+
+DevicePolicy=strict
+DeviceAllow=/dev/null rw
+DeviceAllow=/dev/random r
+DeviceAllow=/dev/urandom r
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/static-web-server.socket
+++ b/systemd/static-web-server.socket
@@ -1,0 +1,18 @@
+# Example systemd socket unit file (see systemd.socket(5) man page) for use
+# with the --fd option of static-web-server.  This allows e.g. binding the
+# server to a TCP port number 0 - 1023 without running the server as root,
+# and/or running sws in an isolated network name space.
+#
+# A comprehensive description can be found in:
+# http://0pointer.de/blog/projects/socket-activation.html
+# ...and the linked articles.
+
+[Unit]
+Description=Static Web Server Socket
+
+[Socket]
+ListenStream=443
+Accept=no
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Hi,

Here's a rough draft PR.  Not for merging yet, just for possible discussion.

- I'm not really happy with the option parsing.  Having just a switch e.g. `static-web-server --inherit-listener` seems reasonable, but it doesn't look like you can do that and also have an ENV variable control the same thing.  I'll have a closer look at this.
- Probably better to split off the transition to a separated `bind` call into a separate commit.
- Not sure if the trace output is OK or not?
- Error handling should be improved.

Closes #36