### PR TITLE
Fix regression when using empty values for `--page-fallback` or `SERVER_FALLBACK_PAGE`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -154,7 +154,18 @@ impl Server {
         let page50x = helpers::read_bytes_default(&general.page50x);
 
         // Fallback page content
-        let page_fallback = helpers::read_bytes_default(&general.page_fallback.unwrap_or_default());
+        let page_fallback_pbuf = general.page_fallback;
+        let page_fallback = helpers::read_bytes_default(&page_fallback_pbuf);
+        let page_fallback_enabled = !page_fallback.is_empty();
+        let mut page_fallback_opt = "";
+        if page_fallback_enabled {
+            page_fallback_opt = page_fallback_pbuf.to_str().unwrap()
+        }
+        tracing::info!(
+            "fallback page: enabled={}, value=\"{}\"",
+            page_fallback_enabled,
+            page_fallback_opt
+        );
 
         // Number of worker threads option
         let threads = self.worker_threads;

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -8,7 +8,7 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use crate::directory_listing::DirListFmt;
+use crate::{directory_listing::DirListFmt, Result};
 
 /// General server configuration available in CLI and config file options.
 #[derive(Parser, Debug)]
@@ -102,9 +102,9 @@ pub struct General {
     /// HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
     pub page404: PathBuf,
 
-    #[arg(long, env = "SERVER_FALLBACK_PAGE")]
+    #[arg(long, default_value = "", value_parser = value_parser_pathbuf, env = "SERVER_FALLBACK_PAGE")]
     /// HTML file path that is used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path is not specified or simply doesn't exist then this feature will not be active.
-    pub page_fallback: Option<PathBuf>,
+    pub page_fallback: PathBuf,
 
     #[arg(long, short = 'g', default_value = "error", env = "SERVER_LOG_LEVEL")]
     /// Specify a logging level in lower case. Values: error, warn, info, debug or trace
@@ -391,4 +391,8 @@ pub enum Commands {
     /// Uninstall the current Windows Service.
     #[command(name = "uninstall")]
     Uninstall {},
+}
+
+fn value_parser_pathbuf(s: &str) -> Result<PathBuf, String> {
+    Ok(PathBuf::from(s))
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -239,7 +239,7 @@ impl Settings {
                         grace_period = v
                     }
                     if let Some(v) = general.page_fallback {
-                        page_fallback = Some(v)
+                        page_fallback = v
                     }
                     if let Some(v) = general.log_remote_address {
                         log_remote_address = v


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a regression when using empty values for `--page-fallback` or `SERVER_FALLBACK_PAGE`

```
error: a value is required for '--page-fallback <PAGE_FALLBACK>' but none was supplied
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #218 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Provide `--page-fallback=""` or its `SERVER_FALLBACK_PAGE=` using empty values and run the server:
```
static-web-server -p 8787 -d docker/public/ -g trace -x -z --page-fallback=""
```

Then you will see the following logs (expected):

```log
2023-06-08T20:34:13.806318Z  INFO static_web_server::logger: logging level: trace
2023-06-08T20:34:13.806540Z DEBUG static_web_server::server: initializing tokio runtime with multi thread scheduler self.worker_threads=8
2023-06-08T20:34:13.808290Z TRACE static_web_server::server: starting web server
2023-06-08T20:34:13.808557Z  INFO static_web_server::server: server bound to tcp socket [::]:8787
2023-06-08T20:34:13.808795Z  INFO static_web_server::server: fallback page: enabled=false, value=""
```

## Screenshots (if appropriate):
