### PR TITLE
Update alpine to 3.17.3

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:3.16.5 as build
+FROM --platform=$BUILDPLATFORM alpine:3.17.3 as build
 
 ARG TARGETPLATFORM
 ARG SERVER_VERSION=0.0.0
@@ -20,7 +20,7 @@ RUN set -ex; \
     rm -rf /tmp/static-web-server.tar.gz static-web-server-v${SERVER_VERSION}-${target}; \
     chmod +x /usr/local/bin/static-web-server
 
-FROM alpine:3.16.5
+FROM alpine:3.17.3
 
 ARG SERVER_VERSION=0.0.0
 ENV SERVER_VERSION=${SERVER_VERSION}

--- a/docker/devel/Dockerfile.alpine
+++ b/docker/devel/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.16.5
+FROM alpine:3.17.3
 
 ENV SERVER_VERSION=devel
 


### PR DESCRIPTION
The main purpose of this PR is to update the base alpine image from `3.16.5` to `3.17.3`

https://www.alpinelinux.org/posts/Alpine-3.17.3-released.html