### PR TITLE
Fix crash at "/" with static compression when base_path is "."

### DIFF
--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -31,20 +31,22 @@ pub async fn precompressed_variant(
     // Try to find the pre-compressed metadata variant for the given file path
     if let Some(ext) = precomp_ext {
         let mut filepath_precomp = file_path;
-        let filename = filepath_precomp.file_name().unwrap().to_str().unwrap();
-        let precomp_file_name = [filename, ".", ext].concat();
-        filepath_precomp.set_file_name(precomp_file_name);
+        if let Some(filename) = filepath_precomp.file_name() {
+            let filename = filename.to_str().unwrap();
+            let precomp_file_name = [filename, ".", ext].concat();
+            filepath_precomp.set_file_name(precomp_file_name);
 
-        tracing::trace!(
-            "getting metadata for pre-compressed file variant {}",
-            filepath_precomp.display()
-        );
+            tracing::trace!(
+                "getting metadata for pre-compressed file variant {}",
+                filepath_precomp.display()
+            );
 
-        if let Ok((meta, _)) = file_metadata(&filepath_precomp) {
-            tracing::trace!("pre-compressed file variant found, serving it directly");
+            if let Ok((meta, _)) = file_metadata(&filepath_precomp) {
+                tracing::trace!("pre-compressed file variant found, serving it directly");
 
-            let encoding = if ext == "gz" { "gzip" } else { ext };
-            precompressed = Some((filepath_precomp, meta, encoding));
+                let encoding = if ext == "gz" { "gzip" } else { ext };
+                precompressed = Some((filepath_precomp, meta, encoding));
+            }
         }
 
         // Note: In error case like "no such file or dir" the workflow just continues

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -126,4 +126,31 @@ mod tests {
             "body and index_gz_buf are not equal in length"
         );
     }
+
+    #[tokio::test]
+    async fn compression_static_base_path_as_dot() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br".parse().unwrap(),
+        );
+
+        let base_path = PathBuf::from(".");
+
+        let (_resp, _) = static_files::handle(&HandleOpts {
+            method: &Method::GET,
+            headers: &headers,
+            base_path: &base_path,
+            uri_path: "/",
+            uri_query: None,
+            dir_listing: true,
+            dir_listing_order: 6,
+            dir_listing_format: &DirListFmt::Html,
+            redirect_trailing_slash: true,
+            compression_static: true,
+            ignore_hidden_files: false,
+        })
+        .await
+        .expect("unexpected error response on `handle` function");
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove one `unwrap()` from `compression_static.rs` that was causing the server to crash.

## Related Issue
Fix #165

## Motivation and Context
This is needed because [`file_name()`](https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name) returns None if path is "."

## How Has This Been Tested?
A test was created for this change. And run `cargo test`

## Screenshots (if appropriate):
