### PR TITLE
feat: add fallback page option

### DIFF
--- a/docs/content/features/error-pages.md
+++ b/docs/content/features/error-pages.md
@@ -5,7 +5,7 @@
 This feature is enabled by default and can be controlled either by the string `--page404` ([SERVER_ERROR_PAGE_404](./../configuration/environment-variables.md#server_error_page_404)) or the `--page50x` ([SERVER_ERROR_PAGE_50X](./../configuration/environment-variables.md#server_error_page_50x)) arguments.
 
 !!! info "Tip"
-    Either `--page404` and `--page50x` have defaults (optional values) so they can be specified or omitted as required.
+Either `--page404` and `--page50x` have defaults (optional values) so they can be specified or omitted as required.
 
 Below an example of how to customize those HTML pages.
 
@@ -15,4 +15,17 @@ static-web-server \
     --root ./my-public-dir \
     --page404 ./my-page-404.html \
     --page50x ./my-page-50x.html
+```
+
+## Fallback Page for use with Client Routers
+
+HTML file path that is used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers like `React Router` or similar. If the path is not specified or simply doesn't exist then this feature will not be active.
+
+It can be set with the `SERVER_FALLBACK_PAGE` environment variable or with the cli argument `--page-fallback`.
+
+```sh
+static-web-server \
+    --port 8787 \
+    --root ./my-public-dir \
+    --page-fallback ./my-public-dir/index.html
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ pub struct Config {
         default_value = "./public/50x.html",
         env = "SERVER_ERROR_PAGE_50X"
     )]
-    /// HTML file path for 50x errors. If path is not specified or simply don't exists then server will use a generic HTML error message.
+    /// HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
     pub page50x: String,
 
     #[structopt(
@@ -55,8 +55,12 @@ pub struct Config {
         default_value = "./public/404.html",
         env = "SERVER_ERROR_PAGE_404"
     )]
-    /// HTML file path for 404 errors. If path is not specified or simply don't exists then server will use a generic HTML error message.
+    /// HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
     pub page404: String,
+
+    #[structopt(long, default_value = "", env = "SERVER_FALLBACK_PAGE")]
+    /// HTML file path that is used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path is not specified or simply doesn't exist then this feature will not be active.
+    pub page_fallback: String,
 
     #[structopt(long, short = "g", default_value = "error", env = "SERVER_LOG_LEVEL")]
     /// Specify a logging level in lower case. Values: error, warn, info, debug or trace

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -1,0 +1,34 @@
+use headers::{AcceptRanges, ContentLength, ContentType, HeaderMapExt, HeaderValue};
+use http::header::CONTENT_TYPE;
+use hyper::{Body, Method, Response, StatusCode};
+
+/// Checks if a fallback response can be generated, i.e. if it is a GET request that would result in a 404 error and a fallback page is configured.
+/// If a response can be generated, it is returned, else `None` is returned.
+pub fn fallback_response(
+    method: &Method,
+    status_code: &StatusCode,
+    page_fallback: &Option<String>,
+) -> Option<Response<Body>> {
+    if (status_code == &StatusCode::NOT_FOUND) && (method == Method::GET) {
+        if let Some(fallback_page_content) = page_fallback {
+            let body = Body::from(fallback_page_content.to_owned());
+            let len = fallback_page_content.len() as u64;
+
+            let mut resp = Response::new(body);
+            *resp.status_mut() = StatusCode::OK;
+            resp.headers_mut().insert(
+                CONTENT_TYPE,
+                HeaderValue::from_static("text/html; charset=utf-8"),
+            );
+            resp.headers_mut().typed_insert(ContentLength(len));
+            resp.headers_mut().typed_insert(ContentType::html());
+            resp.headers_mut().typed_insert(AcceptRanges::bytes());
+
+            Some(resp)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -1,7 +1,6 @@
-use headers::{AcceptRanges, ContentLength, ContentType, HeaderMapExt, HeaderValue};
-use http::header::CONTENT_TYPE;
+use headers::{AcceptRanges, ContentLength, ContentType, HeaderMapExt};
 use hyper::{Body, Response, StatusCode};
-
+use mime_guess::mime;
 /// Checks if a fallback response can be generated, i.e. if it is a GET request that would result in a 404 error and a fallback page is configured.
 /// If a response can be generated, it is returned, else `None` is returned.
 pub fn fallback_response(page_fallback: &str) -> Response<Body> {
@@ -10,12 +9,10 @@ pub fn fallback_response(page_fallback: &str) -> Response<Body> {
 
     let mut resp = Response::new(body);
     *resp.status_mut() = StatusCode::OK;
-    resp.headers_mut().insert(
-        CONTENT_TYPE,
-        HeaderValue::from_static("text/html; charset=utf-8"),
-    );
+
     resp.headers_mut().typed_insert(ContentLength(len));
-    resp.headers_mut().typed_insert(ContentType::html());
+    resp.headers_mut()
+        .typed_insert(ContentType::from(mime::TEXT_HTML_UTF_8));
     resp.headers_mut().typed_insert(AcceptRanges::bytes());
 
     resp

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -1,34 +1,22 @@
 use headers::{AcceptRanges, ContentLength, ContentType, HeaderMapExt, HeaderValue};
 use http::header::CONTENT_TYPE;
-use hyper::{Body, Method, Response, StatusCode};
+use hyper::{Body, Response, StatusCode};
 
 /// Checks if a fallback response can be generated, i.e. if it is a GET request that would result in a 404 error and a fallback page is configured.
 /// If a response can be generated, it is returned, else `None` is returned.
-pub fn fallback_response(
-    method: &Method,
-    status_code: &StatusCode,
-    page_fallback: &Option<String>,
-) -> Option<Response<Body>> {
-    if (status_code == &StatusCode::NOT_FOUND) && (method == Method::GET) {
-        if let Some(fallback_page_content) = page_fallback {
-            let body = Body::from(fallback_page_content.to_owned());
-            let len = fallback_page_content.len() as u64;
+pub fn fallback_response(page_fallback: &str) -> Response<Body> {
+    let body = Body::from(page_fallback.to_owned());
+    let len = page_fallback.len() as u64;
 
-            let mut resp = Response::new(body);
-            *resp.status_mut() = StatusCode::OK;
-            resp.headers_mut().insert(
-                CONTENT_TYPE,
-                HeaderValue::from_static("text/html; charset=utf-8"),
-            );
-            resp.headers_mut().typed_insert(ContentLength(len));
-            resp.headers_mut().typed_insert(ContentType::html());
-            resp.headers_mut().typed_insert(AcceptRanges::bytes());
+    let mut resp = Response::new(body);
+    *resp.status_mut() = StatusCode::OK;
+    resp.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    resp.headers_mut().typed_insert(ContentLength(len));
+    resp.headers_mut().typed_insert(ContentType::html());
+    resp.headers_mut().typed_insert(AcceptRanges::bytes());
 
-            Some(resp)
-        } else {
-            None
-        }
-    } else {
-        None
-    }
+    resp
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod control_headers;
 pub mod cors;
 pub mod error_page;
+pub mod fallback_page;
 pub mod handler;
 pub mod helpers;
 pub mod logger;

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,6 +95,15 @@ impl Server {
         let page404 = helpers::read_file_content(&opts.page404);
         let page50x = helpers::read_file_content(&opts.page50x);
 
+        // Fallback page content
+        let page_fallback = helpers::read_file_content(&opts.page_fallback);
+        let page_fallback = if page_fallback.is_empty() {
+            None
+        } else {
+            Some(page_fallback)
+        };
+        tracing::info!("fallback page: enabled={}", page_fallback.is_some());
+
         // Number of worker threads option
         let threads = self.threads;
         tracing::info!("runtime worker threads: {}", self.threads);
@@ -148,6 +157,7 @@ impl Server {
                 cache_control_headers,
                 page404,
                 page50x,
+                page_fallback,
                 basic_auth,
             }),
         });

--- a/src/server.rs
+++ b/src/server.rs
@@ -97,12 +97,6 @@ impl Server {
 
         // Fallback page content
         let page_fallback = helpers::read_file_content(&opts.page_fallback);
-        let page_fallback = if page_fallback.is_empty() {
-            None
-        } else {
-            Some(page_fallback)
-        };
-        tracing::info!("fallback page: enabled={}", page_fallback.is_some());
 
         // Number of worker threads option
         let threads = self.threads;


### PR DESCRIPTION
## Description
This implements a new option, `--page-fallback` / `SERVER_FALLBACK_PAGE`. If set, it is used to respond to GET requests that would otherwise result in a 404 error. Basically, it is like the `--page404` option, but returns a status code 200 instead.

## Motivation and Context
This is useful when using client routing, e.g. with react-router.

## How Has This Been Tested?
Requested a non-existing path with both the option enabled and disabled.
- enabled: the fallback page is served with a 200 status code.
- disabled: the 404 error page is served with a 404 status code.