### PR TITLE
Ignore Unix hidden files/directories (dotfiles)

### DIFF
--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -82,6 +82,9 @@ OPTIONS:
         --http2-tls-key <http2-tls-key>
             Specify the file path to read the private key [env: SERVER_HTTP2_TLS_KEY=]
 
+        --ignore-hidden-files <ignore-hidden-files>
+            Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML
+            index pages (directory listing) [env: SERVER_IGNORE_HIDDEN_FILES=]  [default: false]
     -g, --log-level <log-level>
             Specify a logging level in lower case. Values: error, warn, info, debug or trace [env: SERVER_LOG_LEVEL=]
             [default: error]

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -74,6 +74,9 @@ redirect-trailing-slash = true
 #### Check for existing pre-compressed files
 compression-static = false
 
+#### Ignore hidden files/directories (dotfiles)
+ignore-hidden-files = false
+
 
 ### Windows Only
 

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -87,6 +87,9 @@ It provides [The "Basic" HTTP Authentication Scheme](https://datatracker.ietf.or
 ### SERVER_REDIRECT_TRAILING_SLASH
 Check for a trailing slash in the requested directory URI and redirect permanent (308) to the same path with a trailing slash suffix if it is missing. Default `true` (enabled).
 
+### SERVER_IGNORE_HIDDEN_FILES
+Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing).
+
 ## Windows
 The following options and commands are Windows platform-specific.
 

--- a/docs/content/features/directory-listing.md
+++ b/docs/content/features/directory-listing.md
@@ -23,7 +23,6 @@ However, when the *"redirect trailing slash"* feature is disabled and a director
 
 Note also that in both cases, SWS will append a trailing slash to the entry if is a directory.
 
-
 ## Sorting
 
 Sorting by `Name`, `Last modified` and `Size` is enabled as clickable columns when the directory listing is activated via the `--directory-listing=true` option.

--- a/docs/content/features/ignore-files.md
+++ b/docs/content/features/ignore-files.md
@@ -1,0 +1,19 @@
+# Ignore files
+
+SWS provides some options to ignore files or directories from being served and displayed if the directory listing is enabled. 
+
+## Ignore hidden files (dotfiles)
+
+SWS doesn't ignore dotfiles (hidden files) by default.
+However, it's possible to ignore those files as shown below. As a result, SWS will respond with a `404 Not Found` status.
+
+This feature is disabled by default and can be controlled by the boolean `--ignore-hidden-files` option or the equivalent [SERVER_IGNORE_HIDDEN_FILES](./../configuration/environment-variables.md#server_ignore_hidden_files) env.
+
+Here is an example of how to ignore hidden files:
+
+```sh
+static-web-server \
+    -p=8787 -d=tests/fixtures/public -g=trace \
+    --directory-listing=true \
+    --ignore-hidden-files true
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
     - 'URL Redirects': 'features/url-redirects.md'
     - 'Windows Service': 'features/windows-service.md'
     - 'Trailing Slash Redirect': 'features/trailing-slash-redirect.md'
+    - 'Ignore Files': 'features/ignore-files.md'
   - 'Platforms & Architectures': 'platforms-architectures.md'
   - 'Migration from v1 to v2': 'migration.md'
   - 'Changelog v2 (latest stable)': 'https://github.com/static-web-server/static-web-server/blob/master/CHANGELOG.md'

--- a/src/exts/mod.rs
+++ b/src/exts/mod.rs
@@ -1,3 +1,4 @@
 //! Some extension traits for various use cases.
 
 pub mod http;
+pub mod path;

--- a/src/exts/path.rs
+++ b/src/exts/path.rs
@@ -1,0 +1,20 @@
+//! Path-related extension traits.
+
+use std::path::{Component, Path};
+
+/// SWS Path extensions trait.
+pub trait PathExt {
+    fn is_hidden(&self) -> bool;
+}
+
+impl PathExt for Path {
+    /// Checks if the current path is hidden (dot file).
+    fn is_hidden(&self) -> bool {
+        self.components()
+            .filter_map(|cmp| match cmp {
+                Component::Normal(s) => s.to_str(),
+                _ => None,
+            })
+            .any(|s| s.starts_with('.'))
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -31,6 +31,7 @@ pub struct RequestHandlerOpts {
     pub basic_auth: String,
     pub log_remote_address: bool,
     pub redirect_trailing_slash: bool,
+    pub ignore_hidden_files: bool,
 
     // Advanced options
     pub advanced_opts: Option<Advanced>,
@@ -61,6 +62,7 @@ impl RequestHandler {
         let log_remote_addr = self.opts.log_remote_address;
         let redirect_trailing_slash = self.opts.redirect_trailing_slash;
         let compression_static = self.opts.compression_static;
+        let ignore_hidden_files = self.opts.ignore_hidden_files;
 
         let mut cors_headers: Option<http::HeaderMap> = None;
 
@@ -198,6 +200,7 @@ impl RequestHandler {
                 dir_listing_format,
                 redirect_trailing_slash,
                 compression_static,
+                ignore_hidden_files,
             })
             .await
             {

--- a/src/server.rs
+++ b/src/server.rs
@@ -183,6 +183,10 @@ impl Server {
             redirect_trailing_slash
         );
 
+        // Ignore hidden files option
+        let ignore_hidden_files = general.ignore_hidden_files;
+        tracing::info!("ignore hidden files: enabled={}", ignore_hidden_files);
+
         // Grace period option
         let grace_period = general.grace_period;
         tracing::info!("grace period before graceful shutdown: {}s", grace_period);
@@ -205,6 +209,7 @@ impl Server {
                 basic_auth,
                 log_remote_address,
                 redirect_trailing_slash,
+                ignore_hidden_files,
                 advanced_opts,
             }),
         });

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -219,6 +219,15 @@ pub struct General {
     /// Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path with a trailing slash suffix if it is missing.
     pub redirect_trailing_slash: bool,
 
+    #[structopt(
+        long,
+        parse(try_from_str),
+        default_value = "false",
+        env = "SERVER_IGNORE_HIDDEN_FILES"
+    )]
+    /// Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing).
+    pub ignore_hidden_files: bool,
+
     //
     // Windows specific arguments and commands
     //

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -136,6 +136,8 @@ pub struct General {
 
     pub redirect_trailing_slash: Option<bool>,
 
+    pub ignore_hidden_files: Option<bool>,
+
     #[cfg(windows)]
     pub windows_service: Option<bool>,
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -87,6 +87,7 @@ impl Settings {
         let mut page_fallback = opts.page_fallback;
         let mut log_remote_address = opts.log_remote_address;
         let mut redirect_trailing_slash = opts.redirect_trailing_slash;
+        let mut ignore_hidden_files = opts.ignore_hidden_files;
 
         // Windows-only options
         #[cfg(windows)]
@@ -189,6 +190,9 @@ impl Settings {
                     }
                     if let Some(v) = general.redirect_trailing_slash {
                         redirect_trailing_slash = v
+                    }
+                    if let Some(v) = general.ignore_hidden_files {
+                        ignore_hidden_files = v
                     }
 
                     // Windows-only options
@@ -320,6 +324,7 @@ impl Settings {
                 page_fallback,
                 log_remote_address,
                 redirect_trailing_slash,
+                ignore_hidden_files,
 
                 // Windows-only options and commands
                 #[cfg(windows)]

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -43,6 +43,7 @@ mod tests {
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: true,
+            ignore_hidden_files: false,
         })
         .await
         .expect("unexpected error response on `handle` function");
@@ -96,6 +97,7 @@ mod tests {
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: true,
+            ignore_hidden_files: false,
         })
         .await
         .expect("unexpected error response on `handle` function");

--- a/tests/fixtures/public/.dotfile
+++ b/tests/fixtures/public/.dotfile
@@ -1,0 +1,1 @@
+dotfile!

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -34,6 +34,7 @@ mod tests {
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
+            ignore_hidden_files: false,
         })
         .await
         .expect("unexpected error response on `handle` function");
@@ -75,6 +76,7 @@ mod tests {
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
+            ignore_hidden_files: false,
         })
         .await
         .expect("unexpected error response on `handle` function");
@@ -117,6 +119,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -143,6 +146,7 @@ mod tests {
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
+            ignore_hidden_files: false,
         })
         .await
         .expect("unexpected error response on `handle` function");
@@ -170,6 +174,7 @@ mod tests {
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
+            ignore_hidden_files: false,
         })
         .await
         {
@@ -196,6 +201,7 @@ mod tests {
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: false,
             compression_static: false,
+            ignore_hidden_files: false,
         })
         .await
         {
@@ -227,6 +233,7 @@ mod tests {
                     dir_listing_format: &DirListFmt::Html,
                     redirect_trailing_slash: true,
                     compression_static: false,
+                    ignore_hidden_files: false,
                 })
                 .await
                 {
@@ -273,6 +280,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -301,6 +309,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -332,6 +341,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -363,6 +373,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -397,6 +408,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -429,6 +441,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -459,6 +472,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -488,6 +502,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -531,6 +546,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -591,6 +607,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -654,6 +671,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -697,6 +715,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -740,6 +759,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -784,6 +804,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -820,6 +841,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -866,6 +888,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -909,6 +932,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -955,6 +979,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -999,6 +1024,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -1038,6 +1064,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -1088,6 +1115,7 @@ mod tests {
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
+                ignore_hidden_files: false,
             })
             .await
             {
@@ -1108,6 +1136,37 @@ mod tests {
                 }
                 Err(_) => {
                     panic!("expected a normal response rather than a status error")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_ignore_hidden_files() {
+        let root_dir = PathBuf::from("tests/fixtures/public/");
+        let headers = HeaderMap::new();
+
+        for method in [Method::HEAD, Method::GET] {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &headers,
+                base_path: &root_dir,
+                uri_path: ".dotfile",
+                uri_query: None,
+                dir_listing: false,
+                dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Html,
+                redirect_trailing_slash: true,
+                compression_static: true,
+                ignore_hidden_files: true,
+            })
+            .await
+            {
+                Ok(_) => {
+                    panic!("expected a status error 404 but not status 200")
+                }
+                Err(status) => {
+                    assert_eq!(status, StatusCode::NOT_FOUND);
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR adds the ability to ignore Unix hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing) via a new boolean `--ignore-hidden-files` option.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
