### PR TITLE
Add logging of real remote IP - in case of proxies

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -62,6 +62,12 @@ impl RequestHandler {
         if log_remote_addr {
             remote_addr_str.push_str(" remote_addr=");
             remote_addr_str.push_str(&remote_addr.map_or("".to_owned(), |v| v.to_string()));
+
+            let forwarded_ip = headers.get("X-Forwarded-For");
+            if let Some(client_ip_address) = forwarded_ip {
+                remote_addr_str.push_str(" real_remote_ip=");
+                remote_addr_str.push_str(client_ip_address.to_str().unwrap())
+            }
         }
         tracing::info!(
             "incoming request: method={} uri={}{}",

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -63,12 +63,14 @@ impl RequestHandler {
             remote_addr_str.push_str(" remote_addr=");
             remote_addr_str.push_str(&remote_addr.map_or("".to_owned(), |v| v.to_string()));
 
-            if let Some(client_ip_address) = headers.get("X-Forwarded-For")
+            if let Some(client_ip_address) = headers
+                .get("X-Forwarded-For")
                 .and_then(|v| v.to_str().ok())
                 .and_then(|s| s.split(',').next())
-                .and_then(|s| s.trim().parse::<IpAddr>().ok()) {
-                    remote_addr_str.push_str(" real_remote_ip=");
-                    remote_addr_str.push_str(&client_ip_address.to_string())
+                .and_then(|s| s.trim().parse::<IpAddr>().ok())
+            {
+                remote_addr_str.push_str(" real_remote_ip=");
+                remote_addr_str.push_str(&client_ip_address.to_string())
             }
         }
         tracing::info!(

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -63,8 +63,7 @@ impl RequestHandler {
             remote_addr_str.push_str(" remote_addr=");
             remote_addr_str.push_str(&remote_addr.map_or("".to_owned(), |v| v.to_string()));
 
-            let forwarded_ip = headers.get("X-Forwarded-For");
-            if let Some(client_ip_address) = forwarded_ip {
+            if let Some(client_ip_address) = headers.get("X-Forwarded-For") {
                 remote_addr_str.push_str(" real_remote_ip=");
                 remote_addr_str.push_str(client_ip_address.to_str().unwrap())
             }


### PR DESCRIPTION
Extends logging to capture `X-Forwarded-For` header (in case of proxies)  

## Description
When server is used behind reverse proxy, reported `remote_addr` reflects internal interface and port, not client external IP. This PR adds additional `real_remote_ip` that is filled with contents of X-Forwarded-For

## Motivation and Context
Main motivation is enable logs to be used with web statistics tools (like AWStats) that require IP addresses to be present in log files

## How Has This Been Tested?
Tested by providing (or not) X-Forwarded-For header with Postman
