### PR TITLE
Security headers for HTTP/2 by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -108,4 +108,17 @@ pub struct Config {
     )]
     /// Enable directory listing for all requests ending with the slash character (‘/’).
     pub directory_listing: bool,
+
+    #[structopt(
+        long,
+        parse(try_from_str),
+        required_if("http2", "true"),
+        default_value_if("http2", Some("true"), "true"),
+        default_value = "false",
+        env = "SERVER_SECURITY_HEADERS"
+    )]
+    /// Enable security headers by default when HTTP/2 feature is activated.
+    /// Headers included: "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age),
+    /// "X-Frame-Options: DENY", "X-XSS-Protection: 1; mode=block" and "Content-Security-Policy: frame-ancestors 'self'".
+    pub security_headers: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error_page;
 pub mod handler;
 pub mod helpers;
 pub mod logger;
+pub mod security_headers;
 pub mod server;
 pub mod service;
 pub mod signals;

--- a/src/security_headers.rs
+++ b/src/security_headers.rs
@@ -1,0 +1,35 @@
+use http::header::{
+    CONTENT_SECURITY_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
+    X_XSS_PROTECTION,
+};
+use hyper::{Body, Response};
+
+/// It appends security headers like `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2 years max-age),
+///`X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block` and `Content-Security-Policy: frame-ancestors 'self'`.
+pub fn with_security_headers(resp: &mut Response<Body>) {
+    // Strict-Transport-Security (HSTS)
+    resp.headers_mut().insert(
+        STRICT_TRANSPORT_SECURITY,
+        "max-age=63072000; includeSubDomains; preload"
+            .parse()
+            .unwrap(),
+    );
+
+    // X-Frame-Options
+    resp.headers_mut()
+        .insert(X_FRAME_OPTIONS, "DENY".parse().unwrap());
+
+    // X-XSS-Protection
+    resp.headers_mut()
+        .insert(X_XSS_PROTECTION, "1; mode=block".parse().unwrap());
+
+    // X-Content-Type-Options
+    resp.headers_mut()
+        .insert(X_CONTENT_TYPE_OPTIONS, "nosniff".parse().unwrap());
+
+    // Content Security Policy (CSP)
+    resp.headers_mut().insert(
+        CONTENT_SECURITY_POLICY,
+        "frame-ancestors 'self'".parse().unwrap(),
+    );
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -89,9 +89,13 @@ impl Server {
             .set(helpers::read_file_content(opts.page50x.as_ref()))
             .expect("page 50x is not initialized");
 
+        // Security Headers option
+        let security_headers = opts.security_headers;
+        tracing::info!("security headers: enabled={}", security_headers);
+
         // Auto compression based on the `Accept-Encoding` header
         let compression = opts.compression;
-        tracing::info!("auto compression compression: enabled={}", compression);
+        tracing::info!("auto compression: enabled={}", compression);
 
         // Directory listing option
         let dir_listing = opts.directory_listing;
@@ -110,6 +114,7 @@ impl Server {
                 compression,
                 dir_listing,
                 cors,
+                security_headers,
             },
         });
 


### PR DESCRIPTION
This PR provides a set of generic security headers introducing a new boolean option `--security-headers` which is only enabled by default when HTTP/2 feature is activated via `--http2=true`.

Headers included:
- [x] `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2 years max-age). Resolves #39
- [x] `X-Frame-Options: DENY`
- [x] `X-XSS-Protection: 1; mode=block`
- [x] `X-Content-Type-Options: nosniff` 
- [x] `Content-Security-Policy: frame-ancestors 'self'`