### PR TITLE
Directory listing format

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -136,7 +136,7 @@ jobs:
         echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
 
     - name: Cache cargo registry and git trees
-      uses: Swatinem/rust-cache@v1
+      uses: Swatinem/rust-cache@v2
 
     - name: Show command used for Cargo
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +921,17 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b3da7eedd967647a866f67829d1c79d184d7c4521126e9cc2c46a9585c6d21"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+dependencies = [
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -1037,6 +1054,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_ignored",
+ "serde_json",
  "serde_repr",
  "signal-hook",
  "signal-hook-tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ windows-sys = { version = "0.36.1", features = [ "Win32_Foundation", "Win32_Netw
 
 [dev-dependencies]
 bytes = "1.1"
+serde_json = "1.0"
 
 [profile.release]
 codegen-units = 1

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,8 +3,9 @@ use hyper::{header::WWW_AUTHENTICATE, Body, Method, Request, Response, StatusCod
 use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc};
 
 use crate::{
-    basic_auth, compression, control_headers, cors, custom_headers, error_page, fallback_page,
-    redirects, rewrites, security_headers,
+    basic_auth, compression, control_headers, cors, custom_headers,
+    directory_listing::DirListFmt,
+    error_page, fallback_page, redirects, rewrites, security_headers,
     settings::Advanced,
     static_files::{self, HandleOpts},
     Error, Result,
@@ -18,6 +19,7 @@ pub struct RequestHandlerOpts {
     pub compression_static: bool,
     pub dir_listing: bool,
     pub dir_listing_order: u8,
+    pub dir_listing_format: DirListFmt,
     pub cors: Option<cors::Configured>,
     pub security_headers: bool,
     pub cache_control_headers: bool,
@@ -53,6 +55,7 @@ impl RequestHandler {
         let uri_query = uri.query();
         let dir_listing = self.opts.dir_listing;
         let dir_listing_order = self.opts.dir_listing_order;
+        let dir_listing_format = &self.opts.dir_listing_format;
         let log_remote_addr = self.opts.log_remote_address;
         let redirect_trailing_slash = self.opts.redirect_trailing_slash;
         let compression_static = self.opts.compression_static;
@@ -190,6 +193,7 @@ impl RequestHandler {
                 uri_query,
                 dir_listing,
                 dir_listing_order,
+                dir_listing_format,
                 redirect_trailing_slash,
                 compression_static,
             })

--- a/src/server.rs
+++ b/src/server.rs
@@ -150,6 +150,10 @@ impl Server {
         let dir_listing_order = general.directory_listing_order;
         tracing::info!("directory listing order code: {}", dir_listing_order);
 
+        // Directory listing format
+        let dir_listing_format = general.directory_listing_format;
+        tracing::info!("directory listing format: {}", dir_listing_format);
+
         // Cache control headers option
         let cache_control_headers = general.cache_control_headers;
         tracing::info!("cache control headers: enabled={}", cache_control_headers);
@@ -191,6 +195,7 @@ impl Server {
                 compression_static,
                 dir_listing,
                 dir_listing_order,
+                dir_listing_format,
                 cors,
                 security_headers,
                 cache_control_headers,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -3,6 +3,8 @@
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+use crate::directory_listing::DirListFmt;
+
 /// General server configuration available in CLI and config file options.
 #[derive(Debug, StructOpt)]
 #[structopt(about, author)]
@@ -152,6 +154,17 @@ pub struct General {
     )]
     /// Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size` attributes (columns). Code numbers supported: 0 (Name asc), 1 (Name desc), 2 (Last modified asc), 3 (Last modified desc), 4 (Size asc), 5 (Size desc). Default 6 (unordered)
     pub directory_listing_order: u8,
+
+    #[structopt(
+        long,
+        required_if("directory_listing", "true"),
+        possible_values = &DirListFmt::variants(),
+        default_value = "html",
+        env = "SERVER_DIRECTORY_LISTING_FORMAT",
+        case_insensitive = true
+    )]
+    /// Specify a content format for directory listing entries. Formats supported: "html" or "json". Default "html".
+    pub directory_listing_format: DirListFmt,
 
     #[structopt(
         long,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -6,6 +6,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::path::Path;
 use std::{collections::BTreeSet, path::PathBuf};
 
+use crate::directory_listing::DirListFmt;
 use crate::{helpers, Context, Result};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -116,6 +117,7 @@ pub struct General {
     // Directory listing
     pub directory_listing: Option<bool>,
     pub directory_listing_order: Option<u8>,
+    pub directory_listing_format: Option<DirListFmt>,
 
     // Basich Authentication
     pub basic_auth: Option<String>,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -79,6 +79,7 @@ impl Settings {
         let mut cors_expose_headers = opts.cors_expose_headers;
         let mut directory_listing = opts.directory_listing;
         let mut directory_listing_order = opts.directory_listing_order;
+        let mut directory_listing_format = opts.directory_listing_format;
         let mut basic_auth = opts.basic_auth;
         let mut fd = opts.fd;
         let mut threads_multiplier = opts.threads_multiplier;
@@ -164,6 +165,9 @@ impl Settings {
                     }
                     if let Some(v) = general.directory_listing_order {
                         directory_listing_order = v
+                    }
+                    if let Some(v) = general.directory_listing_format {
+                        directory_listing_format = v
                     }
                     if let Some(ref v) = general.basic_auth {
                         basic_auth = v.to_owned()
@@ -308,6 +312,7 @@ impl Settings {
                 cors_expose_headers,
                 directory_listing,
                 directory_listing_order,
+                directory_listing_format,
                 basic_auth,
                 fd,
                 threads_multiplier,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -23,6 +23,7 @@ use tokio::fs::File as TkFile;
 use tokio::io::AsyncSeekExt;
 use tokio_util::io::poll_read_buf;
 
+use crate::directory_listing::DirListFmt;
 use crate::{compression_static, directory_listing, Result};
 
 /// Defines all options needed by the static-files handler.
@@ -34,6 +35,7 @@ pub struct HandleOpts<'a> {
     pub uri_query: Option<&'a str>,
     pub dir_listing: bool,
     pub dir_listing_order: u8,
+    pub dir_listing_format: &'a DirListFmt,
     pub redirect_trailing_slash: bool,
     pub compression_static: bool,
 }
@@ -108,6 +110,7 @@ pub async fn handle<'a>(opts: &HandleOpts<'a>) -> Result<(Response<Body>, bool),
             opts.uri_query,
             file_path.as_ref(),
             opts.dir_listing_order,
+            opts.dir_listing_format,
         )
         .await?;
 

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -10,7 +10,10 @@ mod tests {
     use http::Method;
     use std::path::PathBuf;
 
-    use static_web_server::static_files::{self, HandleOpts};
+    use static_web_server::{
+        directory_listing::DirListFmt,
+        static_files::{self, HandleOpts},
+    };
 
     fn public_dir() -> PathBuf {
         PathBuf::from("docker/public/")
@@ -37,6 +40,7 @@ mod tests {
             uri_query: None,
             dir_listing: false,
             dir_listing_order: 6,
+            dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: true,
         })
@@ -89,6 +93,7 @@ mod tests {
             uri_query: None,
             dir_listing: false,
             dir_listing_order: 6,
+            dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: true,
         })

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -13,6 +13,7 @@ mod tests {
 
     use static_web_server::{
         compression,
+        directory_listing::DirListFmt,
         static_files::{self, HandleOpts},
     };
 
@@ -30,6 +31,7 @@ mod tests {
             uri_query: None,
             dir_listing: false,
             dir_listing_order: 6,
+            dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
         })
@@ -70,6 +72,7 @@ mod tests {
             uri_query: None,
             dir_listing: false,
             dir_listing_order: 6,
+            dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
         })
@@ -111,6 +114,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -136,6 +140,7 @@ mod tests {
             uri_query: None,
             dir_listing: false,
             dir_listing_order: 0,
+            dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
         })
@@ -162,6 +167,7 @@ mod tests {
             uri_query: None,
             dir_listing: false,
             dir_listing_order: 0,
+            dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
         })
@@ -187,6 +193,7 @@ mod tests {
             uri_query: None,
             dir_listing: false,
             dir_listing_order: 0,
+            dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: false,
             compression_static: false,
         })
@@ -217,6 +224,7 @@ mod tests {
                     uri_query: None,
                     dir_listing: false,
                     dir_listing_order: 6,
+                    dir_listing_format: &DirListFmt::Html,
                     redirect_trailing_slash: true,
                     compression_static: false,
                 })
@@ -262,6 +270,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -289,6 +298,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -319,6 +329,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -349,6 +360,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -382,6 +394,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -413,6 +426,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -442,6 +456,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -470,6 +485,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -512,6 +528,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -571,6 +588,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -633,6 +651,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -675,6 +694,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -718,6 +738,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -753,6 +774,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -798,6 +820,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -840,6 +863,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -885,6 +909,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -928,6 +953,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -966,6 +992,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })
@@ -1015,6 +1042,7 @@ mod tests {
                 uri_query: None,
                 dir_listing: false,
                 dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
             })

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -3,7 +3,7 @@
 #### Address & Root dir
 host = "::"
 port = 8787
-root = "docker/public"
+root = "tests/fixtures/public"
 
 #### Logging
 log-level = "trace"
@@ -28,7 +28,13 @@ security-headers = true
 cors-allow-origins = ""
 
 #### Directory listing
-directory-listing = false
+directory-listing = true
+
+#### Directory listing sorting code
+directory-listing-order = 1
+
+#### Directory listing content format
+directory-listing-format = "json"
 
 #### Basich Authentication
 basic-auth = ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be concise as possible -->

This PR adds support for specifying an output format for the directory listing entries via a new option `--directory-listing-format <directory-listing-format>`.

Formats supported: `html`, `json`
Default: `html`

__JSON output__
```json
[
  {
    "name": "spécial directöry",
    "type": "directory",
    "mtime": "2022-10-07T00:53:50Z"
  },
  {
    "name": "index.html.gz",
    "type": "file",
    "mtime": "2022-09-27T22:44:34Z",
    "size": 332
  }
]
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Feature request #128

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

SWS:

```sh
$ static-web-server -p=8787 -d=tests/fixtures/public -g=trace -z=true --directory-listing-format=json
```

Client:

```sh
$ curl -iH "Content-Type: application/json" http://localhost:8787
HTTP/1.1 200 OK
content-type: application/json
content-length: 163
cache-control: public, max-age=86400
date: Tue, 11 Oct 2022 23:24:55 GMT

[{"name":"spécial directöry","type":"directory","mtime":"2022-10-07T00:53:50Z"},{"name":"index.html.gz","type":"file","mtime":"2022-09-27T22:44:34Z","size":332}]⏎
```

## Screenshots (if appropriate):
No