### PR TITLE
feat: added application/wasm to compression file list

### DIFF
--- a/docs/content/features/compression.md
+++ b/docs/content/features/compression.md
@@ -32,6 +32,7 @@ application/vnd.ms-fontobject
 font/truetype
 font/opentype
 image/svg+xml
+application/wasm
 ```
 
 This feature is enabled by default and can be controlled by the boolean `-x, --compression` option or the equivalent [SERVER_COMPRESSION](./../configuration/environment-variables.md#server_compression) env.

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -18,7 +18,7 @@ use tokio_util::io::{ReaderStream, StreamReader};
 use crate::Result;
 
 /// Contains a fixed list of common text-based MIME types in order to apply compression.
-pub const TEXT_MIME_TYPES: [&str; 23] = [
+pub const TEXT_MIME_TYPES: [&str; 24] = [
     "text/html",
     "text/css",
     "text/javascript",
@@ -42,6 +42,7 @@ pub const TEXT_MIME_TYPES: [&str; 23] = [
     "font/opentype",
     "application/vnd.ms-fontobject",
     "image/svg+xml",
+    "application/wasm",
 ];
 
 /// Create a wrapping handler that compresses the Body of a [`Response`](hyper::Response)


### PR DESCRIPTION
`application/wasm` added as a plain text type for compression

## Motivation and Context
`application/wasm` are plain text files and can be effectively compressed by gzip or brotli to speedup their download.

## How Has This Been Tested?
No need to test.
