### PR TITLE
Fix missing `SERVER` prefix for the  `redirect-trailing-slash` feature flag

### DIFF
--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -101,7 +101,7 @@ OPTIONS:
     -p, --port <port>                                            Host port [env: SERVER_PORT=]  [default: 80]
         --redirect-trailing-slash <redirect-trailing-slash>
             Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path
-            with a trailing slash suffix if it is missing [env: REDIRECT_TRAILING_SLASH=]  [default: true]
+            with a trailing slash suffix if it is missing [env: SERVER_REDIRECT_TRAILING_SLASH=]  [default: true]
     -d, --root <root>
             Root directory path of static files [env: SERVER_ROOT=]  [default: ./public]
 
@@ -120,7 +120,7 @@ OPTIONS:
 
 ## Windows
 
-Following options and commands are Windows platform specific.
+The following options and commands are Windows platform specific.
 
 ```
  -s, --windows-service <windows-service>

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -84,7 +84,7 @@ Enable cache control headers for incoming requests based on a set of file types.
 ### SERVER_BASIC_AUTH
 It provides [The "Basic" HTTP Authentication Scheme](https://datatracker.ietf.org/doc/html/rfc7617) using credentials as `user-id:password` pairs, encoded using `Base64`. Password must be encoded using the [BCrypt](https://en.wikipedia.org/wiki/Bcrypt) password-hashing function. Default empty (disabled).
 
-### REDIRECT_TRAILING_SLASH
+### SERVER_REDIRECT_TRAILING_SLASH
 Check for a trailing slash in the requested directory URI and redirect permanent (308) to the same path with a trailing slash suffix if it is missing. Default `true` (enabled).
 
 ## Windows

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -214,7 +214,7 @@ pub struct General {
         long,
         parse(try_from_str),
         default_value = "true",
-        env = "REDIRECT_TRAILING_SLASH"
+        env = "SERVER_REDIRECT_TRAILING_SLASH"
     )]
     /// Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path with a trailing slash suffix if it is missing.
     pub redirect_trailing_slash: bool,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

We missed the `SERVER` prefix for the  `redirect-trailing-slash` feature on #131. So this PR adds it.

**Breaking**
This fix is a breaking change only if the previous `REDIRECT_TRAILING_SLASH` env was used **explicitly**.
Otherwise, if not set/used (default behavior) then there is no impact.

**Advice**
We highly encourage users to update `REDIRECT_TRAILING_SLASH` with `SERVER_REDIRECT_TRAILING_SLASH` for consistency reasons.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #131

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Just run `static-web-server -h` and search for `SERVER_REDIRECT_TRAILING_SLASH`.

## Screenshots (if appropriate):
