### PR TITLE
Add support for .html suffixing when the path doesn't exist

### DIFF
--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -201,6 +201,9 @@ async fn composed_file_metadata<'a>(
                     if let Some(new_meta) = new_meta {
                         meta = new_meta;
                         is_dir = false;
+                    } else {
+                        // We do it to preserve previous behavior
+                        file_path.push("index.html");
                     }
                 }
             }

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -183,7 +183,7 @@ async fn composed_file_metadata<'a>(
     tracing::trace!("getting metadata for file {}", file_path.display());
 
     match file_metadata(file_path.as_ref()) {
-        Ok((mut meta, mut is_dir)) => {
+        Ok((mut meta, is_dir)) => {
             if is_dir {
                 // Append a HTML index page by default if it's a directory path (`autoindex`)
                 tracing::debug!("dir: appending an index.html to the directory path");
@@ -200,9 +200,8 @@ async fn composed_file_metadata<'a>(
                     (file_path, new_meta) = prefix_file_html_metadata(file_path);
                     if let Some(new_meta) = new_meta {
                         meta = new_meta;
-                        is_dir = false;
                     } else {
-                        // We do it to preserve previous behavior
+                        // We append the index.html to preserve previous behavior
                         file_path.push("index.html");
                     }
                 }

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -141,9 +141,7 @@ pub async fn handle<'a>(opts: &HandleOpts<'a>) -> Result<(Response<Body>, bool),
 /// Returns the result of trying to append `.html` to the file path.
 /// * If the prefixed html path exists, it mutates the path to the prefixed one and returns the Metadata
 /// * If the prefixed html path doesn't exist, it reverts the path to it's original value
-fn prefix_file_html_metadata<'a>(
-    file_path: &'a mut PathBuf,
-) -> (&'a mut PathBuf, Option<Metadata>) {
+fn prefix_file_html_metadata(file_path: &mut PathBuf) -> (&mut PathBuf, Option<Metadata>) {
     tracing::debug!("file: appending .html to the path");
     if let Some(filename) = file_path.file_name() {
         let owned_filename = filename.to_os_string();


### PR DESCRIPTION
This PR fixes the issue #179.

I tried to implement in multiple ways and places, but this resulted the cleaner one