### PR TITLE
Make static file reading (content/metadata) operations sync

### DIFF
--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -40,7 +40,7 @@ pub async fn precompressed_variant(
             filepath_precomp.display()
         );
 
-        if let Ok((meta, _)) = file_metadata(&filepath_precomp).await {
+        if let Ok((meta, _)) = file_metadata(&filepath_precomp) {
             tracing::trace!("pre-compressed file variant found, serving it directly");
 
             let encoding = if ext == "gz" { "gzip" } else { ext };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR makes file content and metadata read operations _sync_ which increases performance and reduces resource utilization.

**Synopsis**

We know that the throughput is critical for file reading (content/metadata) operations on our static file module.
However, those particular operations were performed _async_, causing significant overhead due to the added extra costs of using the async runtime for them.
But, we have extremely little waiting (we essentially block on one task) for those file reading operations.
so we turned them into their _sync_ counterparts, resulting in `~58%` performance increase and `~10%` _(CPU)_ / `~52%` _(RAM)_ less resource utilization.

**Notes**

We are now using a static `4KB` (read buffer size) for Unix-like since looks like the number is _still_ the [most common page size](https://www.sobyte.net/post/2021-12/whys-the-design-linux-default-page/) for most operating systems.
For Windows, we still keep the usage of `8KB` since it looks like [it's a balanced number](https://devblogs.microsoft.com/oldnewthing/20040908-00/?p=37923).

We were inspired by the ideas of the [weihanglo/sfz's `FileStream`](https://github.com/weihanglo/sfz/blob/master/src/server/send.rs#L143-L173) implementation as analogous to our `file_stream` one.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #146

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Below are two 1min tests using the SWS defaults:

```sh
wrk --latency -t4 -c100 -d1m http://localhost
```

**before (v2.13.0):**

```
Running 1m test @ http://localhost
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     5.47ms    1.15ms  33.78ms   75.84%
    Req/Sec     4.58k   276.47     5.74k    74.96%
  Latency Distribution
     50%    5.47ms
     75%    6.06ms
     90%    6.73ms
     99%    8.49ms
  1094168 requests in 1.00m, 747.13MB read
Requests/sec:  18222.47
Transfer/sec:     12.44MB
```

**after:**

```
Running 1m test @ http://localhost
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.29ms    0.91ms  19.52ms   71.84%
    Req/Sec    10.97k   628.29    13.89k    86.83%
  Latency Distribution
     50%    2.25ms
     75%    2.82ms
     90%    3.40ms
     99%    4.73ms
  2620459 requests in 1.00m, 1.75GB read
Requests/sec:  43648.84
Transfer/sec:     29.80MB
```

## Screenshots (if appropriate):
No