### PR TITLE
Minor optimizations and small improvements

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -9,6 +9,7 @@ use hyper::{
     header::{HeaderValue, CONTENT_ENCODING, CONTENT_LENGTH},
     Body, Method, Response,
 };
+use mime_guess::Mime;
 use pin_project::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -70,8 +71,8 @@ pub fn auto(
     if let Some(encoding) = get_prefered_encoding(headers) {
         // Skip compression for non-text-based MIME types
         if let Some(content_type) = resp.headers().typed_get::<ContentType>() {
-            let content_type = &content_type.to_string();
-            if !TEXT_MIME_TYPES.iter().any(|h| *h == content_type) {
+            let mime = Mime::from(content_type);
+            if !TEXT_MIME_TYPES.iter().any(|h| *h == mime) {
                 return Ok(resp);
             }
         }

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -1,5 +1,6 @@
 use headers::{ContentCoding, HeaderMap, HeaderValue};
 use std::{
+    ffi::OsStr,
     fs::Metadata,
     path::{Path, PathBuf},
 };
@@ -33,11 +34,10 @@ pub async fn precompressed_variant<'a>(
 
     // Try to find the pre-compressed metadata variant for the given file path
     if let Some(ext) = precomp_ext {
-        let mut filepath_precomp = file_path.to_owned();
-        if let Some(filename) = filepath_precomp.file_name() {
-            let filename = filename.to_str().unwrap();
+        let filename = file_path.file_name().and_then(OsStr::to_str);
+        if let Some(filename) = filename {
             let precomp_file_name = [filename, ".", ext].concat();
-            filepath_precomp.set_file_name(precomp_file_name);
+            let filepath_precomp = file_path.with_file_name(precomp_file_name);
 
             tracing::trace!(
                 "getting metadata for pre-compressed file variant {}",

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -1,13 +1,16 @@
 use headers::{ContentCoding, HeaderMap, HeaderValue};
-use std::{fs::Metadata, path::PathBuf};
+use std::{
+    fs::Metadata,
+    path::{Path, PathBuf},
+};
 
 use crate::{compression, static_files::file_metadata};
 
 /// Search for the pre-compressed variant of the given file path.
-pub async fn precompressed_variant(
-    file_path: PathBuf,
-    headers: &HeaderMap<HeaderValue>,
-) -> Option<(PathBuf, Metadata, &str)> {
+pub async fn precompressed_variant<'a>(
+    file_path: &Path,
+    headers: &'a HeaderMap<HeaderValue>,
+) -> Option<(PathBuf, Metadata, &'a str)> {
     let mut precompressed = None;
 
     tracing::trace!(
@@ -30,7 +33,7 @@ pub async fn precompressed_variant(
 
     // Try to find the pre-compressed metadata variant for the given file path
     if let Some(ext) = precomp_ext {
-        let mut filepath_precomp = file_path;
+        let mut filepath_precomp = file_path.to_owned();
         if let Some(filename) = filepath_precomp.file_name() {
             let filename = filename.to_str().unwrap();
             let precomp_file_name = [filename, ".", ext].concat();

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -151,7 +151,7 @@ async fn composed_file_metadata<'a>(
     if compression_static {
         tried_precompressed = true;
         if let Some((path, meta, ext)) =
-            compression_static::precompressed_variant(file_path.clone(), headers).await
+            compression_static::precompressed_variant(file_path, headers).await
         {
             return Ok((file_path, meta, false, Some((path, ext))));
         }
@@ -179,7 +179,7 @@ async fn composed_file_metadata<'a>(
             // Second pre-compressed variant check for the given file path
             if compression_static && !tried_precompressed {
                 if let Some((path, meta, ext)) =
-                    compression_static::precompressed_variant(file_path.clone(), headers).await
+                    compression_static::precompressed_variant(file_path, headers).await
                 {
                     return Ok((file_path, meta, false, Some((path, ext))));
                 }
@@ -219,7 +219,7 @@ fn file_reply<'a>(
 ) -> impl Future<Output = Result<Response<Body>, StatusCode>> + Send + 'a {
     let conditionals = get_conditional_headers(headers);
 
-    let file_path = path_precompressed.unwrap_or_else(|| path.clone());
+    let file_path = path_precompressed.as_ref().unwrap_or(path);
 
     match File::open(file_path) {
         Ok(file) => Either::Left(response_body(file, path, meta, conditionals)),

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -18,7 +18,6 @@ use std::io::{self, BufReader, Read, Seek, SeekFrom};
 use std::ops::Bound;
 use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
-use std::sync::Mutex;
 use std::task::{Context, Poll};
 
 use crate::directory_listing::DirListFmt;
@@ -367,23 +366,15 @@ const READ_BUF_SIZE: usize = 8_192;
 
 #[derive(Debug)]
 pub struct FileStream<T> {
-    reader: Mutex<T>,
+    reader: T,
 }
 
-impl<T: Read> Stream for FileStream<T> {
+impl<T: Read + Unpin> Stream for FileStream<T> {
     type Item = Result<Bytes>;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut reader = match self.reader.lock() {
-            Ok(reader) => reader,
-            Err(err) => {
-                tracing::error!("file stream error: {:?}", err);
-                return Poll::Ready(Some(Err(anyhow::anyhow!("failed to read stream file"))));
-            }
-        };
-
         let mut buf = BytesMut::zeroed(READ_BUF_SIZE);
-        match reader.read(&mut buf[..]) {
+        match Pin::into_inner(self).reader.read(&mut buf[..]) {
             Ok(n) => {
                 if n == 0 {
                     Poll::Ready(None)
@@ -420,7 +411,7 @@ async fn response_body(
                     };
 
                     let sub_len = end - start;
-                    let reader = Mutex::new(BufReader::new(file).take(sub_len));
+                    let reader = BufReader::new(file).take(sub_len);
                     let stream = FileStream { reader };
 
                     let body = Body::wrap_stream(stream);


### PR DESCRIPTION
## Description
This fixes the minor improvements brought up in #176. Namely:
* The mutex in `FileStream` is unnecessary.
* Some `PathBuf`s are being cloned unnecessarily.
* A `Mime` is being converted into a `String` when its `AsRef<str>` implementation does the trick.

## Related Issue
Closes #176

## Motivation and Context
There were no noticeable performance improvements but it's good to avoid these things (clones and mutexes) at least for the sake of code simplicity.

## How Has This Been Tested?
`cargo test` and tested in a browser.
