### PR TITLE
Cargo feature for compression and compression static 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,20 @@ path = "src/bin/server.rs"
 doc = false
 
 [features]
-default = ["http2"]
+default = ["compression", "http2"]
+# HTTP2
 tls = ["tokio-rustls"]
 http2 = ["tls"]
+# Compression
+compression = ["compression-brotli", "compression-deflate", "compression-gzip", "compression-zstd"]
+compression-brotli = ["async-compression/brotli"]
+compression-deflate = ["async-compression/deflate"]
+compression-gzip = ["async-compression/deflate"]
+compression-zstd = ["async-compression/zstd"]
 
 [dependencies]
 anyhow = "1.0"
-async-compression = { version = "0.3", default-features = false, features = ["brotli", "deflate", "gzip", "zstd", "tokio"] }
+async-compression = { version = "0.3", default-features = false, optional = true, features = ["brotli", "deflate", "gzip", "zstd", "tokio"] }
 bcrypt = "0.14"
 bytes = "1.4"
 form_urlencoded = "1.1"

--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -21,22 +21,41 @@ Finally, the release binary should be available at `target/release/static-web-se
 !!! info "Don't use the project's `Makefile`"
     Please don't use the project's `Makefile` since it's only intended for development and some on-demand tasks.
 
+## Cargo features
+
+When building from the source, all features are enabled by default.
+However, you can disable just the ones you don't need from the lists below.
+
+Feature | Description
+---------|------
+**Deafult** |
+`default` | Activates all features by default.
+[**HTTP2/TLS**](./features/http2-tls.md) |
+`http2` | Activates the HTTP2 and TLS feature.
+`tls` | Activates only the TLS feature.
+[**Compression**](./features/compression.md) |
+`compression` | Activates auto-compression and compression static with all supported algorithms.
+`compression-brotli` | Activates auto-compression/compression static with only the `brotli` algorithm.
+`compression-deflate` | Activates auto-compression/compression static with only the `deflate` algorithm.
+`compression-gzip` | Activates auto-compression/compression static with only the `gzip` algorithm.
+`compression-zstd` | Activates auto-compression/compression static with only the `zstd` algorithm.
+
+### Disable all default features
+
+For example, if you want to run or build SWS without the default features like `compression`, `http2`, etc then just try:
+
+```sh
+# run
+cargo run --no-default-features -- -h
+# or build
+cargo build --release --no-default-features
+```
+
 ## Building documentation from source
 
 All HTML documentation is located in the `docs/` project's directory and is built using [Material for MkDocs](https://github.com/squidfunk/mkdocs-material).
 
 It's only necessary to have [Docker](https://www.docker.com/get-started/) installed.
-
-## Cargo features
-
-Some features are optional when running or building from the source.
-For example, if you want to run without the default features like `http2` just try.
-
-```sh
-cargo run --no-default-features -- -h
-```
-
-For more optional features take a look a the `[features]` section of the `cargo.toml` file adjusting them on demand.
 
 ### Building documentation
 

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -38,10 +38,13 @@ pub async fn precompressed_variant<'a>(
     // Determine prefered-encoding extension if available
     let comp_ext = match compression::get_prefered_encoding(headers) {
         // https://zlib.net/zlib_faq.html#faq39
+        #[cfg(feature = "compression-gzip")]
         Some(ContentCoding::GZIP | ContentCoding::DEFLATE) => "gz",
         // https://peazip.github.io/brotli-compressed-file-format.html
+        #[cfg(feature = "compression-brotli")]
         Some(ContentCoding::BROTLI) => "br",
         // https://datatracker.ietf.org/doc/html/rfc8878
+        #[cfg(feature = "compression-zstd")]
         Some(ContentCoding::ZSTD) => "zst",
         _ => {
             tracing::trace!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,9 @@ extern crate serde;
 
 // Public modules
 pub mod basic_auth;
+#[cfg(feature = "compression")]
 pub mod compression;
+#[cfg(feature = "compression")]
 pub mod compression_static;
 pub mod control_headers;
 pub mod cors;

--- a/src/server.rs
+++ b/src/server.rs
@@ -166,11 +166,19 @@ impl Server {
         tracing::info!("security headers: enabled={}", security_headers);
 
         // Auto compression based on the `Accept-Encoding` header
+        #[cfg(not(feature = "compression"))]
+        let compression = false;
+        #[cfg(feature = "compression")]
         let compression = general.compression;
+        #[cfg(feature = "compression")]
         tracing::info!("auto compression: enabled={}", compression);
 
         // Check pre-compressed files based on the `Accept-Encoding` header
+        #[cfg(not(feature = "compression"))]
+        let compression_static = false;
+        #[cfg(feature = "compression")]
         let compression_static = general.compression_static;
+        #[cfg(feature = "compression")]
         tracing::info!("compression static: enabled={}", compression_static);
 
         // Directory listing option

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -157,6 +157,7 @@ pub struct General {
     /// Specify the file path to read the private key.
     pub http2_tls_key: Option<PathBuf>,
 
+    #[cfg(feature = "compression")]
     #[structopt(
         long,
         short = "x",
@@ -164,16 +165,17 @@ pub struct General {
         default_value = "true",
         env = "SERVER_COMPRESSION"
     )]
-    /// Gzip, Deflate or Brotli compression on demand determined by the Accept-Encoding header and applied to text-based web file types only.
+    /// Gzip, Deflate, Brotli or Zstd compression on demand determined by the Accept-Encoding header and applied to text-based web file types only.
     pub compression: bool,
 
+    #[cfg(feature = "compression")]
     #[structopt(
         long,
         parse(try_from_str),
         default_value = "false",
         env = "SERVER_COMPRESSION_STATIC"
     )]
-    /// Look up the pre-compressed file variant (`.gz` or `.br`) on disk of a requested file and serves it directly if available.
+    /// Look up the pre-compressed file variant (`.gz`, `.br` or `.zst`) on disk of a requested file and serves it directly if available.
     /// The compression type is determined by the `Accept-Encoding` header.
     pub compression_static: bool,
 

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -117,9 +117,11 @@ pub struct General {
     pub cache_control_headers: Option<bool>,
 
     /// Compression.
+    #[cfg(feature = "compression")]
     pub compression: Option<bool>,
 
     /// Check for a pre-compressed file on disk.
+    #[cfg(feature = "compression")]
     pub compression_static: Option<bool>,
 
     /// Error 404 pages.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -77,8 +77,12 @@ impl Settings {
         let mut log_level = opts.log_level;
         let mut config_file = opts.config_file.clone();
         let mut cache_control_headers = opts.cache_control_headers;
+
+        #[cfg(feature = "compression")]
         let mut compression = opts.compression;
+        #[cfg(feature = "compression")]
         let mut compression_static = opts.compression_static;
+
         let mut page404 = opts.page404;
         let mut page50x = opts.page50x;
         #[cfg(feature = "http2")]
@@ -143,9 +147,11 @@ impl Settings {
                     if let Some(v) = general.cache_control_headers {
                         cache_control_headers = v
                     }
+                    #[cfg(feature = "compression")]
                     if let Some(v) = general.compression {
                         compression = v
                     }
+                    #[cfg(feature = "compression")]
                     if let Some(v) = general.compression_static {
                         compression_static = v
                     }
@@ -324,7 +330,9 @@ impl Settings {
                 log_level,
                 config_file,
                 cache_control_headers,
+                #[cfg(feature = "compression")]
                 compression,
+                #[cfg(feature = "compression")]
                 compression_static,
                 page404,
                 page50x,

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
+#[cfg(feature = "compression")]
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
@@ -42,6 +43,7 @@ mod tests {
             dir_listing_order: 6,
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
+            #[cfg(feature = "compression")]
             compression_static: true,
             ignore_hidden_files: false,
         })
@@ -96,6 +98,7 @@ mod tests {
             dir_listing_order: 6,
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
+            #[cfg(feature = "compression")]
             compression_static: true,
             ignore_hidden_files: false,
         })
@@ -147,6 +150,7 @@ mod tests {
             dir_listing_order: 6,
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
+            #[cfg(feature = "compression")]
             compression_static: true,
             ignore_hidden_files: false,
         })

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -11,8 +11,10 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    #[cfg(feature = "compression")]
+    use static_web_server::compression;
+
     use static_web_server::{
-        compression,
         directory_listing::DirListFmt,
         static_files::{self, HandleOpts},
     };
@@ -575,9 +577,10 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "compression")]
     #[tokio::test]
     async fn handle_file_compressions() {
-        let encodings = ["gzip", "deflate", "br", "xyz"];
+        let encodings = ["gzip", "deflate", "br", "zstd", "xyz"];
         let method = &Method::GET;
 
         for enc in encodings {
@@ -612,7 +615,7 @@ mod tests {
 
                     match enc {
                         // The handle only accepts `HEAD` or `GET` request methods
-                        "gzip" | "deflate" | "br" => {
+                        "gzip" | "deflate" | "br" | "zstd" => {
                             assert!(res.headers().get("content-length").is_none());
                             assert_eq!(res.headers()["content-encoding"], enc);
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR adds a `compression` Cargo feature with four variants (`compression-brotli`, `compression-deflate`, `compression-gzip`, and `compression-zstd`) in order to allow library users to turn on/off compression algorithms on demand.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Have more control over compression algorithms when building `static-web-server`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
