### PR TITLE
Check missing auto index for directory requests when `compression-static` is enabled

### DIFF
--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -44,7 +44,14 @@ pub async fn precompressed_variant<'a>(
                 filepath_precomp.display()
             );
 
-            if let Ok((meta, _)) = file_metadata(&filepath_precomp) {
+            if let Ok((meta, is_dir)) = file_metadata(&filepath_precomp) {
+                if is_dir {
+                    tracing::trace!(
+                        "pre-compressed file variant found but it's a directory, skipping"
+                    );
+                    return None;
+                }
+
                 tracing::trace!("pre-compressed file variant found, serving it directly");
 
                 let encoding = if ext == "gz" { "gzip" } else { ext };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR checks auto-index (`index.html` auto-appended) for directory requests when the `compression-static` is enabled. Since previously the code was missing that check and was going directly to look up the pre-compressed variant.

Additionally, It prevents trying to serve a pre-compressed file variant if the file found was a directory (a folder named as a file).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #178

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Server Setup**

```sh
$ static-web-server -w config.toml
```

config.toml

```toml
[general]
host = "::"
port = 8787
root = "docker/public/"
log-level = "trace"
compression = false
compression-static = true
```

**Client Request**

```sh
$ curl -I -H "accept-encoding: gzip, deflate, br" http://localhost:8787/assets/
```

**Server Logs**

Before:

```log
2023-03-05T21:28:48.625650Z DEBUG hyper::proto::h1::conn: incoming body is empty
2023-03-05T21:28:48.625756Z  INFO static_web_server::handler: incoming request: method=HEAD uri=/assets
2023-03-05T21:28:48.625882Z TRACE static_web_server::static_files: dir: base="docker/public/", route="assets"
2023-03-05T21:28:48.625907Z TRACE static_web_server::compression_static: preparing pre-compressed file path variant of docker/public/assets
2023-03-05T21:28:48.626201Z TRACE static_web_server::compression_static: getting metadata for pre-compressed file variant docker/public/assets.gz
2023-03-05T21:28:48.626247Z DEBUG static_web_server::static_files: file not found: "docker/public/assets.gz" Os { code: 2, kind: NotFound, message: "No such file or directory" }
2023-03-05T21:28:48.626272Z TRACE static_web_server::static_files: getting metadata for file docker/public/assets
2023-03-05T21:28:48.626300Z TRACE static_web_server::static_files: file found: "docker/public/assets"
2023-03-05T21:28:48.626314Z DEBUG static_web_server::static_files: dir: appending an index.html to the directory path
2023-03-05T21:28:48.626339Z TRACE static_web_server::static_files: file found: "docker/public/assets/index.html"
2023-03-05T21:28:48.626412Z TRACE static_web_server::static_files: uri doesn't end with a slash so redirecting permanently
2023-03-05T21:28:48.626504Z TRACE encode_headers: hyper::proto::h1::role: Server::encode status=308, body=None, req_method=Some(HEAD)
2023-03-05T21:28:48.626618Z TRACE encode_headers: hyper::proto::h1::role: server body forced to 0; method=Some(HEAD), status=308
2023-03-05T21:28:48.626649Z TRACE encode_headers: hyper::proto::h1::role: close time.busy=144µs time.idle=6.46µs
2023-03-05T21:28:48.626702Z DEBUG hyper::proto::h1::io: flushed 130 bytes
```

After:

```log
2023-03-05T21:27:09.946550Z DEBUG hyper::proto::h1::conn: incoming body is empty
2023-03-05T21:27:09.946674Z  INFO static_web_server::handler: incoming request: method=HEAD uri=/assets
2023-03-05T21:27:09.946799Z TRACE static_web_server::static_files: dir: base="docker/public/", route="assets"
2023-03-05T21:27:09.946821Z TRACE static_web_server::static_files: getting metadata for file docker/public/assets
2023-03-05T21:27:09.946867Z TRACE static_web_server::static_files: file found: "docker/public/assets"
2023-03-05T21:27:09.946888Z DEBUG static_web_server::static_files: dir: appending an index.html to the directory path
2023-03-05T21:27:09.946902Z TRACE static_web_server::compression_static: preparing pre-compressed file path variant of docker/public/assets/index.html
2023-03-05T21:27:09.947179Z TRACE static_web_server::compression_static: getting metadata for pre-compressed file variant docker/public/assets/index.html.gz
2023-03-05T21:27:09.948409Z TRACE static_web_server::static_files: file found: "docker/public/assets/index.html.gz"
2023-03-05T21:27:09.948430Z TRACE static_web_server::compression_static: pre-compressed file variant found, serving it directly
2023-03-05T21:27:09.948873Z TRACE encode_headers: hyper::proto::h1::role: Server::encode status=200, body=Some(Unknown), req_method=Some(HEAD)
2023-03-05T21:27:09.949017Z TRACE encode_headers: hyper::proto::h1::role: server body forced to 0; method=Some(HEAD), status=200
2023-03-05T21:27:09.949053Z TRACE encode_headers: hyper::proto::h1::role: close time.busy=179µs time.idle=7.92µs
2023-03-05T21:27:09.949088Z TRACE hyper::proto::h1::dispatch: no more write body allowed, user body is_end_stream = false
2023-03-05T21:27:09.949142Z DEBUG hyper::proto::h1::io: flushed 211 bytes
```

## Screenshots (if appropriate):
No