### PR TITLE
Relative paths for directory listing entries

### DIFF
--- a/docs/content/features/directory-listing.md
+++ b/docs/content/features/directory-listing.md
@@ -11,9 +11,18 @@ static-web-server \
     --directory-listing true
 ```
 
-And here an example of how the directory listing looks like.
+And here is an example of how the directory listing looks like.
 
 <img title="SWS - Directory Listing" src="https://user-images.githubusercontent.com/1700322/145420578-5a508d2a-773b-4239-acc0-197ea2062ff4.png" width="400">
+
+## Relative paths for entries
+
+SWS uses relative paths for the directory listing entries (file or directory) and is used regardless of the [redirect trailing slash](../features/trailing-slash-redirect.md) feature.
+
+However, when the *"redirect trailing slash"* feature is disabled and a directory request URI doesn't contain a trailing slash then the entries will contain the path `parent-dir/entry-name` as the link value. Otherwise, just an `entry-name` link value is used (default behavior).
+
+Note also that in both cases, SWS will append a trailing slash to the entry if is a directory.
+
 
 ## Sorting
 

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -252,9 +252,13 @@ async fn read_directory_entries(
         }
 
         let mut uri = None;
-        // NOTE: Use relative paths by default and absolute ones only
-        // when "redirect trailing slash" feature is disabled and
-        // `base_path` doesn't end with a slash char
+        // NOTE: Use relative paths by default independently of
+        // the "redirect trailing slash" feature.
+        // However, when "redirect trailing slash" is disabled
+        // and a request path doesn't contain a trailing slash then
+        // entries should contain the "parent/entry-name" as a link format.
+        // Otherwise, we just use the "entry-name" as a link (default behavior).
+        // Note that in both cases, we add a trailing slash if the entry is a directory.
         if !base_path.ends_with('/') {
             let base_path = Path::new(base_path);
             let parent_dir = base_path.parent().unwrap_or(base_path);

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -7,31 +7,35 @@
 mod tests {
     use headers::HeaderMap;
     use http::{Method, StatusCode};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use static_web_server::static_files::{self, HandleOpts};
 
-    fn root_dir() -> PathBuf {
-        PathBuf::from("docker/public/")
+    const METHODS: [Method; 8] = [
+        Method::CONNECT,
+        Method::DELETE,
+        Method::GET,
+        Method::HEAD,
+        Method::PATCH,
+        Method::POST,
+        Method::PUT,
+        Method::TRACE,
+    ];
+
+    fn root_dir<P: AsRef<Path>>(dir: P) -> PathBuf
+    where
+        PathBuf: From<P>,
+    {
+        PathBuf::from(dir)
     }
 
     #[tokio::test]
-    async fn dir_listing_redirect_permanent_uri() {
-        let methods = [
-            Method::CONNECT,
-            Method::DELETE,
-            Method::GET,
-            Method::HEAD,
-            Method::PATCH,
-            Method::POST,
-            Method::PUT,
-            Method::TRACE,
-        ];
-        for method in methods {
+    async fn dir_listing_redirect_trailing_slash_dir() {
+        for method in METHODS {
             match static_files::handle(&HandleOpts {
                 method: &method,
                 headers: &HeaderMap::new(),
-                base_path: &root_dir(),
+                base_path: &root_dir("docker/public/"),
                 uri_path: "/assets",
                 uri_query: None,
                 dir_listing: true,
@@ -43,6 +47,107 @@ mod tests {
                 Ok(res) => {
                     assert_eq!(res.status(), 308);
                     assert_eq!(res.headers()["location"], "/assets/");
+                }
+                Err(status) => {
+                    assert!(method != Method::GET && method != Method::HEAD);
+                    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn dir_listing_redirect_trailing_slash_relative_dir_path() {
+        for method in METHODS {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &HeaderMap::new(),
+                base_path: &root_dir("docs/"),
+                uri_path: "/content/",
+                uri_query: None,
+                dir_listing: true,
+                dir_listing_order: 6,
+                redirect_trailing_slash: true,
+            })
+            .await
+            {
+                Ok(mut res) => {
+                    assert_eq!(res.status(), 200);
+                    assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
+
+                    let body = hyper::body::to_bytes(res.body_mut())
+                        .await
+                        .expect("unexpected bytes error during `body` conversion");
+                    let body_str = std::str::from_utf8(&body).unwrap();
+                    // directory link should only contain "dir-name/" in a relative way
+                    assert_eq!(
+                        body_str.contains(r#"href="features/""#),
+                        method == Method::GET
+                    );
+                }
+                Err(status) => {
+                    assert!(method != Method::GET && method != Method::HEAD);
+                    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn dir_listing_no_redirect_trailing_slash_relative_dir_path() {
+        for method in METHODS {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &HeaderMap::new(),
+                base_path: &root_dir("docs/"),
+                uri_path: "/content",
+                uri_query: None,
+                dir_listing: true,
+                dir_listing_order: 6,
+                redirect_trailing_slash: false,
+            })
+            .await
+            {
+                Ok(mut res) => {
+                    assert_eq!(res.status(), 200);
+                    assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
+
+                    let body = hyper::body::to_bytes(res.body_mut())
+                        .await
+                        .expect("unexpected bytes error during `body` conversion");
+                    let body_str = std::str::from_utf8(&body).unwrap();
+                    // directory link should contain "parent/dir-name/" in a relative way
+                    assert_eq!(
+                        body_str.contains(r#"href="content/features/""#),
+                        method == Method::GET
+                    );
+                }
+                Err(status) => {
+                    assert!(method != Method::GET && method != Method::HEAD);
+                    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn dir_listing_no_redirect_trailing_slash_relative_file_path() {
+        for method in METHODS {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &HeaderMap::new(),
+                base_path: &root_dir("docs/"),
+                uri_path: "/README.md",
+                uri_query: None,
+                dir_listing: true,
+                dir_listing_order: 6,
+                redirect_trailing_slash: false,
+            })
+            .await
+            {
+                Ok(res) => {
+                    assert_eq!(res.status(), 200);
+                    assert_eq!(res.headers()["content-type"], "text/markdown");
                 }
                 Err(status) => {
                     assert!(method != Method::GET && method != Method::HEAD);


### PR DESCRIPTION
## Description

It provides relative path support for directory listing entries (file/directory links) either if `--redirect-trailing-slash` is enabled or not.

SWS will use relative paths by default regardless of the _"redirect trailing slash"_ feature.
However, when _"redirect trailing slash"_ is disabled and a directory request URI doesn't contain a trailing slash then entries should contain the `parent/entry-name` as a link format.
Otherwise, SWS will just use the `entry-name` as a link (default behavior).

Note that in both cases, SWS will append a trailing slash if the entry is a directory.

## Motivation and Context

Feature request #136

## How Has This Been Tested?

Unit tests on `tests/dir_listing.rs` that keep relative paths either when `--redirect-trailing-slash` is enabled or disabled.

## Screenshots (if appropriate):

No