### PR TITLE
Remove extra Docker Scratch/Alpine volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,18 @@ fmt:
 	@cargo fmt --all
 .PHONY: fmt
 
+docker.image:
+	@echo "Creating Docker Scratch image..."
+	@docker build \
+		--rm=true -f ./docker/scratch/Dockerfile \
+		--build-arg SERVER_VERSION="${PKG_TAG}" -t joseluisq/${PKG_NAME}:devel . --pull=true
+.PHONY: docker.image
+
 docker.image.alpine:
+	@echo "Creating Docker Alpine image..."
 	@docker build \
 		--rm=true -f ./docker/alpine/Dockerfile \
-		--build-arg SERVER_VERSION="alpine" -t ${PKG_NAME}:alpine . --pull=true
+		--build-arg SERVER_VERSION="${PKG_TAG}" -t joseluisq/${PKG_NAME}:devel-alpine . --pull=true
 .PHONY: docker.image.alpine
 
 

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -19,7 +19,6 @@ COPY ./docker/alpine/entrypoint.sh /
 COPY ./docker/public /public
 
 EXPOSE 80
-VOLUME ["/public"]
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["static-web-server"]
 

--- a/docker/scratch/Dockerfile
+++ b/docker/scratch/Dockerfile
@@ -15,7 +15,6 @@ COPY --from=latest /usr/local/bin/static-web-server /
 COPY ./docker/public /public
 
 EXPOSE 80
-VOLUME ["/public"]
 ENTRYPOINT ["/static-web-server"]
 
 # Metadata


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Scratch/Alpine Docker images create an extra Docker volume at `/public`.
The problem is that for example, an extra Docker volume can difficult umounting shares on unRAID and other environments.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #51

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since these extra Docker volumes can be optional. This PR remove them of `scratch` and `alpine` images.
So it allows to avoid extra Docker volumes for some directory (`/public`) that can be perfectly within the container. Leaving any volumes decision up to users.
For more context see #51

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using two new development Docker images. Testing should be done by @joseluisq and @bergi9

Docker development images:

- `joseluisq/static-web-server:devel` (scratch)
- `joseluisq/static-web-server:devel-alpine` (alpine)