### PR TITLE
Log request file with its remote address if available

### DIFF
--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -60,6 +60,16 @@ grace-period = 0
 #### Page fallback for 404s
 # page-fallback = "some_page.html"
 
+#### Log request Remote Address if available
+log-remote-address = false
+
+
+### Windows Only
+
+#### Run the web server as a Windows Service
+# windows-service = false
+
+
 
 [advanced]
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -20,6 +20,7 @@ pub struct RequestHandlerOpts {
     pub page50x: Vec<u8>,
     pub page_fallback: Vec<u8>,
     pub basic_auth: String,
+    pub log_remote_address: bool,
 
     // Advanced options
     pub advanced_opts: Option<Advanced>,
@@ -46,16 +47,21 @@ impl RequestHandler {
         let uri_query = uri.query();
         let dir_listing = self.opts.dir_listing;
         let dir_listing_order = self.opts.dir_listing_order;
+        let log_remote_addr = self.opts.log_remote_address;
 
         let mut cors_headers: Option<http::HeaderMap> = None;
 
-        // Log request information with its remote address
-        let remote_addr = remote_addr.map_or("".to_owned(), |v| v.to_string());
+        // Log request information with its remote address if available
+        let mut remote_addr_str = String::new();
+        if log_remote_addr {
+            remote_addr_str.push_str(" remote_addr=");
+            remote_addr_str.push_str(&remote_addr.map_or("".to_owned(), |v| v.to_string()));
+        }
         tracing::info!(
-            "incoming request: method={} uri={} remote_addr={}",
+            "incoming request: method={} uri={}{}",
             method,
             uri,
-            remote_addr,
+            remote_addr_str,
         );
 
         async move {

--- a/src/server.rs
+++ b/src/server.rs
@@ -162,6 +162,10 @@ impl Server {
             !general.basic_auth.is_empty()
         );
 
+        // Log remote address option
+        let log_remote_address = general.log_remote_address;
+        tracing::info!("log remote address: enabled={}", log_remote_address);
+
         // Grace period option
         let grace_period = general.grace_period;
         tracing::info!("grace period before graceful shutdown: {}s", grace_period);
@@ -180,6 +184,7 @@ impl Server {
                 page50x,
                 page_fallback,
                 basic_auth,
+                log_remote_address,
                 advanced_opts,
             }),
         });

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -170,6 +170,15 @@ pub struct General {
     /// Server TOML configuration file path.
     pub config_file: Option<PathBuf>,
 
+    #[structopt(
+        long,
+        parse(try_from_str),
+        default_value = "false",
+        env = "SERVER_LOG_REMOTE_ADDRESS"
+    )]
+    /// Log incoming requests information along with its remote address if available using the `info` log level.
+    pub log_remote_address: bool,
+
     //
     // Windows specific arguments and commands
     //

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -96,6 +96,8 @@ pub struct General {
     pub grace_period: Option<u8>,
 
     pub page_fallback: Option<PathBuf>,
+
+    pub log_remote_address: Option<bool>,
 }
 
 /// Full server configuration

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -61,6 +61,7 @@ impl Settings {
         let mut threads_multiplier = opts.threads_multiplier;
         let mut grace_period = opts.grace_period;
         let mut page_fallback = opts.page_fallback;
+        let mut log_remote_address = opts.log_remote_address;
 
         // Define the advanced file options
         let mut settings_advanced: Option<Advanced> = None;
@@ -145,6 +146,9 @@ impl Settings {
                     if let Some(v) = general.page_fallback {
                         page_fallback = Some(v)
                     }
+                    if let Some(v) = general.log_remote_address {
+                        log_remote_address = v
+                    }
                 }
 
                 // Prepare the "advanced" options
@@ -206,6 +210,7 @@ impl Settings {
                 threads_multiplier,
                 grace_period,
                 page_fallback,
+                log_remote_address,
 
                 // NOTE:
                 // Windows-only options and commands

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -45,6 +45,19 @@ grace-period = 0
 #### Page fallback for 404s
 page-fallback = ""
 
+#### Page fallback for 404s
+page-fallback = ""
+
+#### Log request Remote Address if available
+log-remote-address = false
+
+
+### Windows Only
+
+#### Run the web server as a Windows Service
+# windows-service = false
+
+
 [advanced]
 
 #### HTTP Headers customization
@@ -56,7 +69,7 @@ headers = { Access-Control-Allow-Origin = "*", X-XSS-PROTECTION = "1; mode=block
 
 # #### b. Multiline version
 [[advanced.headers]]
-source = "index.html"
+source = "/index.html"
 [advanced.headers.headers]
 Cache-Control = "public, max-age=36000"
 Content-Security-Policy = "frame-ancestors 'self'"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a boolean option (`--log-remote-address`) to log incoming requests information along with its _remote address_ if available using the `info` log level.

**Log examples**

```log
2022-05-23T22:24:50.519540Z  INFO static_web_server::handler: incoming request: method=GET uri=/ remote_addr=192.168.1.126:57625
2022-05-23T22:25:26.516841Z  INFO static_web_server::handler: incoming request: method=GET uri=/favicon.ico remote_addr=192.168.1.126:57625
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature request #111 and motivated by #77 discussion.

## How Has This Been Tested?

```sh
static-web-server -a 0.0.0.0 -p 8080 -d docker/public/ -g info
# 2022-05-23T22:24:44.523057Z  INFO static_web_server::logger: logging level: info
# 2022-05-23T22:24:44.523856Z  INFO static_web_server::server: server bound to TCP socket 0.0.0.0:8080
# 2022-05-23T22:24:44.523962Z  INFO static_web_server::server: runtime worker threads: 4
# 2022-05-23T22:24:44.523989Z  INFO static_web_server::server: security headers: enabled=false
# 2022-05-23T22:24:44.524006Z  INFO static_web_server::server: auto compression: enabled=true
# 2022-05-23T22:24:44.524061Z  INFO static_web_server::server: directory listing: enabled=false
# 2022-05-23T22:24:44.524097Z  INFO static_web_server::server: directory listing order code: 6
# 2022-05-23T22:24:44.524133Z  INFO static_web_server::server: cache control headers: enabled=true
# 2022-05-23T22:24:44.524191Z  INFO static_web_server::server: basic authentication: enabled=false
# 2022-05-23T22:24:44.524210Z  INFO static_web_server::server: grace period before graceful shutdown: 0s
# 2022-05-23T22:24:44.524527Z  INFO Server::start_server{addr_str="0.0.0.0:8080" threads=4}: static_web_server::server: close time.busy=0.00ns time.idle=10.6µs
# 2022-05-23T22:24:44.524585Z  INFO static_web_server::server: listening on http://0.0.0.0:8080
# 2022-05-23T22:24:44.524614Z  INFO static_web_server::server: press ctrl+c to shut down the server
# 2022-05-23T22:24:50.519540Z  INFO static_web_server::handler: incoming request: method=GET uri=/ remote_addr=192.168.1.126:57625
# 2022-05-23T22:25:26.516841Z  INFO static_web_server::handler: incoming request: method=GET uri=/favicon.ico remote_addr=192.168.1.126:57625
# 2022-05-23T22:25:26.517787Z  WARN static_web_server::error_page: method=GET uri=/favicon.ico status=404 error="Not Found"
```

## Screenshots (if appropriate):
No