### PR TITLE
Graceful shutdown support for http1 and http2 servers by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,12 +822,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+dependencies = [
+ "cc",
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c5d32165ff8b94e68e7b3bdecb1b082e958c22434b363482cfb89dcd6f3ff8"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]
@@ -877,6 +900,8 @@ dependencies = [
  "num_cpus",
  "percent-encoding",
  "pin-project",
+ "signal-hook",
+ "signal-hook-tokio",
  "structopt",
  "time",
  "tokio",
@@ -961,9 +986,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
- "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,16 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
-dependencies = [
- "nix",
- "winapi",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,15 +537,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,19 +582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -854,6 +822,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,7 +866,6 @@ dependencies = [
  "async-compression",
  "bcrypt",
  "bytes",
- "ctrlc",
  "futures-util",
  "headers",
  "http",
@@ -985,7 +961,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,13 @@ tokio-rustls = { version = "0.22" }
 tokio-util = { version = "0.6", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
-signal-hook = { version = "0.3.4", features = ["extended-siginfo"] }
-signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"], default-features = false }
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
 version = "0.3"
+
+[target.'cfg(not(windows))'.dependencies]
+signal-hook = { version = "0.3.4", features = ["extended-siginfo"] }
+signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"], default-features = false }
 
 [dev-dependencies]
 bytes = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ anyhow = "1.0"
 async-compression = { version = "0.3", features = ["brotli", "deflate", "gzip", "tokio"] }
 bcrypt = "0.10"
 bytes = "1.0"
-ctrlc = { version = "3.1", features = ["termination"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 headers = { git = "https://github.com/joseluisq/hyper-headers.git", branch = "headers_encoding" }
 http = "0.2"
@@ -45,7 +44,7 @@ percent-encoding = "2.1"
 pin-project = "1.0"
 structopt = { version = "0.3", default-features = false }
 time = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util"], default-features = false }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"], default-features = false }
 tokio-rustls = { version = "0.22" }
 tokio-util = { version = "0.6", features = ["io"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ percent-encoding = "2.1"
 pin-project = "1.0"
 structopt = { version = "0.3", default-features = false }
 time = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util"], default-features = false }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"], default-features = false }
 tokio-rustls = { version = "0.22" }
 tokio-util = { version = "0.6", features = ["io"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,13 @@ percent-encoding = "2.1"
 pin-project = "1.0"
 structopt = { version = "0.3", default-features = false }
 time = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"], default-features = false }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs", "io-util"], default-features = false }
 tokio-rustls = { version = "0.22" }
 tokio-util = { version = "0.6", features = ["io"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
+signal-hook = { version = "0.3.4", features = ["extended-siginfo"] }
+signal-hook-tokio = { version = "0.3", features = ["futures-v0_3"], default-features = false }
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
 version = "0.3"

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -19,7 +19,11 @@ COPY ./docker/alpine/entrypoint.sh /
 COPY ./docker/public /public
 
 EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
 ENTRYPOINT ["/entrypoint.sh"]
+
 CMD ["static-web-server"]
 
 # Metadata

--- a/docker/scratch/Dockerfile
+++ b/docker/scratch/Dockerfile
@@ -15,6 +15,9 @@ COPY --from=latest /usr/local/bin/static-web-server /
 COPY ./docker/public /public
 
 EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
 ENTRYPOINT ["/static-web-server"]
 
 # Metadata

--- a/src/server.rs
+++ b/src/server.rs
@@ -132,7 +132,7 @@ impl Server {
             },
         });
 
-        // Spawn a new Tokio asynchronous task with its given options
+        // Run the corresponding HTTP Server asynchronously with its given options
 
         if opts.http2 {
             // HTTP/2 + TLS
@@ -140,54 +140,58 @@ impl Server {
             let cert_path = opts.http2_tls_cert.clone();
             let key_path = opts.http2_tls_key.clone();
 
-            tokio::task::spawn(async move {
-                tcp_listener
-                    .set_nonblocking(true)
-                    .expect("cannot set non-blocking");
-                let listener = tokio::net::TcpListener::from_std(tcp_listener)
-                    .expect("failed to create tokio::net::TcpListener");
-                let mut incoming = AddrIncoming::from_listener(listener)?;
-                incoming.set_nodelay(true);
+            tcp_listener
+                .set_nonblocking(true)
+                .expect("cannot set non-blocking");
+            let listener = tokio::net::TcpListener::from_std(tcp_listener)
+                .expect("failed to create tokio::net::TcpListener");
+            let mut incoming = AddrIncoming::from_listener(listener)?;
+            incoming.set_nodelay(true);
 
-                let tls = TlsConfigBuilder::new()
-                    .cert_path(cert_path)
-                    .key_path(key_path)
-                    .build()
-                    .expect(
-                        "error during TLS server initialization, probably cert or key file missing",
-                    );
-
-                let server =
-                    HyperServer::builder(TlsAcceptor::new(tls, incoming)).serve(router_service);
-
-                tracing::info!(
-                    parent: tracing::info_span!("Server::start_server", ?addr_str, ?threads),
-                    "listening on https://{}",
-                    addr_str
+            let tls = TlsConfigBuilder::new()
+                .cert_path(cert_path)
+                .key_path(key_path)
+                .build()
+                .expect(
+                    "error during TLS server initialization, probably cert or key file missing",
                 );
 
-                server.await
-            });
+            let server = HyperServer::builder(TlsAcceptor::new(tls, incoming))
+                .serve(router_service)
+                .with_graceful_shutdown(signals::wait_for_ctrl_c());
+
+            tracing::info!(
+                parent: tracing::info_span!("Server::start_server", ?addr_str, ?threads),
+                "listening on https://{}",
+                addr_str
+            );
+
+            tracing::info!("press Ctrl + C to shut down the server");
+
+            server.await?;
         } else {
             // HTTP/1
 
-            tokio::task::spawn(async move {
-                let server = HyperServer::from_tcp(tcp_listener)
-                    .unwrap()
-                    .tcp_nodelay(true)
-                    .serve(router_service);
+            let server = HyperServer::from_tcp(tcp_listener)
+                .unwrap()
+                .tcp_nodelay(true)
+                .serve(router_service)
+                .with_graceful_shutdown(signals::wait_for_ctrl_c());
 
-                tracing::info!(
-                    parent: tracing::info_span!("Server::start_server", ?addr_str, ?threads),
-                    "listening on http://{}",
-                    addr_str
-                );
+            tracing::info!(
+                parent: tracing::info_span!("Server::start_server", ?addr_str, ?threads),
+                "listening on http://{}",
+                addr_str
+            );
 
-                server.await
-            });
+            tracing::info!("press Ctrl + C to shut down the server");
+
+            server.await?;
         }
 
-        signals::wait_for_ctrl_c()
+        tracing::warn!("Ctrl+C signal caught, shutting down the server execution");
+
+        Ok(())
     }
 }
 

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,10 +1,8 @@
 #[cfg(not(windows))]
-use {futures_util::stream::StreamExt, signal_hook::consts::signal::*, signal_hook_tokio::Signals};
-
-#[cfg(windows)]
-type Signals = futures_util::stream::Empty<()>;
-
-use crate::Result;
+use {
+    crate::Result, futures_util::stream::StreamExt, signal_hook::consts::signal::*,
+    signal_hook_tokio::Signals,
+};
 
 #[cfg(not(windows))]
 /// It creates a common list of signals stream for `SIGTERM`, `SIGINT` and `SIGQUIT` to be observed.
@@ -12,14 +10,8 @@ pub fn create_signals() -> Result<Signals> {
     Ok(Signals::new(&[SIGHUP, SIGTERM, SIGINT, SIGQUIT])?)
 }
 
-#[cfg(windows)]
-// No signal handling available on Windows for now
-pub fn create_signals() -> Result<Signals> {
-    Ok(futures_util::stream::empty())
-}
-
 #[cfg(not(windows))]
-/// It waits for a specific type of incoming signals.
+/// It waits for a specific type of incoming signals included `ctrl+c`.
 pub async fn wait_for_signals(signals: Signals) {
     let mut signals = signals.fuse();
     while let Some(signal) = signals.next().await {
@@ -38,5 +30,9 @@ pub async fn wait_for_signals(signals: Signals) {
 }
 
 #[cfg(windows)]
-// No signal handling available on Windows for now
-pub async fn wait_for_signals(signals: Signals) {}
+/// It waits for an incoming `ctrl+c` signal on Windows.
+pub async fn wait_for_ctrl_c() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install ctrl+c signal handler");
+}

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,8 +1,28 @@
-/// It waits for a `Ctrl-C` incoming signal.
-pub async fn wait_for_ctrl_c() {
-    tracing::debug!("server waiting for incoming Ctrl+C signals");
-    tokio::signal::ctrl_c()
-        .await
-        .expect("failed to install the Ctrl+C signal handler");
-    tracing::debug!("server caught an incoming Ctrl+C signal, starting graceful shutdown");
+use futures_util::stream::StreamExt;
+use signal_hook::consts::signal::*;
+use signal_hook_tokio::Signals;
+
+use crate::Result;
+
+/// It creates a common list of signals stream for `SIGTERM`, `SIGINT` and `SIGQUIT` to be observed.
+pub fn create_signals() -> Result<Signals> {
+    Ok(Signals::new(&[SIGHUP, SIGTERM, SIGINT, SIGQUIT])?)
+}
+
+/// It waits for a specific type of incoming signals.
+pub async fn wait_for_signals(signals: Signals) {
+    let mut signals = signals.fuse();
+    while let Some(signal) = signals.next().await {
+        match signal {
+            SIGHUP => {
+                // Note: for now we don't do something for SIGHUPs
+                tracing::debug!("SIGHUP caught, nothing to do about")
+            }
+            SIGTERM | SIGINT | SIGQUIT => {
+                tracing::debug!("an incoming SIGTERM received, SIGINT or SIGQUIT signal, delegating graceful shutdown to server");
+                break;
+            }
+            _ => unreachable!(),
+        }
+    }
 }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,21 +1,8 @@
-use ctrlc;
-use std::sync::mpsc::channel;
-
-use crate::{Context, Result};
-
 /// It waits for a `Ctrl-C` incoming signal.
-pub fn wait_for_ctrl_c() -> Result {
-    let (tx, rx) = channel();
-
-    ctrlc::set_handler(move || tx.send(()).expect("could not send signal on channel"))
-        .with_context(|| "error setting Ctrl-C handler".to_owned())?;
-
-    tracing::info!("press Ctrl+C to shutdown server");
-
-    rx.recv()
-        .with_context(|| "could not receive signal from channel".to_owned())?;
-
-    tracing::warn!("Ctrl+C signal caught, shutting down server execution");
-
-    Ok(())
+pub async fn wait_for_ctrl_c() {
+    tracing::debug!("server waiting for incoming Ctrl+C signals");
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install the Ctrl+C signal handler");
+    tracing::debug!("server caught an incoming Ctrl+C signal, starting graceful shutdown");
 }


### PR DESCRIPTION
## Description

This PR adds gracefully shutdown support for HTTP/1 and HTTP/2 servers by default without need of extra setup or an option.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It resolves #61

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Motivation comes from #61 and the recommendations below.

> It’s important that your application handle termination gracefully so that there is minimal impact on the end user and the time-to-recovery is as fast as possible!
> 
> In practice, this means your application needs to handle the SIGTERM message and begin shutting down when it receives it. This means saving all data that needs to be saved, closing down network connections, finishing any work that is left, and other similar tasks.
> https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace

## How Has This Been Tested?

"Simple" steps:

- Run the SWS (server) with `trace` mode
- Run a client for example to download a file of regular size.
- Simulate a download with some rate limit. E.g via `curl --limit-rate=`.
- Press Ctrl+C on SWS
- At this point you will see that server logs info about graceful shutdown process, it will begin intermediately and the file download will be not interrupt until it finishes.
- Finally, once fie download is complete, then the SWS will be shuttled down "gracefully".

### 1. Linux testing trace

```sh
docker run --name="sws" --rm -v $HOME/downloads:/public -p 8787:80 joseluisq/static-web-server:devel -g trace
```

<details>
  <summary>Linux log tracing when a Docker container is signaled with SIGTERM</summary>

    ```log
    Oct 29 10:13:54.150  INFO static_web_server::server: bound to TCP socket [::]:80
    Oct 29 10:13:54.150  INFO static_web_server::server: runtime worker threads: 4
    Oct 29 10:13:54.150  INFO static_web_server::server: security headers: enabled=false
    Oct 29 10:13:54.150  INFO static_web_server::server: auto compression: enabled=true
    Oct 29 10:13:54.150  INFO static_web_server::server: directory listing: enabled=false
    Oct 29 10:13:54.150  INFO static_web_server::server: cache control headers: enabled=true
    Oct 29 10:13:54.150  INFO static_web_server::server: basic authentication: enabled=false
    Oct 29 10:13:54.150 TRACE mio::poll: registering event source with poller: token=Token(0), interests=READABLE | WRITABLE    
    Oct 29 10:13:54.150 TRACE mio::poll: registering event source with poller: token=Token(1), interests=READABLE | WRITABLE    
    Oct 29 10:13:54.150 TRACE mio::poll: registering event source with poller: token=Token(2), interests=READABLE | WRITABLE    
    Oct 29 10:13:54.151  INFO Server::start_server{addr_str="[::]:80" threads=4}: static_web_server::server: close time.busy=0.00ns time.idle=1.26µs
    Oct 29 10:13:54.151  INFO static_web_server::server: listening on http://[::]:80
    Oct 29 10:13:54.151  INFO static_web_server::server: press ctrl+c to shut down the server
    Oct 29 10:13:57.765 TRACE mio::poll: registering event source with poller: token=Token(3), interests=READABLE | WRITABLE    
    Oct 29 10:13:57.765 TRACE mio::poll: registering event source with poller: token=Token(4), interests=READABLE | WRITABLE    
    Oct 29 10:13:57.766 TRACE hyper::proto::h1::conn: Conn::read_head
    Oct 29 10:13:57.766 TRACE hyper::proto::h1::conn: Conn::read_head
    Oct 29 10:13:57.766 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Busy }
    Oct 29 10:13:57.766 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Busy }
    Oct 29 10:13:57.875 TRACE hyper::proto::h1::conn: Conn::read_head
    Oct 29 10:13:57.875 TRACE hyper::proto::h1::io: received 605 bytes
    Oct 29 10:13:57.875 TRACE parse_headers: hyper::proto::h1::role: Request.parse bytes=605
    Oct 29 10:13:57.875 TRACE parse_headers: hyper::proto::h1::role: Request.parse Complete(605)
    Oct 29 10:13:57.875 TRACE parse_headers: hyper::proto::h1::role: close time.busy=53.2µs time.idle=1.96µs
    Oct 29 10:13:57.875 DEBUG hyper::proto::h1::io: parsed 14 headers
    Oct 29 10:13:57.875 DEBUG hyper::proto::h1::conn: incoming body is empty
    Oct 29 10:13:57.875 TRACE static_web_server::static_files: dir? base="./public", route="/assets/main.css"
    Oct 29 10:13:57.875 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
    Oct 29 10:13:57.875 DEBUG static_web_server::static_files: file not found: Os { code: 2, kind: NotFound, message: "No such file or directory" }
    Oct 29 10:13:57.875  WARN static_web_server::error_page: method=GET status=404 error=404
    Oct 29 10:13:57.875 TRACE encode_headers: hyper::proto::h1::role: Server::encode status=404, body=Some(Known(106)), req_method=Some(GET)
    Oct 29 10:13:57.875 TRACE encode_headers: hyper::proto::h1::role: close time.busy=27.1µs time.idle=1.02µs
    Oct 29 10:13:57.875 TRACE hyper::proto::h1::io: buffer.queue self.len=131 buf.len=106
    Oct 29 10:13:57.876 DEBUG hyper::proto::h1::io: flushed 237 bytes
    Oct 29 10:13:57.876 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle }
    Oct 29 10:13:57.876 TRACE hyper::proto::h1::conn: Conn::read_head
    Oct 29 10:13:57.876 TRACE hyper::proto::h1::io: received 590 bytes
    Oct 29 10:13:57.876 TRACE parse_headers: hyper::proto::h1::role: Request.parse bytes=590
    Oct 29 10:13:57.876 TRACE parse_headers: hyper::proto::h1::role: Request.parse Complete(590)
    Oct 29 10:13:57.876 TRACE parse_headers: hyper::proto::h1::role: close time.busy=44.0µs time.idle=1.70µs
    Oct 29 10:13:57.876 DEBUG hyper::proto::h1::io: parsed 14 headers
    Oct 29 10:13:57.876 DEBUG hyper::proto::h1::conn: incoming body is empty
    Oct 29 10:13:57.876 TRACE static_web_server::static_files: dir? base="./public", route="/assets/main.js"
    Oct 29 10:13:57.876 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
    Oct 29 10:13:57.876 DEBUG static_web_server::static_files: file not found: Os { code: 2, kind: NotFound, message: "No such file or directory" }
    Oct 29 10:13:57.876  WARN static_web_server::error_page: method=GET status=404 error=404
    Oct 29 10:13:57.876 TRACE encode_headers: hyper::proto::h1::role: Server::encode status=404, body=Some(Known(106)), req_method=Some(GET)
    Oct 29 10:13:57.876 TRACE encode_headers: hyper::proto::h1::role: close time.busy=15.9µs time.idle=741ns
    Oct 29 10:13:57.876 TRACE hyper::proto::h1::io: buffer.queue self.len=131 buf.len=106
    Oct 29 10:13:57.876 DEBUG hyper::proto::h1::io: flushed 237 bytes
    Oct 29 10:13:57.876 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle }
    Oct 29 10:13:58.038 TRACE hyper::proto::h1::conn: Conn::read_head
    Oct 29 10:13:58.038 TRACE hyper::proto::h1::io: received 654 bytes
    Oct 29 10:13:58.038 TRACE parse_headers: hyper::proto::h1::role: Request.parse bytes=654
    Oct 29 10:13:58.038 TRACE parse_headers: hyper::proto::h1::role: Request.parse Complete(654)
    Oct 29 10:13:58.038 TRACE parse_headers: hyper::proto::h1::role: close time.busy=57.4µs time.idle=6.26µs
    Oct 29 10:13:58.038 DEBUG hyper::proto::h1::io: parsed 14 headers
    Oct 29 10:13:58.038 DEBUG hyper::proto::h1::conn: incoming body is empty
    Oct 29 10:13:58.038 TRACE static_web_server::static_files: dir? base="./public", route="/assets/favicon.ico"
    Oct 29 10:13:58.038 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
    Oct 29 10:13:58.038 DEBUG static_web_server::static_files: file not found: Os { code: 2, kind: NotFound, message: "No such file or directory" }
    Oct 29 10:13:58.038  WARN static_web_server::error_page: method=GET status=404 error=404
    Oct 29 10:13:58.038 TRACE encode_headers: hyper::proto::h1::role: Server::encode status=404, body=Some(Known(106)), req_method=Some(GET)
    Oct 29 10:13:58.038 TRACE encode_headers: hyper::proto::h1::role: close time.busy=15.5µs time.idle=892ns
    Oct 29 10:13:58.038 TRACE hyper::proto::h1::io: buffer.queue self.len=131 buf.len=106
    Oct 29 10:13:58.038 DEBUG hyper::proto::h1::io: flushed 237 bytes
    Oct 29 10:13:58.038 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle }
    ^COct 29 10:14:01.651 DEBUG static_web_server::signals: an incoming SIGTERM, SIGINT or SIGQUIT signal, delegating graceful shutdown to server caught
    Oct 29 10:14:01.651 TRACE mio::poll: deregistering event source from poller    
    Oct 29 10:14:01.651 DEBUG hyper::server::shutdown: signal received, starting graceful shutdown
    Oct 29 10:14:01.651 TRACE mio::poll: deregistering event source from poller    
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: disable_keep_alive; closing idle connection
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: State::close()
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: State::close_read()
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: State::close_write()
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Closed, writing: Closed, keep_alive: Disabled }
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: disable_keep_alive; closing idle connection
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: State::close()
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: State::close_read()
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: State::close_write()
    Oct 29 10:14:01.652 TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Closed, writing: Closed, keep_alive: Disabled }
    Oct 29 10:14:01.653 TRACE hyper::proto::h1::conn: shut down IO complete
    Oct 29 10:14:01.653 TRACE mio::poll: deregistering event source from poller    
    Oct 29 10:14:01.653 TRACE hyper::proto::h1::conn: shut down IO complete
    Oct 29 10:14:01.653 TRACE mio::poll: deregistering event source from poller    
    Oct 29 10:14:01.653 TRACE mio::poll: deregistering event source from poller    
    Oct 29 10:14:01.653  WARN static_web_server::server: termination signal caught, shutting down the server execution
    ```
</details>


### 2. Windows testing trace

```sh
.\static-web-server.exe -p 8787 -d .\docker\public\ -g trace
```

<details>
  <summary>Windows log tracing when a Ctrl + C is submitted</summary>

    ```log
    ←[2mOct 30 00:30:03.820←[0m ←[32m INFO←[0m static_web_server::server: bound to TCP socket [::]:8787
    ←[2mOct 30 00:30:03.822←[0m ←[32m INFO←[0m static_web_server::server: runtime worker threads: 2
    ←[2mOct 30 00:30:03.823←[0m ←[32m INFO←[0m static_web_server::server: security headers: enabled=false
    ←[2mOct 30 00:30:03.823←[0m ←[32m INFO←[0m static_web_server::server: auto compression: enabled=true
    ←[2mOct 30 00:30:03.823←[0m ←[32m INFO←[0m static_web_server::server: directory listing: enabled=false
    ←[2mOct 30 00:30:03.823←[0m ←[32m INFO←[0m static_web_server::server: cache control headers: enabled=true
    ←[2mOct 30 00:30:03.824←[0m ←[32m INFO←[0m static_web_server::server: basic authentication: enabled=false
    ←[2mOct 30 00:30:03.824←[0m ←[35mTRACE←[0m mio::poll: registering event source with poller: token=Token(0), interests=READABLE | WRITABLE
    ←[2mOct 30 00:30:03.824←[0m ←[32m INFO←[0m ←[1mServer::start_server←[0m←[1m{←[0maddr_str="[::]:8787" threads=2←[1m}←[0m: static_web_server::server: close time.busy=0.00ns time.idle=13.0µs
    ←[2mOct 30 00:30:03.826←[0m ←[32m INFO←[0m static_web_server::server: listening on http://[::]:8787
    ←[2mOct 30 00:30:03.826←[0m ←[32m INFO←[0m static_web_server::server: press ctrl+c to shut down the server
    ←[2mOct 30 00:30:05.561←[0m ←[35mTRACE←[0m mio::poll: registering event source with poller: token=Token(1), interests=READABLE | WRITABLE
    ←[2mOct 30 00:30:05.562←[0m ←[35mTRACE←[0m mio::poll: registering event source with poller: token=Token(2), interests=READABLE | WRITABLE
    ←[2mOct 30 00:30:05.563←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: Conn::read_head
    ←[2mOct 30 00:30:05.564←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: Conn::read_head
    ←[2mOct 30 00:30:05.564←[0m ←[35mTRACE←[0m hyper::proto::h1::io: received 743 bytes
    ←[2mOct 30 00:30:05.565←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Busy }
    ←[2mOct 30 00:30:05.565←[0m ←[35mTRACE←[0m ←[1mparse_headers←[0m: hyper::proto::h1::role: Request.parse bytes=743
    ←[2mOct 30 00:30:05.567←[0m ←[35mTRACE←[0m ←[1mparse_headers←[0m: hyper::proto::h1::role: Request.parse Complete(743)
    ←[2mOct 30 00:30:05.568←[0m ←[35mTRACE←[0m ←[1mparse_headers←[0m: hyper::proto::h1::role: close time.busy=2.37ms time.idle=34.9µs
    ←[2mOct 30 00:30:05.568←[0m ←[34mDEBUG←[0m hyper::proto::h1::io: parsed 16 headers
    ←[2mOct 30 00:30:05.569←[0m ←[34mDEBUG←[0m hyper::proto::h1::conn: incoming body is empty
    ←[2mOct 30 00:30:05.569←[0m ←[35mTRACE←[0m static_web_server::static_files: dir? base=".\\docker\\public\\", route="/"
    ←[2mOct 30 00:30:05.570←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
    ←[2mOct 30 00:30:05.572←[0m ←[34mDEBUG←[0m static_web_server::static_files: dir: appending index.html to directory path
    ←[2mOct 30 00:30:05.572←[0m ←[35mTRACE←[0m static_web_server::static_files: dir: ".\\docker\\public\\index.html"
    ←[2mOct 30 00:30:05.573←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
    ←[2mOct 30 00:30:05.574←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
    ←[2mOct 30 00:30:05.574←[0m ←[35mTRACE←[0m static_web_server::static_files: if-modified-since? header = IfModifiedSince(Sat, 30 Oct 2021 04:48:53 GMT), file = Some(LastModified(Sat, 30 Oct 2021 04:48:53 GMT))
    ←[2mOct 30 00:30:05.576←[0m ←[35mTRACE←[0m ←[1mencode_headers←[0m: hyper::proto::h1::role: Server::encode status=304, body=Some(Unknown), req_method=Some(GET)
    ←[2mOct 30 00:30:05.577←[0m ←[35mTRACE←[0m ←[1mencode_headers←[0m: hyper::proto::h1::role: server body forced to 0; method=Some(GET), status=304
    ←[2mOct 30 00:30:05.578←[0m ←[35mTRACE←[0m ←[1mencode_headers←[0m: hyper::proto::h1::role: close time.busy=1.31ms time.idle=17.7µs
    ←[2mOct 30 00:30:05.578←[0m ←[35mTRACE←[0m hyper::proto::h1::dispatch: no more write body allowed, user body is_end_stream = false
    ←[2mOct 30 00:30:05.579←[0m ←[34mDEBUG←[0m hyper::proto::h1::io: flushed 128 bytes
    ←[2mOct 30 00:30:05.579←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle }
    ←[2mOct 30 00:30:08.580←[0m ←[34mDEBUG←[0m hyper::server::shutdown: signal received, starting graceful shutdown
    ←[2mOct 30 00:30:08.581←[0m ←[35mTRACE←[0m mio::poll: deregistering event source from poller
    ←[2mOct 30 00:30:08.581←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: disable_keep_alive; in-progress connection
    ←[2mOct 30 00:30:08.581←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: disable_keep_alive; closing idle connection
    ←[2mOct 30 00:30:08.582←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: Conn::read_head
    ←[2mOct 30 00:30:08.583←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: State::close()
    ←[2mOct 30 00:30:08.584←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Disabled }
    ←[2mOct 30 00:30:08.584←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: State::close_read()
    ←[2mOct 30 00:30:08.585←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: State::close_write()
    ←[2mOct 30 00:30:08.586←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: Closed, writing: Closed, keep_alive: Disabled }
    ←[2mOct 30 00:30:08.586←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: shut down IO complete
    ←[2mOct 30 00:30:08.587←[0m ←[35mTRACE←[0m mio::poll: deregistering event source from poller
    ←[2mOct 30 00:30:14.033←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: Conn::read_head
    ←[2mOct 30 00:30:14.041←[0m ←[35mTRACE←[0m hyper::proto::h1::io: received 0 bytes
    ←[2mOct 30 00:30:14.041←[0m ←[35mTRACE←[0m hyper::proto::h1::io: parse eof
    ←[2mOct 30 00:30:14.042←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: State::close_read()
    ←[2mOct 30 00:30:14.042←[0m ←[34mDEBUG←[0m hyper::proto::h1::conn: read eof
    ←[2mOct 30 00:30:14.042←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: State::close_write()
    ←[2mOct 30 00:30:14.043←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: State::close_read()
    ←[2mOct 30 00:30:14.043←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: State::close_write()
    ←[2mOct 30 00:30:14.044←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: flushed({role=server}): State { reading: Closed, writing: Closed, keep_alive: Disabled }
    ←[2mOct 30 00:30:14.044←[0m ←[35mTRACE←[0m hyper::proto::h1::conn: shut down IO complete
    ←[2mOct 30 00:30:14.048←[0m ←[35mTRACE←[0m mio::poll: deregistering event source from poller
    ←[2mOct 30 00:30:14.060←[0m ←[33m WARN←[0m static_web_server::server: termination signal caught, shutting down the server execution
    ```
</details>

**Tip:** The key is both cases (Linux/Windows) is the log entry `hyper::server::shutdown: signal received, starting graceful shutdown` which is where the _graceful shutdown_ begins. And the log entry `static_web_server::server: termination signal caught, shutting down the server execution` (for both) at the end confirms the _graceful shutdown_ is done. 