### PR TITLE
Multi-arch Docker images

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -36,6 +36,8 @@ jobs:
           - linux-gnu-arm64
           - linux-gnu-i686
           - linux-arm-gnueabihf
+          - linux-musl-armv6
+          - linux-musl-armv7
           - macos
           - macos-arm64
           - windows-msvc
@@ -83,6 +85,14 @@ jobs:
             os: ubuntu-20.04
             rust: nightly
             target: arm-unknown-linux-gnueabihf
+          - build: linux-musl-armv6
+            os: ubuntu-20.04
+            rust: nightly
+            target: arm-unknown-linux-musleabihf
+          - build: linux-musl-armv7
+            os: ubuntu-20.04
+            rust: nightly
+            target: armv7-unknown-linux-musleabihf
           - build: macos
             os: macos-11
             rust: stable

--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -12,6 +12,9 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v2
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
         name: Docker meta alpine
         id: meta_alpine
         uses: docker/metadata-action@v3
@@ -45,6 +48,7 @@ jobs:
         with:
           push: true
           context: .
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           file: ${{ env.SERVER_DOCKERFILE }}
           tags: ${{ steps.meta_alpine.outputs.tags }}
           build-args: |
@@ -57,6 +61,9 @@ jobs:
       -
         name: Checkout repository
         uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       -
         name: Docker meta scratch
         id: meta_scratch
@@ -88,6 +95,7 @@ jobs:
         with:
           push: true
           context: .
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           file: ${{ env.SERVER_DOCKERFILE }}
           tags: ${{ steps.meta_scratch.outputs.tags }}
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
           - linux-gnu-arm64
           - linux-gnu-i686
           - linux-arm-gnueabihf
+          - linux-musl-armv6
+          - linux-musl-armv7
           - macos
           - macos-arm64
           - windows-msvc
@@ -91,6 +93,14 @@ jobs:
           os: ubuntu-20.04
           rust: nightly
           target: arm-unknown-linux-gnueabihf
+        - build: linux-musl-armv6
+          os: ubuntu-20.04
+          rust: nightly
+          target: arm-unknown-linux-musleabihf
+        - build: linux-musl-armv7
+          os: ubuntu-20.04
+          rust: nightly
+          target: armv7-unknown-linux-musleabihf
         - build: macos
           os: macos-11
           rust: stable
@@ -148,7 +158,7 @@ jobs:
       run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }}
 
     - name: Strip release binary (linux and macos)
-      if: matrix.os != 'windows-2019' && matrix.build != 'linux-arm-gnueabihf' && matrix.build != 'linux-gnu-arm64' && matrix.build != 'linux-musl-arm64' && matrix.build != 'linux-musl-i686'
+      if: matrix.os != 'windows-2019' && matrix.build != 'linux-arm-gnueabihf' && matrix.build != 'linux-musl-armv7' && matrix.build != 'linux-musl-armv6' && matrix.build != 'linux-gnu-arm64' && matrix.build != 'linux-musl-arm64' && matrix.build != 'linux-musl-i686'
       run: strip "target/${{ matrix.target }}/release/static-web-server"
 
     - name: Strip release binary (linux-arm-gnueabihf)
@@ -157,6 +167,20 @@ jobs:
         docker run --rm -v "$PWD/target:/target:Z" \
           rustembedded/cross:arm-unknown-linux-gnueabihf \
           arm-linux-gnueabihf-strip /target/arm-unknown-linux-gnueabihf/release/static-web-server
+
+    - name: Strip release binary (linux-musl-armv7)
+      if: matrix.build == 'linux-musl-armv7'
+      run: |
+        docker run --rm -v "$PWD/target:/target:Z" \
+          rustembedded/cross:armv7-unknown-linux-musleabihf \
+          arm-linux-gnueabihf-strip /target/armv7-unknown-linux-musleabihf/release/static-web-server
+
+    - name: Strip release binary (linux-musl-armv6)
+      if: matrix.build == 'linux-musl-armv6'
+      run: |
+        docker run --rm -v "$PWD/target:/target:Z" \
+          rustembedded/cross:arm-unknown-linux-musleabihf \
+          arm-linux-gnueabihf-strip /target/arm-unknown-linux-musleabihf/release/static-web-server
 
     - name: Strip release binary (linux-gnu-arm64)
       if: matrix.build == 'linux-gnu-arm64'

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine:3.14
+FROM --platform=$BUILDPLATFORM alpine:3.14 as build
 
+ARG TARGETPLATFORM
 ARG SERVER_VERSION=0.0.0
 ENV SERVER_VERSION=${SERVER_VERSION}
 
@@ -9,12 +10,23 @@ LABEL version="${SERVER_VERSION}" \
 
 RUN apk --no-cache add ca-certificates tzdata
 RUN set -ex; \
-	wget --quiet -O /tmp/static-web-server.tar.gz "https://github.com/joseluisq/static-web-server/releases/download/v$SERVER_VERSION/static-web-server-v$SERVER_VERSION-x86_64-unknown-linux-musl.tar.gz"; \
+	case "$TARGETPLATFORM" in \
+		"linux/amd64") target='x86_64-unknown-linux-musl' ;; \
+		"linux/arm64") target='aarch64-unknown-linux-musl' ;; \
+		"linux/386") target='i686-unknown-linux-musl' ;; \
+		"linux/arm/v7") target='armv7-unknown-linux-musleabihf' ;; \
+		"linux/arm/v6") target='arm-unknown-linux-musleabihf' ;; \
+		*) echo >&2 "error: unsupported $TARGETPLATFORM architecture"; exit 1 ;; \
+	esac; \
+	wget --quiet -O /tmp/static-web-server.tar.gz "https://github.com/joseluisq/static-web-server/releases/download/v${SERVER_VERSION}/static-web-server-v${SERVER_VERSION}-${target}.tar.gz"; \
     tar xzvf /tmp/static-web-server.tar.gz; \
-    cp static-web-server-v${SERVER_VERSION}-x86_64-unknown-linux-musl/static-web-server /usr/local/bin/; \
-	rm -rf /tmp/static-web-server.tar.gz static-web-server-v${SERVER_VERSION}-x86_64-unknown-linux-musl; \
+    cp static-web-server-v${SERVER_VERSION}-${target}/static-web-server /usr/local/bin/; \
+	rm -rf /tmp/static-web-server.tar.gz static-web-server-v${SERVER_VERSION}-${target}; \
 	chmod +x /usr/local/bin/static-web-server
 
+FROM alpine:3.14
+
+COPY --from=build /usr/local/bin/static-web-server /
 COPY ./docker/alpine/entrypoint.sh /
 COPY ./docker/public /public
 

--- a/docker/scratch/Dockerfile
+++ b/docker/scratch/Dockerfile
@@ -1,6 +1,6 @@
 ARG SERVER_VERSION=0.0.0
 
-FROM joseluisq/static-web-server:${SERVER_VERSION}-alpine AS latest
+FROM joseluisq/static-web-server:${SERVER_VERSION}-alpine AS build
 
 FROM scratch
 
@@ -11,7 +11,7 @@ LABEL version="${SERVER_VERSION}" \
     description="A blazing fast and asynchronous web server for static files-serving." \
     maintainer="Jose Quintana <joseluisq.net>"
 
-COPY --from=latest /usr/local/bin/static-web-server /
+COPY --from=build /usr/local/bin/static-web-server /
 COPY ./docker/public /public
 
 EXPOSE 80


### PR DESCRIPTION
## Description
This PR introduces two new binary targets as well as new four additional Docker arch images.

**Binary targets**

- `armv7-unknown-linux-musleabihf` (armv7)
- `arm-unknown-linux-musleabihf` (armv6)

**Docker targets**

- linux/amd64 (already present)
- linux/arm64
- linux/386
- linux/arm/v7
- linux/arm/v6

## Related Issue
No

## Motivation and Context

Feature request #54

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It should be tested aside.

## Screenshots (if appropriate):
No