### PR TITLE
CORS `access-control-request-headers` support and `OPTIONS` requests

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -54,8 +54,8 @@ pub fn auto(
     headers: &HeaderMap<HeaderValue>,
     resp: Response<Body>,
 ) -> Result<Response<Body>> {
-    // Skip compression for HEAD request methods
-    if method == Method::HEAD {
+    // Skip compression for HEAD and OPTIONS request methods
+    if method == Method::HEAD || method == Method::OPTIONS {
         return Ok(resp);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,15 @@ pub struct Config {
 
     #[structopt(
         long,
+        short = "j",
+        default_value = "origin, content-type",
+        env = "SERVER_CORS_ALLOW_HEADERS"
+    )]
+    /// Specify an optional CORS list of allowed headers separated by comas. Default "origin, content-type". It requires `--cors-allow-origins` to be used along with.
+    pub cors_allow_headers: String,
+
+    #[structopt(
+        long,
         short = "t",
         parse(try_from_str),
         default_value = "false",

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -51,9 +51,9 @@ pub fn new(origins_str: String, headers_str: String) -> Option<Arc<Configured>> 
 
         if cors_res.is_some() {
             tracing::info!(
-                    "enabled=true, allow_headers=[{}], allow_methods=[GET,HEAD,OPTIONS], allow_origins={}",
-                    headers_str,
-                    origins_str
+                    "enabled=true, allow_methods=[GET,HEAD,OPTIONS], allow_origins={}, allow_headers=[{}]",
+                    origins_str,
+                    headers_str
                 );
         }
         cors_res

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -119,8 +119,11 @@ impl RequestHandler {
                 Ok(mut resp) => {
                     // Append CORS headers if they are present
                     if let Some(cors_headers) = cors_headers {
-                        for (k, v) in cors_headers.iter() {
-                            resp.headers_mut().insert(k, v.to_owned());
+                        if !cors_headers.is_empty() {
+                            for (k, v) in cors_headers.iter() {
+                                resp.headers_mut().insert(k, v.to_owned());
+                            }
+                            resp.headers_mut().remove(http::header::ALLOW);
                         }
                     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,3 @@
-use headers::{AcceptRanges, HeaderMapExt, HeaderValue};
-use http::header::ALLOW;
 use hyper::{header::WWW_AUTHENTICATE, Body, Method, Request, Response, StatusCode};
 use std::{future::Future, path::PathBuf, sync::Arc};
 
@@ -150,16 +148,6 @@ impl RequestHandler {
                     // Append security headers
                     if self.opts.security_headers {
                         security_headers::append_headers(&mut resp);
-                    }
-
-                    // Respond with the permitted communication options
-                    if method == Method::OPTIONS {
-                        *resp.status_mut() = StatusCode::NO_CONTENT;
-                        *resp.body_mut() = Body::empty();
-                        resp.headers_mut()
-                            .insert(ALLOW, HeaderValue::from_static("OPTIONS, GET, HEAD"));
-                        resp.headers_mut().typed_insert(AcceptRanges::bytes());
-                        return Ok(resp);
                     }
 
                     Ok(resp)

--- a/src/server.rs
+++ b/src/server.rs
@@ -121,7 +121,10 @@ impl Server {
         tracing::info!("cache control headers: enabled={}", cache_control_headers);
 
         // CORS option
-        let cors = cors::new(opts.cors_allow_origins.trim().to_owned());
+        let cors = cors::new(
+            opts.cors_allow_origins.trim().to_owned(),
+            opts.cors_allow_headers.trim().to_owned(),
+        );
 
         // `Basic` HTTP Authentication Schema option
         let basic_auth = opts.basic_auth.trim();

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -22,7 +22,6 @@ mod tests {
             Method::DELETE,
             Method::GET,
             Method::HEAD,
-            Method::OPTIONS,
             Method::PATCH,
             Method::POST,
             Method::PUT,

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -388,7 +388,6 @@ mod tests {
             Method::DELETE,
             Method::GET,
             Method::HEAD,
-            Method::OPTIONS,
             Method::PATCH,
             Method::POST,
             Method::PUT,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR refactors the current CORS functionality with proper headers handling for responses.

However since the addressed CORS issue is related with preflighted requests via the `OPTIONS` method. I have decided that it could be even reasonable to add also support to control `access-control-request-headers` and `OPTIONS` requests together. This last one which in turn can help to _just identify server allowed request methods_ or check for _preflighted requests_ when using CORS.

```
-j, --cors-allow-headers <cors-allow-headers>
            Specify an optional CORS list of allowed headers separated by comas. Default "origin, content-type". It
            requires `--cors-allow-origins` to be used along with [env: SERVER_CORS_ALLOW_HEADERS=]  [default: origin,
            content-type]
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes  #86

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Server config used and ltracing log after a CORS request

```sh
$ static-web-server -p 8788 -d ./docker/public/ -g trace -z true '-c=http://devel.local:8788/'`
# 2022-03-02T22:13:25.544207Z  INFO static_web_server::server: server bound to TCP socket [::]:8788
# 2022-03-02T22:13:25.544328Z  INFO static_web_server::server: runtime worker threads: 4
# 2022-03-02T22:13:25.544348Z  INFO static_web_server::server: security headers: enabled=false
# 2022-03-02T22:13:25.544360Z  INFO static_web_server::server: auto compression: enabled=true
# 2022-03-02T22:13:25.544390Z  INFO static_web_server::server: directory listing: enabled=true
# 2022-03-02T22:13:25.544412Z  INFO static_web_server::server: directory listing order code: 6
# 2022-03-02T22:13:25.544429Z  INFO static_web_server::server: cache control headers: enabled=true
# 2022-03-02T22:13:25.544621Z  INFO static_web_server::cors: enabled=true, allow_methods=[GET,HEAD,OPTIONS], allow_origins=http://devel.local:8788/, allow_headers=[origin,content-type]
# 2022-03-02T22:13:25.544675Z  INFO static_web_server::server: basic authentication: enabled=false
# 2022-03-02T22:13:25.544695Z  INFO static_web_server::server: grace period before graceful shutdown: 0s
# 2022-03-02T22:13:25.544736Z TRACE mio::poll: registering event source with poller: token=Token(1), interests=READABLE | WRITABLE    
# 2022-03-02T22:13:25.544771Z TRACE mio::poll: registering event source with poller: token=Token(2), interests=READABLE | WRITABLE    
# 2022-03-02T22:13:25.544968Z TRACE mio::poll: registering event source with poller: token=Token(3), interests=READABLE | WRITABLE    
# 2022-03-02T22:13:25.545091Z  INFO Server::start_server{addr_str="[::]:8788" threads=4}: static_web_server::server: close time.busy=0.00ns time.idle=9.74µs
# 2022-03-02T22:13:25.545138Z  INFO static_web_server::server: listening on http://[::]:8788
# 2022-03-02T22:13:25.545169Z  INFO static_web_server::server: press ctrl+c to shut down the server
# 2022-03-02T22:13:34.386809Z TRACE mio::poll: registering event source with poller: token=Token(4), interests=READABLE | WRITABLE    
# 2022-03-02T22:13:34.389028Z TRACE hyper::proto::h1::conn: Conn::read_head
# 2022-03-02T22:13:34.389354Z TRACE hyper::proto::h1::io: received 591 bytes
# 2022-03-02T22:13:34.389992Z TRACE parse_headers: hyper::proto::h1::role: Request.parse bytes=591
# 2022-03-02T22:13:34.390439Z TRACE parse_headers: hyper::proto::h1::role: Request.parse Complete(591)
# 2022-03-02T22:13:34.391294Z TRACE parse_headers: hyper::proto::h1::role: close time.busy=1.41ms time.idle=89.7µs
# 2022-03-02T22:13:34.391564Z DEBUG hyper::proto::h1::io: parsed 16 headers
# 2022-03-02T22:13:34.391648Z DEBUG hyper::proto::h1::conn: incoming body is empty
# 2022-03-02T22:13:34.391855Z TRACE static_web_server::cors: cors origin header: "http://devel.local:8788"
# 2022-03-02T22:13:34.392036Z DEBUG static_web_server::handler: cors state: Simple("http://devel.local:8788")
# 2022-03-02T22:13:34.392156Z TRACE static_web_server::static_files: dir? base="./docker/public/", route="/assets/main.js"
# 2022-03-02T22:13:34.392537Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
# 2022-03-02T22:13:34.392862Z TRACE static_web_server::static_files: dir: "./docker/public/assets/main.js"
# 2022-03-02T22:13:34.393065Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Init, keep_alive: Busy }
# 2022-03-02T22:13:34.395255Z TRACE encode_headers: hyper::proto::h1::role: Server::encode status=200, body=Some(Unknown), req_method=Some(GET)
# 2022-03-02T22:13:34.395522Z TRACE encode_headers: hyper::proto::h1::role: close time.busy=270µs time.idle=45.9µs
# 2022-03-02T22:13:34.396020Z DEBUG hyper::proto::h1::io: flushed 411 bytes
# 2022-03-02T22:13:34.396118Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: KeepAlive, writing: Body(Encoder { kind: Chunked, is_last: false }), keep_alive: Busy }
# 2022-03-02T22:13:34.397304Z TRACE hyper::proto::h1::encode: encoding chunked 75B
# 2022-03-02T22:13:34.397451Z TRACE hyper::proto::h1::io: buffer.queue self.len=0 buf.len=81
# 2022-03-02T22:13:34.397653Z TRACE hyper::proto::h1::io: buffer.queue self.len=81 buf.len=5
# 2022-03-02T22:13:34.397905Z DEBUG hyper::proto::h1::io: flushed 86 bytes
# 2022-03-02T22:13:34.397992Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle
```

2. See CORS request on screenshot below.

## Screenshots (if appropriate):

<img src="https://user-images.githubusercontent.com/1700322/156458292-4af73ac4-7c93-4cda-889e-86fde5afd935.png" width="760">
