### PR TITLE
Ascending & descending ordering support for directory listing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +517,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -801,6 +817,7 @@ dependencies = [
  "async-compression",
  "bcrypt",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "headers",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio-rustls = { version = "0.22" }
 tokio-util = { version = "0.6", default-features = false, features = ["io"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", features = ["smallvec", "fmt", "ansi", "tracing-log", "std"] }
+form_urlencoded = "1.0"
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
 version = "0.3"

--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -10,7 +10,7 @@ The server can be configured via the following command-line arguments.
 ```
 $ static-web-server -h
 
-static-web-server 2.2.0
+static-web-server 2.3.0
 Jose Quintana <https://git.io/joseluisq>
 A blazing fast and asynchronous web server for static files-serving.
 
@@ -37,6 +37,11 @@ OPTIONS:
     -z, --directory-listing <directory-listing>
             Enable directory listing for all requests ending with the slash character (‘/’) [env:
             SERVER_DIRECTORY_LISTING=]  [default: false]
+        --directory-listing-order <directory-listing-order>
+            Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size`
+            attributes (columns). Code numbers supported: 0 (Name asc), 1 (Name desc), 2 (Last modified asc), 3 (Last
+            modified desc), 4 (Size asc), 5 (Size desc). Default 6 (unordered) [env: SERVER_DIRECTORY_LISTING_ORDER=]
+            [default: 6]
     -f, --fd <fd>
             Instead of binding to a TCP port, accept incoming connections to an already-bound TCP socket listener on the
             specified file descriptor number (usually zero). Requires that the parent process (e.g. inetd, launchd, or
@@ -65,7 +70,7 @@ OPTIONS:
         --page50x <page50x>
             HTML file path for 50x errors. If path is not specified or simply don't exists then server will use a
             generic HTML error message [env: SERVER_ERROR_PAGE_50X=]  [default: ./public/50x.html]
-    -p, --port <port>                                      Host port [env: SERVER_PORT=]  [default: 80]
+    -p, --port <port>                                          Host port [env: SERVER_PORT=]  [default: 80]
     -d, --root <root>
             Root directory path of static files [env: SERVER_ROOT=]  [default: ./public]
 

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -48,6 +48,9 @@ Specify a optional CORS list of allowed origin hosts separated by comas. Host po
 ### SERVER_DIRECTORY_LISTING
 Enable directory listing for all requests ending with the slash character (‘/’). Default `false` (disabled).
 
+### SERVER_DIRECTORY_LISTING_ORDER
+Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size` attributes (columns). Code numbers supported: `0` (Name asc), `1` (Name desc), `2` (Last modified asc), `3` (Last modified desc), `4` (Size asc), `5` (Size desc). Default `6` (unordered).
+
 ### SERVER_SECURITY_HEADERS
 Enable security headers by default when HTTP/2 feature is activated. Headers included: `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2 years max-age), `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block` and `Content-Security-Policy: frame-ancestors 'self'`. Default `false` (disabled).
 

--- a/docs/content/examples/directory-listing.md
+++ b/docs/content/examples/directory-listing.md
@@ -13,4 +13,44 @@ static-web-server \
 
 And here an example of how the directory listing looks like.
 
-<img title="SWS - Directory Listing" src="https://user-images.githubusercontent.com/1700322/118666481-81f22c80-b7f3-11eb-8c10-d530304e0e34.png" width="400">
+<img title="SWS - Directory Listing" src="https://user-images.githubusercontent.com/1700322/145420578-5a508d2a-773b-4239-acc0-197ea2062ff4.png" width="400">
+
+## Sorting
+
+Ascending and descending ordering of files/dirs by their attributes are provided by the numeric `--directory-listing-order` option or the equivalent [SERVER_DIRECTORY_LISTING_ORDER](./../configuration/environment-variables.md#server_directory_listing_order) env.
+
+The possible number code values are grouped by attribute as follows:
+
+### Name
+
+- 0: Ascending
+- 1: Descending
+
+### Last modified
+
+- 2: Ascending
+- 3: Descending
+
+### Size
+
+- 4: Ascending
+- 5: Descending
+
+### Default
+
+- 6: Unordered
+
+!!! info "Tip"
+    - The `--directory-listing-order` option depends on `--directory-listing` to be enabled.
+    - Use the query `?sort=NUMBER` to customize the sorting. E.g `https://localhost/?sort=5` (sort by Size in descending order)
+
+Example:
+
+```sh
+static-web-server \
+    --port 8787 \
+    --root ./my-public-dir \
+    --directory-listing true \
+    # Sorting file/dir names in descending order
+    --directory-listing-order 1
+```

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,15 @@ pub struct Config {
 
     #[structopt(
         long,
+        required_if("directory_listing", "true"),
+        default_value = "6",
+        env = "SERVER_DIRECTORY_LISTING_ORDER"
+    )]
+    /// Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size` attributes (columns). Code numbers supported: 0 (Name asc), 1 (Name desc), 2 (Last modified asc), 3 (Last modified desc), 4 (Size asc), 5 (Size desc). Default 6 (unordered)
+    pub directory_listing_order: u8,
+
+    #[structopt(
+        long,
         parse(try_from_str),
         required_if("http2", "true"),
         default_value_if("http2", Some("true"), "true"),

--- a/src/server.rs
+++ b/src/server.rs
@@ -102,6 +102,10 @@ impl Server {
         let dir_listing = opts.directory_listing;
         tracing::info!("directory listing: enabled={}", dir_listing);
 
+        // Directory listing order number
+        let dir_listing_order = opts.directory_listing_order;
+        tracing::info!("directory listing order code: {}", dir_listing_order);
+
         // Cache control headers option
         let cache_control_headers = opts.cache_control_headers;
         tracing::info!("cache control headers: enabled={}", cache_control_headers);
@@ -123,6 +127,7 @@ impl Server {
                 root_dir,
                 compression,
                 dir_listing,
+                dir_listing_order,
                 cors,
                 security_headers,
                 cache_control_headers,

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -27,8 +27,16 @@ mod tests {
             Method::TRACE,
         ];
         for method in methods {
-            match static_files::handle(&method, &HeaderMap::new(), root_dir(), "/assets", true)
-                .await
+            match static_files::handle(
+                &method,
+                &HeaderMap::new(),
+                root_dir(),
+                "/assets",
+                None,
+                true,
+                6,
+            )
+            .await
             {
                 Ok(res) => {
                     assert_eq!(res.status(), 308);

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -22,7 +22,9 @@ mod tests {
             &HeaderMap::new(),
             root_dir(),
             "index.html",
+            None,
             false,
+            6,
         )
         .await
         .expect("unexpected error response on `handle` function");
@@ -58,7 +60,9 @@ mod tests {
             &HeaderMap::new(),
             root_dir(),
             "index.html",
+            None,
             false,
+            6,
         )
         .await
         .expect("unexpected error response on `handle` function");
@@ -90,8 +94,16 @@ mod tests {
     #[tokio::test]
     async fn handle_file_not_found() {
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &HeaderMap::new(), root_dir(), "xyz.html", false)
-                .await
+            match static_files::handle(
+                &method,
+                &HeaderMap::new(),
+                root_dir(),
+                "xyz.html",
+                None,
+                false,
+                6,
+            )
+            .await
             {
                 Ok(_) => {
                     panic!("expected a status error 404 but not status 200")
@@ -111,7 +123,16 @@ mod tests {
 
         for method in [Method::HEAD, Method::GET] {
             for uri in ["", "/"] {
-                match static_files::handle(&method, &HeaderMap::new(), root_dir(), uri, false).await
+                match static_files::handle(
+                    &method,
+                    &HeaderMap::new(),
+                    root_dir(),
+                    uri,
+                    None,
+                    false,
+                    6,
+                )
+                .await
                 {
                     Ok(res) => {
                         assert_eq!(res.status(), 200);
@@ -137,7 +158,9 @@ mod tests {
                 &HeaderMap::new(),
                 root_dir(),
                 "/index%2ehtml",
+                None,
                 false,
+                6,
             )
             .await
             {
@@ -160,7 +183,9 @@ mod tests {
                 &HeaderMap::new(),
                 root_dir(),
                 "/%2E%2e.html",
+                None,
                 false,
+                6,
             )
             .await
             {
@@ -186,7 +211,9 @@ mod tests {
                 &HeaderMap::new(),
                 root_dir(),
                 "index.html",
+                None,
                 false,
+                6,
             )
             .await
             {
@@ -207,7 +234,9 @@ mod tests {
                 res1.headers()["last-modified"].to_owned(),
             );
 
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 304);
                     assert_eq!(res.headers().get("content-length"), None);
@@ -228,7 +257,9 @@ mod tests {
                 "Mon, 18 Nov 1974 00:00:00 GMT".parse().unwrap(),
             );
 
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 200);
                     let body = hyper::body::to_bytes(res.body_mut())
@@ -252,7 +283,9 @@ mod tests {
                 &HeaderMap::new(),
                 root_dir(),
                 "index.html",
+                None,
                 false,
+                6,
             )
             .await
             {
@@ -272,7 +305,9 @@ mod tests {
                 res1.headers()["last-modified"].to_owned(),
             );
 
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(res) => {
                     assert_eq!(res.status(), 200);
                 }
@@ -288,7 +323,9 @@ mod tests {
                 "Mon, 18 Nov 1974 00:00:00 GMT".parse().unwrap(),
             );
 
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 412);
 
@@ -319,8 +356,16 @@ mod tests {
             Method::TRACE,
         ];
         for method in methods {
-            match static_files::handle(&method, &HeaderMap::new(), root_dir(), "index.html", false)
-                .await
+            match static_files::handle(
+                &method,
+                &HeaderMap::new(),
+                root_dir(),
+                "index.html",
+                None,
+                false,
+                6,
+            )
+            .await
             {
                 Ok(mut res) => match method {
                     // The handle only accepts HEAD or GET request methods
@@ -368,7 +413,9 @@ mod tests {
             let mut headers = HeaderMap::new();
             headers.insert(http::header::ACCEPT_ENCODING, enc.parse().unwrap());
 
-            match static_files::handle(method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(res) => {
                     let res = compression::auto(method, &headers, res)
                         .expect("unexpected bytes error during body compression");
@@ -418,7 +465,9 @@ mod tests {
         let buf = Bytes::from(buf);
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 206);
                     assert_eq!(
@@ -448,7 +497,9 @@ mod tests {
         let buf = Bytes::from(buf);
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 416);
                     assert_eq!(
@@ -479,7 +530,9 @@ mod tests {
         let buf = Bytes::from(buf);
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(res) => {
                     assert_eq!(res.status(), 200);
                     assert_eq!(res.headers()["content-length"], buf.len().to_string());
@@ -502,7 +555,9 @@ mod tests {
         let buf = Bytes::from(buf);
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 206);
                     assert_eq!(
@@ -535,7 +590,9 @@ mod tests {
         let buf = Bytes::from(buf);
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 206);
                     assert_eq!(
@@ -565,7 +622,9 @@ mod tests {
         let buf = Bytes::from(buf);
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 416);
                     assert_eq!(
@@ -598,7 +657,9 @@ mod tests {
         );
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 416);
                     assert_eq!(
@@ -629,7 +690,9 @@ mod tests {
         headers.insert("range", "bytes=".parse().unwrap());
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 200);
                     let body = hyper::body::to_bytes(res.body_mut())
@@ -655,7 +718,9 @@ mod tests {
         headers.insert("range", format!("bytes=100-{}", buf.len()).parse().unwrap());
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 206);
                     assert_eq!(
@@ -692,7 +757,9 @@ mod tests {
         );
 
         for method in [Method::HEAD, Method::GET] {
-            match static_files::handle(&method, &headers, root_dir(), "index.html", false).await {
+            match static_files::handle(&method, &headers, root_dir(), "index.html", None, false, 6)
+                .await
+            {
                 Ok(mut res) => {
                     assert_eq!(res.status(), 206);
                     assert_eq!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR provides the ability of sorting files by `name`, `modified` and `file size` attributes (either ascending or descending) in the directory listing.

Example URL: `https://blah/?sort=5`

**Variants:**

- Name:
  - 0 = ASC
  - 1 = DESC
- Modified:
  - 2 = ASC
  - 3 = DESC
- File size:
  - 4 = ASC
  - 5 = DESC
- Default:
  - Unordered

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature request #68

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1700322/145420578-5a508d2a-773b-4239-acc0-197ea2062ff4.png)
