### PR TITLE
Fix security headers not enabled by default issue when using config file

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -197,8 +197,13 @@ impl Settings {
                     if let Some(v) = general.https_redirect_from_hosts {
                         https_redirect_from_hosts = v
                     }
-                    if let Some(v) = general.security_headers {
-                        security_headers = v
+                    match general.security_headers {
+                        Some(v) => security_headers = v,
+                        _ => {
+                            if http2 {
+                                security_headers = true;
+                            }
+                        }
                     }
                     if let Some(ref v) = general.cors_allow_origins {
                         cors_allow_origins = v.to_owned()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR fixes an issue about `security-headers` not being enabled by default via `config.toml` if `http2` is also enabled.
Note also that when `security-headers` is explicitly defined then it will take precedence over the  `http2`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #210

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
