### PR TITLE
Make signals optional for non-unix or non-windows systems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod security_headers;
 pub mod server;
 pub mod service;
 pub mod settings;
+#[cfg(any(unix, windows))]
 pub mod signals;
 pub mod static_files;
 pub mod tls;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -18,7 +18,7 @@ pub fn init(log_level: &str) -> Result {
 fn configure(level: &str) -> Result {
     let level = level.parse::<Level>()?;
 
-    #[cfg(unix)]
+    #[cfg(not(windows))]
     let enable_ansi = true;
     #[cfg(windows)]
     let enable_ansi = false;

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,8 +6,10 @@ use std::sync::Arc;
 use tokio::sync::oneshot::Receiver;
 
 use crate::handler::{RequestHandler, RequestHandlerOpts};
+#[cfg(any(unix, windows))]
+use crate::signals;
 use crate::tls::{TlsAcceptor, TlsConfigBuilder};
-use crate::{cors, helpers, logger, signals, Settings};
+use crate::{cors, helpers, logger, Settings};
 use crate::{service::RouterService, Context, Result};
 
 /// Define a multi-thread HTTP or HTTP/2 web server.


### PR DESCRIPTION
This PR makes static-web-server compile in systems without signals.

Fixes #184 