### PR TITLE
Configurable grace period support after a `SIGTERM` signal caught

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -154,4 +154,8 @@ pub struct Config {
     /// It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function.
     #[structopt(long, default_value = "", env = "SERVER_BASIC_AUTH")]
     pub basic_auth: String,
+
+    #[structopt(long, short = "q", default_value = "0", env = "SERVER_GRACE_PERIOD")]
+    /// Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to shut it down gracefully. The maximum value is 255 seconds.
+    pub grace_period: u8,
 }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -4,6 +4,8 @@ use {
     signal_hook_tokio::Signals,
 };
 
+use tokio::time::{sleep, Duration};
+
 #[cfg(not(windows))]
 /// It creates a common list of signals stream for `SIGTERM`, `SIGINT` and `SIGQUIT` to be observed.
 pub fn create_signals() -> Result<Signals> {
@@ -12,27 +14,43 @@ pub fn create_signals() -> Result<Signals> {
 
 #[cfg(not(windows))]
 /// It waits for a specific type of incoming signals included `ctrl+c`.
-pub async fn wait_for_signals(signals: Signals) {
+pub async fn wait_for_signals(signals: Signals, grace_period_secs: u8) {
     let mut signals = signals.fuse();
     while let Some(signal) = signals.next().await {
         match signal {
             SIGHUP => {
-                // Note: for now we don't do something for SIGHUPs
+                // NOTE: for now we don't do something for SIGHUPs
                 tracing::debug!("SIGHUP caught, nothing to do about")
             }
             SIGTERM | SIGINT | SIGQUIT => {
-                tracing::debug!("SIGTERM, SIGINT or SIGQUIT signal received, delegating graceful shutdown to the server");
+                tracing::info!("SIGTERM, SIGINT or SIGQUIT signal caught");
                 break;
             }
             _ => unreachable!(),
         }
     }
+    // NOTE: once loop above is done then an upstream graceful shutdown should come next.
+    delay_graceful_shutdown(grace_period_secs).await;
+    tracing::info!("delegating server's graceful shutdown");
+}
+
+/// Function intended to delay the server's graceful shutdown providing a grace period in seconds.
+async fn delay_graceful_shutdown(grace_period_secs: u8) {
+    if grace_period_secs > 0 {
+        tracing::info!(
+            "grace period of {}s after the SIGTERM started",
+            grace_period_secs
+        );
+        sleep(Duration::from_secs(grace_period_secs.into())).await;
+        tracing::info!("grace period has elapsed");
+    }
 }
 
 #[cfg(windows)]
 /// It waits for an incoming `ctrl+c` signal on Windows.
-pub async fn wait_for_ctrl_c() {
+pub async fn wait_for_ctrl_c(grace_period_secs: u8) {
     tokio::signal::ctrl_c()
         .await
         .expect("failed to install ctrl+c signal handler");
+    delay_graceful_shutdown(grace_period_secs).await;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces a new `--grace-period` option that happens right after a `SIGTERM` in order to delay server's graceful showdown.

```
-q, --grace-period <grace-period>
Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to
shut it down gracefully. 255 seconds maximum [env: SERVER_GRACE_PERIOD=]  [default: 0]
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature request #79

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using the following command and options

```sh
static-web-server -p 8787 -d docker/public/ -g trace -q 10
```

**Note:** The logs below have been split out for better understanding.

1. Server starts with a grace period of 10 secs

```log
2022-02-01T15:21:41.222866Z  INFO static_web_server::server: bound to TCP socket [::]:8787
2022-02-01T15:21:41.222950Z  INFO static_web_server::server: runtime worker threads: 4
2022-02-01T15:21:41.222973Z  INFO static_web_server::server: security headers: enabled=false
2022-02-01T15:21:41.222991Z  INFO static_web_server::server: auto compression: enabled=true
2022-02-01T15:21:41.223017Z  INFO static_web_server::server: directory listing: enabled=false
2022-02-01T15:21:41.223042Z  INFO static_web_server::server: directory listing order code: 6
2022-02-01T15:21:41.223058Z  INFO static_web_server::server: cache control headers: enabled=true
2022-02-01T15:21:41.223100Z  INFO static_web_server::server: basic authentication: enabled=false
2022-02-01T15:21:41.223150Z TRACE mio::poll: registering event source with poller: token=Token(1), interests=READABLE | WRITABLE    
2022-02-01T15:21:41.223194Z TRACE mio::poll: registering event source with poller: token=Token(2), interests=READABLE | WRITABLE    
2022-02-01T15:21:41.223402Z TRACE mio::poll: registering event source with poller: token=Token(3), interests=READABLE | WRITABLE    
2022-02-01T15:21:41.223544Z  INFO Server::start_server{addr_str="[::]:8787" threads=4}: static_web_server::server: close time.busy=0.00ns time.idle=11.3µs
2022-02-01T15:21:41.223599Z  INFO static_web_server::server: listening on http://[::]:8787
2022-02-01T15:21:41.223622Z  INFO static_web_server::server: press ctrl+c to shut down the server
```

2. Server receives one request

```log
2022-02-01T15:21:50.015015Z TRACE mio::poll: registering event source with poller: token=Token(4), interests=READABLE | WRITABLE    
2022-02-01T15:21:50.015353Z TRACE hyper::proto::h1::conn: Conn::read_head
2022-02-01T15:21:50.015442Z TRACE hyper::proto::h1::io: received 93 bytes
2022-02-01T15:21:50.015617Z TRACE parse_headers: hyper::proto::h1::role: Request.parse bytes=93
2022-02-01T15:21:50.015714Z TRACE parse_headers: hyper::proto::h1::role: Request.parse Complete(93)
2022-02-01T15:21:50.015854Z TRACE parse_headers: hyper::proto::h1::role: close time.busy=264µs time.idle=25.0µs
2022-02-01T15:21:50.015939Z DEBUG hyper::proto::h1::io: parsed 3 headers
2022-02-01T15:21:50.015970Z DEBUG hyper::proto::h1::conn: incoming body is empty
2022-02-01T15:21:50.016070Z TRACE static_web_server::static_files: dir? base="docker/public/", route="/assets/main.js"
2022-02-01T15:21:50.016262Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
2022-02-01T15:21:50.016379Z TRACE static_web_server::static_files: dir: "docker/public/assets/main.js"
2022-02-01T15:21:50.016464Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
2022-02-01T15:21:50.016794Z TRACE encode_headers: hyper::proto::h1::role: Server::encode status=200, body=Some(Unknown), req_method=Some(HEAD)
2022-02-01T15:21:50.016869Z TRACE encode_headers: hyper::proto::h1::role: server body forced to 0; method=Some(HEAD), status=200
2022-02-01T15:21:50.016932Z TRACE encode_headers: hyper::proto::h1::role: close time.busy=140µs time.idle=15.4µs
2022-02-01T15:21:50.016999Z TRACE hyper::proto::h1::dispatch: no more write body allowed, user body is_end_stream = false
2022-02-01T15:21:50.017122Z DEBUG hyper::proto::h1::io: flushed 223 bytes
2022-02-01T15:21:50.017158Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle }
2022-02-01T15:21:50.017377Z TRACE hyper::proto::h1::conn: Conn::read_head
2022-02-01T15:21:50.017438Z TRACE hyper::proto::h1::io: received 0 bytes
2022-02-01T15:21:50.017470Z TRACE hyper::proto::h1::io: parse eof
2022-02-01T15:21:50.017506Z TRACE hyper::proto::h1::conn: State::close_read()
2022-02-01T15:21:50.017532Z DEBUG hyper::proto::h1::conn: read eof
2022-02-01T15:21:50.017565Z TRACE hyper::proto::h1::conn: State::close_write()
2022-02-01T15:21:50.017588Z TRACE hyper::proto::h1::conn: State::close_read()
2022-02-01T15:21:50.017616Z TRACE hyper::proto::h1::conn: State::close_write()
2022-02-01T15:21:50.017650Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Closed, writing: Closed, keep_alive: Disabled }
2022-02-01T15:21:50.017727Z TRACE hyper::proto::h1::conn: shut down IO complete
2022-02-01T15:21:50.017774Z TRACE mio::poll: deregistering event source from poller    
```

3. Server receives an intentional ctrl+c
Note the `Grace period of 10 second(s) after the SIGTERM` log entry

```log
^C2022-02-01T15:21:58.756116Z  INFO static_web_server::signals: SIGTERM, SIGINT or SIGQUIT signal caught
2022-02-01T15:21:58.756301Z  INFO static_web_server::signals: Grace period of 10 second(s) after the SIGTERM
```

4. Server receives another request completed sucessfully

```log
2022-02-01T15:22:02.685889Z TRACE mio::poll: registering event source with poller: token=Token(16777220), interests=READABLE | WRITABLE    
2022-02-01T15:22:02.686097Z TRACE hyper::proto::h1::conn: Conn::read_head
2022-02-01T15:22:02.686159Z TRACE hyper::proto::h1::io: received 94 bytes
2022-02-01T15:22:02.686322Z TRACE parse_headers: hyper::proto::h1::role: Request.parse bytes=94
2022-02-01T15:22:02.686393Z TRACE parse_headers: hyper::proto::h1::role: Request.parse Complete(94)
2022-02-01T15:22:02.686501Z TRACE parse_headers: hyper::proto::h1::role: close time.busy=199µs time.idle=28.4µs
2022-02-01T15:22:02.686561Z DEBUG hyper::proto::h1::io: parsed 3 headers
2022-02-01T15:22:02.686584Z DEBUG hyper::proto::h1::conn: incoming body is empty
2022-02-01T15:22:02.686658Z TRACE static_web_server::static_files: dir? base="docker/public/", route="/assets/main.css"
2022-02-01T15:22:02.686810Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
2022-02-01T15:22:02.686954Z TRACE static_web_server::static_files: dir: "docker/public/assets/main.css"
2022-02-01T15:22:02.687026Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
2022-02-01T15:22:02.687292Z TRACE encode_headers: hyper::proto::h1::role: Server::encode status=200, body=Some(Unknown), req_method=Some(HEAD)
2022-02-01T15:22:02.687356Z TRACE encode_headers: hyper::proto::h1::role: server body forced to 0; method=Some(HEAD), status=200
2022-02-01T15:22:02.687411Z TRACE encode_headers: hyper::proto::h1::role: close time.busy=120µs time.idle=12.9µs
2022-02-01T15:22:02.687469Z TRACE hyper::proto::h1::dispatch: no more write body allowed, user body is_end_stream = false
2022-02-01T15:22:02.687583Z DEBUG hyper::proto::h1::io: flushed 210 bytes
2022-02-01T15:22:02.687638Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle }
2022-02-01T15:22:02.687816Z TRACE hyper::proto::h1::conn: Conn::read_head
2022-02-01T15:22:02.687872Z TRACE hyper::proto::h1::io: received 0 bytes
2022-02-01T15:22:02.687897Z TRACE hyper::proto::h1::io: parse eof
2022-02-01T15:22:02.687918Z TRACE hyper::proto::h1::conn: State::close_read()
2022-02-01T15:22:02.687937Z DEBUG hyper::proto::h1::conn: read eof
2022-02-01T15:22:02.687955Z TRACE hyper::proto::h1::conn: State::close_write()
2022-02-01T15:22:02.687974Z TRACE hyper::proto::h1::conn: State::close_read()
2022-02-01T15:22:02.687990Z TRACE hyper::proto::h1::conn: State::close_write()
2022-02-01T15:22:02.688011Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Closed, writing: Closed, keep_alive: Disabled }
2022-02-01T15:22:02.688074Z TRACE hyper::proto::h1::conn: shut down IO complete
2022-02-01T15:22:02.688116Z TRACE mio::poll: deregistering event source from poller    
```

5. Server's 10 secs grace period elapsed so delegate server's graceful shutdown

```log
2022-02-01T15:22:08.757722Z  INFO static_web_server::signals: Grace period has elapsed
2022-02-01T15:22:08.757845Z  INFO static_web_server::signals: Delegating server's graceful shutdown
2022-02-01T15:22:08.757948Z TRACE mio::poll: deregistering event source from poller    
2022-02-01T15:22:08.758197Z DEBUG hyper::server::shutdown: signal received, starting graceful shutdown
2022-02-01T15:22:08.758347Z TRACE mio::poll: deregistering event source from poller    
2022-02-01T15:22:08.758844Z TRACE mio::poll: deregistering event source from poller    
2022-02-01T15:22:08.759118Z  WARN static_web_server::server: termination signal caught, shutting down the server execution
```

## Screenshots (if appropriate):

No
