### PR TITLE
Redirects with pattern matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +974,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_ignored",
+ "serde_repr",
  "signal-hook",
  "signal-hook-tokio",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ pin-project = "1.0"
 rustls-pemfile = "0.2"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
+serde_repr = "0.1"
 structopt = { version = "0.3", default-features = false }
 time = { version = "0.1", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"] }

--- a/docs/content/features/url-redirects.md
+++ b/docs/content/features/url-redirects.md
@@ -1,0 +1,52 @@
+# URL Redirects 
+
+**SWS** provides the ability to redirect request URLs with pattern matching support.
+
+URI redirects are particularly useful with pattern matching ([globs](https://en.wikipedia.org/wiki/Glob_(programming))). Use them for example to prevent broken links if you've moved a page or to shorten URLs.
+
+## Structure
+
+The URL redirect rules should be defined mainly as an [Array of Tables](https://toml.io/en/v1.0.0#array-of-tables).
+
+Each table entry should have the following key/value pairs:
+
+- One `source` key containing a string _glob pattern_.
+- One `destination` string containing the local file path or a full URL.
+- One `kind` number containing the HTTP response code.
+
+!!! info "Note"
+    The incoming request(s) will reach the `destination` only if the request(s) URI matches the `source` pattern.
+
+### Source
+
+The source is a [Glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)) that should match against the URI that is requesting a resource file.
+
+### Destination
+
+A local file path must exist. It can be a local path `/some/directory/file.html` or a full URL. It is worth noting that the `/` at the beginning indicates the server's root directory.
+
+### Kind
+
+It indicates the HTTP response code.
+The values can be:
+
+- `301` for "Moved Permanently"
+- `302` for "Found" (Temporary Redirect)
+
+## Examples
+
+```toml
+[advanced]
+
+### URL Redirects
+
+[[advanced.redirects]]
+source = "**/*.{jpg,jpeg}"
+destination = "/images/generic1.png"
+kind = 301
+
+[[advanced.redirects]]
+source = "/index.html"
+destination = "https://sws.joseluisq.net"
+kind = 302
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
     - 'Error Pages': 'features/error-pages.md'
     - 'Custom HTTP Headers': 'features/custom-http-headers.md'
     - 'URL Rewrites': 'features/url-rewrites.md'
+    - 'URL Redirects': 'features/url-redirects.md'
     - 'Windows Service': 'features/windows-service.md'
   - 'Platforms & Architectures': 'platforms-architectures.md'
   - 'Migration from v1 to v2': 'migration.md'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod fallback_page;
 pub mod handler;
 pub mod helpers;
 pub mod logger;
+pub mod redirects;
 pub mod rewrites;
 pub mod security_headers;
 pub mod server;

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -1,0 +1,21 @@
+use hyper::StatusCode;
+
+use crate::settings::Redirects;
+
+/// It returns a redirect's destination path and status code if the current request uri
+/// matches againt the provided redirect's array.
+pub fn get_redirection<'a>(
+    uri_path: &'a str,
+    redirects_opts_vec: &'a Option<Vec<Redirects>>,
+) -> Option<(&'a str, &'a StatusCode)> {
+    if let Some(redirects_vec) = redirects_opts_vec {
+        for redirect_entry in redirects_vec.iter() {
+            // Match source glob pattern against the request uri path
+            if redirect_entry.source.is_match(uri_path) {
+                return Some((redirect_entry.destination.as_str(), &redirect_entry.kind));
+            }
+        }
+    }
+
+    None
+}

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -2,6 +2,7 @@
 
 use headers::HeaderMap;
 use serde::Deserialize;
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::path::Path;
 use std::{collections::BTreeSet, path::PathBuf};
 
@@ -37,6 +38,23 @@ pub struct Headers {
     pub headers: HeaderMap,
 }
 
+#[derive(Debug, Serialize_repr, Deserialize_repr, Clone)]
+#[repr(u16)]
+pub enum RedirectsKind {
+    /// Moved Permanently
+    Permanent = 301,
+    /// Found
+    Temporary = 302,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct Redirects {
+    pub source: String,
+    pub destination: String,
+    pub kind: RedirectsKind,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Rewrites {
@@ -52,6 +70,8 @@ pub struct Advanced {
     pub headers: Option<Vec<Headers>>,
     // Rewrites
     pub rewrites: Option<Vec<Rewrites>>,
+    // Redirects
+    pub redirects: Option<Vec<Redirects>>,
 }
 
 /// General server options available in configuration file mode.

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -78,6 +78,18 @@ source = "**/*.{jpg,jpeg,png,ico,gif}"
 headers.Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
 
 
+### URL Redirects
+
+[[advanced.redirects]]
+source = "**/*.{jpg,jpeg}"
+destination = "/images/generic1.png"
+kind = 301
+
+[[advanced.redirects]]
+source = "/index.html"
+destination = "https://sws.joseluisq.net"
+kind = 302
+
 ### URL Rewrites
 
 [[advanced.rewrites]]


### PR DESCRIPTION
## Description

It adds the ability to redirect request URLs with pattern matching (globs) support via the configuration file.

## Related Issue

No

## Motivation and Context

URL redirects are particularly useful with pattern matching ([globs](https://en.wikipedia.org/wiki/Glob_(programming))). For example to prevent broken links if one's has moved a page or to shorten URLs.

Reference: https://firebase.google.com/docs/hosting/full-config?authuser=0#redirects

## How Has This Been Tested?

Cross-platform smoke test

## Screenshots (if appropriate):

No