### PR TITLE
`zstd` auto-compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -171,6 +173,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -443,8 +448,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 [[package]]
 name = "headers-accept-encoding"
 version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450f8482d4d4ec4db6d82d0e8ce6c3cd5421dd469bc0104e43c635c11a645314"
+source = "git+https://github.com/static-web-server/headers-accept-encoding.git?branch=headers_encoding#8c9e99e0ac5640507071cb51e4a94a0cb7e8a04d"
 dependencies = [
  "base64 0.13.1",
  "bitflags",
@@ -618,6 +622,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -839,6 +852,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro-error"
@@ -1700,3 +1719,33 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,8 +447,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "headers-accept-encoding"
-version = "0.3.8"
-source = "git+https://github.com/static-web-server/headers-accept-encoding.git?branch=headers_encoding#8c9e99e0ac5640507071cb51e4a94a0cb7e8a04d"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31dd148a6d59ca552b4b30a018188701f588c0d398da9e280a455775e450d69"
 dependencies = [
  "base64 0.13.1",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,13 @@ http2 = ["tls"]
 
 [dependencies]
 anyhow = "1.0"
-async-compression = { version = "0.3", default-features = false, features = ["brotli", "deflate", "gzip", "tokio"] }
+async-compression = { version = "0.3", default-features = false, features = ["brotli", "deflate", "gzip", "zstd", "tokio"] }
 bcrypt = "0.14"
 bytes = "1.4"
 form_urlencoded = "1.1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 globset = { version = "0.4", features = ["serde1"] }
-headers = { package = "headers-accept-encoding", version = "0.3" }
+headers = { package = "headers-accept-encoding", version = "0.3", git = "https://github.com/static-web-server/headers-accept-encoding.git", branch = "headers_encoding" }
 http = "0.2"
 http-serde = "1.1"
 humansize = { version = "2.1", features = ["impl_style"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ bytes = "1.4"
 form_urlencoded = "1.1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 globset = { version = "0.4", features = ["serde1"] }
-headers = { package = "headers-accept-encoding", version = "0.3", git = "https://github.com/static-web-server/headers-accept-encoding.git", branch = "headers_encoding" }
+headers = { package = "headers-accept-encoding", version = "1.0" }
 http = "0.2"
 http-serde = "1.1"
 humansize = { version = "2.1", features = ["impl_style"] }

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -36,6 +36,8 @@ pub async fn precompressed_variant<'a>(
         Some(ContentCoding::GZIP | ContentCoding::DEFLATE) => "gz",
         // https://peazip.github.io/brotli-compressed-file-format.html
         Some(ContentCoding::BROTLI) => "br",
+        // https://datatracker.ietf.org/doc/html/rfc8878
+        Some(ContentCoding::ZSTD) => "zst",
         _ => {
             tracing::trace!(
                 "preferred encoding based on the file extension was not determined, skipping"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR provides support for on-the-fly auto-compression using a `content-encoding` called `zstd` (Zstandard).
The auto-compression is determined by `accept-encoding` header similar to gzip, brotli.

It also adds support for pre-compressed files to be served in zstd format. E.g `file.zst`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #193

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Server**

```sh
# Note that auto-compression is enabled by default
static-web-server -p 8787 -d ./public -g trace
```

**Logs**

```log
2023-04-19T22:20:26.065667Z TRACE mio::poll: registering event source with poller: token=Token(3), interests=READABLE | WRITABLE
2023-04-19T22:20:26.066586Z TRACE hyper::proto::h1::conn: Conn::read_head
2023-04-19T22:20:26.066691Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Busy }
2023-04-19T22:20:26.066984Z TRACE hyper::proto::h1::conn: Conn::read_head
2023-04-19T22:20:26.067028Z TRACE hyper::proto::h1::io: received 111 bytes
2023-04-19T22:20:26.067184Z TRACE parse_headers: hyper::proto::h1::role: Request.parse bytes=111
2023-04-19T22:20:26.067279Z TRACE parse_headers: hyper::proto::h1::role: Request.parse Complete(111)
2023-04-19T22:20:26.067593Z TRACE parse_headers: hyper::proto::h1::role: close time.busy=425µs time.idle=19.2µs
2023-04-19T22:20:26.067636Z DEBUG hyper::proto::h1::io: parsed 4 headers
2023-04-19T22:20:26.067651Z DEBUG hyper::proto::h1::conn: incoming body is empty
2023-04-19T22:20:26.067696Z  INFO static_web_server::handler: incoming request: method=GET uri=/logo.svg
2023-04-19T22:20:26.067905Z TRACE static_web_server::static_files: dir: base="/public/", route="logo.svg"
2023-04-19T22:20:26.067961Z TRACE static_web_server::static_files: getting metadata for file /public/logo.svg
2023-04-19T22:20:26.068067Z TRACE static_web_server::static_files: file found: "/public/logo.svg"
2023-04-19T22:20:26.068564Z TRACE static_web_server::compression: compressing response body on the fly using zstd
2023-04-19T22:20:26.068777Z TRACE encode_headers: hyper::proto::h1::role: Server::encode status=200, body=Some(Unknown), req_method=Some(GET)
2023-04-19T22:20:26.068868Z TRACE encode_headers: hyper::proto::h1::role: close time.busy=89.8µs time.idle=7.71µs
2023-04-19T22:20:26.075314Z TRACE hyper::proto::h1::encode: encoding chunked 4096B
2023-04-19T22:20:26.075345Z TRACE hyper::proto::h1::io: buffer.queue self.len=266 buf.len=4104
2023-04-19T22:20:26.075408Z TRACE hyper::proto::h1::encode: encoding chunked 4096B
2023-04-19T22:20:26.075414Z TRACE hyper::proto::h1::io: buffer.queue self.len=4370 buf.len=4104
2023-04-19T22:20:26.075423Z TRACE hyper::proto::h1::encode: encoding chunked 4096B
2023-04-19T22:20:26.075427Z TRACE hyper::proto::h1::io: buffer.queue self.len=8474 buf.len=4104
2023-04-19T22:20:26.075437Z TRACE hyper::proto::h1::encode: encoding chunked 4096B
2023-04-19T22:20:26.075442Z TRACE hyper::proto::h1::io: buffer.queue self.len=12578 buf.len=4104
2023-04-19T22:20:26.075450Z TRACE hyper::proto::h1::encode: encoding chunked 4096B
2023-04-19T22:20:26.075454Z TRACE hyper::proto::h1::io: buffer.queue self.len=16682 buf.len=4104
2023-04-19T22:20:26.075463Z TRACE hyper::proto::h1::encode: encoding chunked 4096B
2023-04-19T22:20:26.075468Z TRACE hyper::proto::h1::io: buffer.queue self.len=20786 buf.len=4104
2023-04-19T22:20:26.075476Z TRACE hyper::proto::h1::encode: encoding chunked 3163B
2023-04-19T22:20:26.075480Z TRACE hyper::proto::h1::io: buffer.queue self.len=24890 buf.len=3170
2023-04-19T22:20:26.075538Z TRACE hyper::proto::h1::io: buffer.queue self.len=28060 buf.len=5
2023-04-19T22:20:26.075601Z DEBUG hyper::proto::h1::io: flushed 28065 bytes
2023-04-19T22:20:26.075607Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Init, writing: Init, keep_alive: Idle }
2023-04-19T22:20:26.077148Z TRACE hyper::proto::h1::conn: Conn::read_head
2023-04-19T22:20:26.077161Z TRACE hyper::proto::h1::io: received 0 bytes
2023-04-19T22:20:26.077168Z TRACE hyper::proto::h1::io: parse eof
2023-04-19T22:20:26.077189Z TRACE hyper::proto::h1::conn: State::close_read()
2023-04-19T22:20:26.077194Z DEBUG hyper::proto::h1::conn: read eof
2023-04-19T22:20:26.077198Z TRACE hyper::proto::h1::conn: State::close_write()
2023-04-19T22:20:26.077203Z TRACE hyper::proto::h1::conn: State::close_read()
2023-04-19T22:20:26.077207Z TRACE hyper::proto::h1::conn: State::close_write()
2023-04-19T22:20:26.077212Z TRACE hyper::proto::h1::conn: flushed({role=server}): State { reading: Closed, writing: Closed, keep_alive: Disabled }
2023-04-19T22:20:26.077224Z TRACE hyper::proto::h1::conn: shut down IO complete
2023-04-19T22:20:26.077235Z TRACE mio::poll: deregistering event source from poller
```

**Client request**

```sh
# Note the `accept-encoding` and `content-encoding` headers below
docker run --rm joseluisq/alpine-curl \
    curl -s -i -H "accept-encoding: zstd" --compressed http://192.168.1.3:8787/logo.svg

# HTTP/1.1 200 OK
# vary: accept-encoding
# content-type: image/svg+xml
# accept-ranges: bytes
# last-modified: Sun, 19 Mar 2023 00:19:48 GMT
# content-encoding: zstd
# cache-control: public, max-age=86400
# transfer-encoding: chunked
# date: Wed, 19 Apr 2023 22:09:53 GMT

# <?xml version="1.0" encoding="UTF-8" standalone="no"?>
# <svg...
```

## Screenshots (if appropriate):
