### PR TITLE
Improve address binding error messages and log them instead of just panic

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,10 @@ pub fn run(opts: Options) {
                 listening,
                 server_type: "HTTPS".to_string(),
             }),
-            Err(err) => panic!("{:?}", err),
+            Err(err) => {
+                error!("Error binding to address {} for https: {}", addr, err);
+                std::process::exit(1)
+            }
         }
 
         // Launch redirect HTTP server (if requested)
@@ -59,7 +62,13 @@ pub fn run(opts: Options) {
                     listening,
                     server_type: "Redirect HTTP".to_string(),
                 }),
-                Err(err) => panic!("{:?}", err),
+                Err(err) => {
+                    error!(
+                        "Error binding to address {} for http redirection: {}",
+                        addr, err
+                    );
+                    std::process::exit(1)
+                }
             }
         }
     } else {
@@ -69,7 +78,10 @@ pub fn run(opts: Options) {
                 listening,
                 server_type: "HTTP".to_string(),
             }),
-            Err(err) => panic!("{:?}", err),
+            Err(err) => {
+                error!("Error binding to address {} for http: {}", addr, err);
+                std::process::exit(1)
+            }
         }
     }
 


### PR DESCRIPTION
This PR improves the error messages and log them during HTTP, HTTPS and HTTP to HTTPS redirection server launching instead of just panic when address binding errors occur.

Now the error is shown in this way:

```log
2021-05-27T22:26:36 [ERROR] - Error binding to address [::]:80 for http: Permission denied (os error 13)
```

For example, it helps to make more obvious address binding errors like #42

