### PR TITLE
URL rewrites with pattern matching support

### DIFF
--- a/docs/content/features/url-rewrites.md
+++ b/docs/content/features/url-rewrites.md
@@ -1,0 +1,41 @@
+# URL Rewrites 
+
+**SWS** provides the ability to rewrite request URLs with pattern matching support.
+
+URI rewrites are particularly useful with pattern matching ([globs](https://en.wikipedia.org/wiki/Glob_(programming))), as the server can accept any URL that matches the pattern and let the client-side code decide what to display.
+
+## Structure
+
+The URL rewrite rules should be defined mainly as an [Array of Tables](https://toml.io/en/v1.0.0#array-of-tables).
+
+Each table entry should have two key/value pairs:
+
+- One `source` key containing a string _glob pattern_.
+- One `destination` string containing the local file path.
+
+!!! info "Note"
+    The incoming request(s) will reach the `destination` only if the request(s) URI matches the `source` pattern.
+
+### Source
+
+The source is a [Glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)) that should match against the URI that is requesting a resource file.
+
+### Destination
+
+A local file path which must exist. It has to look something like `/some/directory/file.html`. It is worth noting that the `/` at the beginning indicates the server's root directory.
+
+## Examples
+
+```toml
+[advanced]
+
+### URL Rewrites
+
+[[advanced.rewrites]]
+source = "**/*.{png,ico,gif}"
+destination = "/assets/generic1.png"
+
+[[advanced.rewrites]]
+source = "**/*.{jpg,jpeg}"
+destination = "/images/generic2.png"
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
     - 'Worker Threads Customization': 'features/worker-threads.md'
     - 'Error Pages': 'features/error-pages.md'
     - 'Custom HTTP Headers': 'features/custom-http-headers.md'
+    - 'URL Rewrites': 'features/url-rewrites.md'
     - 'Windows Service': 'features/windows-service.md'
   - 'Platforms & Architectures': 'platforms-architectures.md'
   - 'Migration from v1 to v2': 'migration.md'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod fallback_page;
 pub mod handler;
 pub mod helpers;
 pub mod logger;
+pub mod rewrites;
 pub mod security_headers;
 pub mod server;
 pub mod service;

--- a/src/rewrites.rs
+++ b/src/rewrites.rs
@@ -1,0 +1,19 @@
+use crate::settings::Rewrites;
+
+/// It returns a rewrite's destination path if the current request uri
+/// matches againt the provided rewrites array.
+pub fn rewrite_uri_path<'a>(
+    uri_path: &'a str,
+    rewrites_opts_vec: &'a Option<Vec<Rewrites>>,
+) -> Option<&'a str> {
+    if let Some(rewrites_vec) = rewrites_opts_vec {
+        for rewrites_entry in rewrites_vec.iter() {
+            // Match source glob pattern against request uri path
+            if rewrites_entry.source.is_match(uri_path) {
+                return Some(rewrites_entry.destination.as_str());
+            }
+        }
+    }
+
+    None
+}

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeSet, path::PathBuf};
 
 use crate::{helpers, Context, Result};
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum LogLevel {
     Error,
@@ -37,12 +37,21 @@ pub struct Headers {
     pub headers: HeaderMap,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct Rewrites {
+    pub source: String,
+    pub destination: String,
+}
+
 /// Advanced server options only available in configuration file mode.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Advanced {
     // Headers
     pub headers: Option<Vec<Headers>>,
+    // Rewrites
+    pub rewrites: Option<Vec<Rewrites>>,
 }
 
 /// General server options available in configuration file mode.

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -2,7 +2,7 @@
 
 #### Address & Root dir
 host = "::"
-port = 8087
+port = 8787
 root = "docker/public"
 
 #### Logging
@@ -45,9 +45,6 @@ grace-period = 0
 #### Page fallback for 404s
 page-fallback = ""
 
-#### Page fallback for 404s
-page-fallback = ""
-
 #### Log request Remote Address if available
 log-remote-address = false
 
@@ -79,3 +76,14 @@ Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
 [[advanced.headers]]
 source = "**/*.{jpg,jpeg,png,ico,gif}"
 headers.Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+
+
+### URL Rewrites
+
+[[advanced.rewrites]]
+source = "**/*.{png,ico,gif}"
+destination = "/assets/favicon.ico"
+
+[[advanced.rewrites]]
+source = "**/*.{jpg,jpeg}"
+destination = "/images/nomad.png"


### PR DESCRIPTION
## Description

It adds the ability to rewrite request URLs with pattern matching (globs) support via the configuration file.

```toml
[advanced]

### URL Rewrites

[[advanced.rewrites]]
source = "**/*.{png,ico,gif}"
destination = "/assets/generic1.png"

[[advanced.rewrites]]
source = "**/*.{jpg,jpeg}"
destination = "/images/generic2.png"
```

## Related Issue

Resolves #116, #115

## Motivation and Context

URI rewrites are particularly useful with pattern matching (globs), as one can accept any URL that matches the pattern and let the client-side code decide what to display.

Reference: https://firebase.google.com/docs/hosting/full-config?authuser=0#rewrites

## How Has This Been Tested?

Smoke test

## Screenshots (if appropriate):

No