### PR TITLE
Cargo feature for directory listing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ path = "src/bin/server.rs"
 doc = false
 
 [features]
-default = ["compression", "http2"]
+# All features enabled by default
+default = ["compression", "http2", "directory-listing"]
 # HTTP2
 http2 = ["tokio-rustls", "rustls-pemfile"]
 # Compression
@@ -47,6 +48,8 @@ compression-brotli = ["async-compression/brotli"]
 compression-deflate = ["async-compression/deflate"]
 compression-gzip = ["async-compression/deflate"]
 compression-zstd = ["async-compression/zstd"]
+# Directory listing
+directory-listing = ["humansize", "chrono"]
 
 [dependencies]
 anyhow = "1.0"
@@ -59,7 +62,7 @@ globset = { version = "0.4", features = ["serde1"] }
 headers = { package = "headers-accept-encoding", version = "1.0" }
 http = "0.2"
 http-serde = "1.1"
-humansize = { version = "2.1", features = ["impl_style"] }
+humansize = { version = "2.1", features = ["impl_style"], optional = true }
 hyper = { version = "0.14", features = ["stream", "http1", "http2", "tcp", "server"] }
 listenfd = "1.0"
 mime_guess = "2.0"
@@ -71,7 +74,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
 serde_repr = "0.1"
 clap = { version = "4.3", features = ["derive", "env"] }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"] }
 tokio-rustls = { version = "0.24", optional = true }
 tokio-util = { version = "0.7", default-features = false, features = ["io"] }

--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -38,6 +38,8 @@ Feature | Description
 `compression-deflate` | Activates auto-compression/compression static with only the `deflate` algorithm.
 `compression-gzip` | Activates auto-compression/compression static with only the `gzip` algorithm.
 `compression-zstd` | Activates auto-compression/compression static with only the `zstd` algorithm.
+[**Directory Listing**](./features/directory-listing.md) |
+`directory-listing` | Activates the directory listing feature.
 
 ### Disable all default features
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -14,15 +14,16 @@ use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc
 use crate::compression;
 
 use crate::{
-    basic_auth, control_headers, cors, custom_headers,
-    directory_listing::DirListFmt,
-    error_page,
+    basic_auth, control_headers, cors, custom_headers, error_page,
     exts::http::MethodExt,
     fallback_page, redirects, rewrites, security_headers,
     settings::Advanced,
     static_files::{self, HandleOpts},
     Error, Result,
 };
+
+#[cfg(feature = "directory-listing")]
+use crate::directory_listing::DirListFmt;
 
 /// It defines options for a request handler.
 pub struct RequestHandlerOpts {
@@ -34,9 +35,12 @@ pub struct RequestHandlerOpts {
     /// Compression static feature.
     pub compression_static: bool,
     /// Directory listing feature.
+    #[cfg(feature = "directory-listing")]
     pub dir_listing: bool,
     /// Directory listing order feature.
+    #[cfg(feature = "directory-listing")]
     pub dir_listing_order: u8,
+    #[cfg(feature = "directory-listing")]
     /// Directory listing format feature.
     pub dir_listing_format: DirListFmt,
     /// CORS feature.
@@ -84,8 +88,11 @@ impl RequestHandler {
         let base_path = &self.opts.root_dir;
         let mut uri_path = uri.path();
         let uri_query = uri.query();
+        #[cfg(feature = "directory-listing")]
         let dir_listing = self.opts.dir_listing;
+        #[cfg(feature = "directory-listing")]
         let dir_listing_order = self.opts.dir_listing_order;
+        #[cfg(feature = "directory-listing")]
         let dir_listing_format = &self.opts.dir_listing_format;
         let log_remote_addr = self.opts.log_remote_address;
         let redirect_trailing_slash = self.opts.redirect_trailing_slash;
@@ -223,8 +230,11 @@ impl RequestHandler {
                 base_path,
                 uri_path,
                 uri_query,
+                #[cfg(feature = "directory-listing")]
                 dir_listing,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format,
                 redirect_trailing_slash,
                 compression_static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@
 //! `compression-deflate` | Activates auto-compression/compression static with only the `deflate` algorithm.
 //! `compression-gzip` | Activates auto-compression/compression static with only the `gzip` algorithm.
 //! `compression-zstd` | Activates auto-compression/compression static with only the `zstd` algorithm.
+//! [**Directory Listing**](https://static-web-server.net/features/directory-listing/) |
+//! `directory-listing` | Activates the directory listing feature.
 //!
 
 #![deny(missing_docs)]
@@ -110,6 +112,8 @@ pub mod compression_static;
 pub mod control_headers;
 pub mod cors;
 pub mod custom_headers;
+#[cfg(feature = "directory-listing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "directory-listing")))]
 pub mod directory_listing;
 pub mod error_page;
 pub mod exts;

--- a/src/server.rs
+++ b/src/server.rs
@@ -197,16 +197,20 @@ impl Server {
         #[cfg(feature = "compression")]
         tracing::info!("compression static: enabled={}", compression_static);
 
-        // Directory listing option
+        // Directory listing options
+        #[cfg(feature = "directory-listing")]
         let dir_listing = general.directory_listing;
+        #[cfg(feature = "directory-listing")]
         tracing::info!("directory listing: enabled={}", dir_listing);
-
         // Directory listing order number
+        #[cfg(feature = "directory-listing")]
         let dir_listing_order = general.directory_listing_order;
+        #[cfg(feature = "directory-listing")]
         tracing::info!("directory listing order code: {}", dir_listing_order);
-
         // Directory listing format
+        #[cfg(feature = "directory-listing")]
         let dir_listing_format = general.directory_listing_format;
+        #[cfg(feature = "directory-listing")]
         tracing::info!("directory listing format: {:?}", dir_listing_format);
 
         // Cache control headers option
@@ -252,8 +256,11 @@ impl Server {
                 root_dir,
                 compression,
                 compression_static,
+                #[cfg(feature = "directory-listing")]
                 dir_listing,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format,
                 cors,
                 security_headers,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -8,7 +8,10 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use crate::{directory_listing::DirListFmt, Result};
+use crate::Result;
+
+#[cfg(feature = "directory-listing")]
+use crate::directory_listing::DirListFmt;
 
 /// General server configuration available in CLI and config file options.
 #[derive(Parser, Debug)]
@@ -241,6 +244,8 @@ pub struct General {
     /// The compression type is determined by the `Accept-Encoding` header.
     pub compression_static: bool,
 
+    #[cfg(feature = "directory-listing")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing")))]
     #[arg(
         long,
         short = 'z',
@@ -254,6 +259,8 @@ pub struct General {
     /// Enable directory listing for all requests ending with the slash character (‘/’).
     pub directory_listing: bool,
 
+    #[cfg(feature = "directory-listing")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing")))]
     #[arg(
         long,
         requires_if("true", "directory_listing"),
@@ -263,6 +270,8 @@ pub struct General {
     /// Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size` attributes (columns). Code numbers supported: 0 (Name asc), 1 (Name desc), 2 (Last modified asc), 3 (Last modified desc), 4 (Size asc), 5 (Size desc). Default 6 (unordered)
     pub directory_listing_order: u8,
 
+    #[cfg(feature = "directory-listing")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing")))]
     #[arg(
         long,
         value_enum,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -11,7 +11,9 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::path::Path;
 use std::{collections::BTreeSet, path::PathBuf};
 
+#[cfg(feature = "directory-listing")]
 use crate::directory_listing::DirListFmt;
+
 use crate::{helpers, Context, Result};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -165,10 +167,13 @@ pub struct General {
     pub cors_expose_headers: Option<String>,
 
     /// Directory listing feature.
+    #[cfg(feature = "directory-listing")]
     pub directory_listing: Option<bool>,
     /// Directory listing order feature.
+    #[cfg(feature = "directory-listing")]
     pub directory_listing_order: Option<u8>,
     /// Directory listing format feature.
+    #[cfg(feature = "directory-listing")]
     pub directory_listing_format: Option<DirListFmt>,
 
     /// Basich Authentication feature.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -85,6 +85,7 @@ impl Settings {
 
         let mut page404 = opts.page404;
         let mut page50x = opts.page50x;
+
         #[cfg(feature = "http2")]
         let mut http2 = opts.http2;
         #[cfg(feature = "http2")]
@@ -99,13 +100,19 @@ impl Settings {
         let mut https_redirect_from_port = opts.https_redirect_from_port;
         #[cfg(feature = "http2")]
         let mut https_redirect_from_hosts = opts.https_redirect_from_hosts;
+
         let mut security_headers = opts.security_headers;
         let mut cors_allow_origins = opts.cors_allow_origins;
         let mut cors_allow_headers = opts.cors_allow_headers;
         let mut cors_expose_headers = opts.cors_expose_headers;
+
+        #[cfg(feature = "directory-listing")]
         let mut directory_listing = opts.directory_listing;
+        #[cfg(feature = "directory-listing")]
         let mut directory_listing_order = opts.directory_listing_order;
+        #[cfg(feature = "directory-listing")]
         let mut directory_listing_format = opts.directory_listing_format;
+
         let mut basic_auth = opts.basic_auth;
         let mut fd = opts.fd;
         let mut threads_multiplier = opts.threads_multiplier;
@@ -214,12 +221,15 @@ impl Settings {
                     if let Some(ref v) = general.cors_expose_headers {
                         cors_expose_headers = v.to_owned()
                     }
+                    #[cfg(feature = "directory-listing")]
                     if let Some(v) = general.directory_listing {
                         directory_listing = v
                     }
+                    #[cfg(feature = "directory-listing")]
                     if let Some(v) = general.directory_listing_order {
                         directory_listing_order = v
                     }
+                    #[cfg(feature = "directory-listing")]
                     if let Some(v) = general.directory_listing_format {
                         directory_listing_format = v
                     }
@@ -383,8 +393,11 @@ impl Settings {
                 cors_allow_origins,
                 cors_allow_headers,
                 cors_expose_headers,
+                #[cfg(feature = "directory-listing")]
                 directory_listing,
+                #[cfg(feature = "directory-listing")]
                 directory_listing_order,
+                #[cfg(feature = "directory-listing")]
                 directory_listing_format,
                 basic_auth,
                 fd,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -31,7 +31,10 @@ use crate::compression_static;
 
 use crate::exts::http::{MethodExt, HTTP_SUPPORTED_METHODS};
 use crate::exts::path::PathExt;
-use crate::{directory_listing, directory_listing::DirListFmt, Result};
+use crate::Result;
+
+#[cfg(feature = "directory-listing")]
+use crate::{directory_listing, directory_listing::DirListFmt};
 
 /// Defines all options needed by the static-files handler.
 pub struct HandleOpts<'a> {
@@ -46,10 +49,13 @@ pub struct HandleOpts<'a> {
     /// Request URI query.
     pub uri_query: Option<&'a str>,
     /// Directory listing feature.
+    #[cfg(feature = "directory-listing")]
     pub dir_listing: bool,
     /// Directory listing order feature.
+    #[cfg(feature = "directory-listing")]
     pub dir_listing_order: u8,
     /// Directory listing format feature.
+    #[cfg(feature = "directory-listing")]
     pub dir_listing_format: &'a DirListFmt,
     /// Redirect trailing slash feature.
     pub redirect_trailing_slash: bool,
@@ -125,6 +131,7 @@ pub async fn handle<'a>(opts: &HandleOpts<'a>) -> Result<(Response<Body>, bool),
         // Check if "directory listing" feature is enabled,
         // if current path is a valid directory and
         // if it does not contain an `index.html` file (if a proper auto index is generated)
+        #[cfg(feature = "directory-listing")]
         if opts.dir_listing && !file_path.exists() {
             let resp = directory_listing::auto_index(
                 method,

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -11,10 +11,9 @@ mod tests {
     use http::Method;
     use std::path::PathBuf;
 
-    use static_web_server::{
-        directory_listing::DirListFmt,
-        static_files::{self, HandleOpts},
-    };
+    #[cfg(feature = "directory-listing")]
+    use static_web_server::directory_listing::DirListFmt;
+    use static_web_server::static_files::{self, HandleOpts};
 
     fn public_dir() -> PathBuf {
         PathBuf::from("docker/public/")
@@ -39,8 +38,11 @@ mod tests {
             base_path: &public_dir(),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "directory-listing")]
             dir_listing: false,
+            #[cfg(feature = "directory-listing")]
             dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             #[cfg(feature = "compression")]
@@ -94,8 +96,11 @@ mod tests {
             base_path: &public_dir().join("assets/"),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "directory-listing")]
             dir_listing: false,
+            #[cfg(feature = "directory-listing")]
             dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             #[cfg(feature = "compression")]
@@ -130,6 +135,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "directory-listing")]
     #[tokio::test]
     async fn compression_static_base_path_as_dot() {
         let mut headers = HeaderMap::new();
@@ -150,7 +156,6 @@ mod tests {
             dir_listing_order: 6,
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
-            #[cfg(feature = "compression")]
             compression_static: true,
             ignore_hidden_files: false,
         })

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
+#[cfg(feature = "directory-listing")]
 #[cfg(test)]
 mod tests {
     use headers::HeaderMap;

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -14,10 +14,9 @@ mod tests {
     #[cfg(feature = "compression")]
     use static_web_server::compression;
 
-    use static_web_server::{
-        directory_listing::DirListFmt,
-        static_files::{self, HandleOpts},
-    };
+    #[cfg(feature = "directory-listing")]
+    use static_web_server::directory_listing::DirListFmt;
+    use static_web_server::static_files::{self, HandleOpts};
 
     fn root_dir() -> PathBuf {
         PathBuf::from("docker/public/")
@@ -31,8 +30,11 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "directory-listing")]
             dir_listing: false,
+            #[cfg(feature = "directory-listing")]
             dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
@@ -69,8 +71,11 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "directory-listing")]
             dir_listing: false,
+            #[cfg(feature = "directory-listing")]
             dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
@@ -108,8 +113,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "xyz.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -135,8 +143,11 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
+            #[cfg(feature = "directory-listing")]
             dir_listing: false,
+            #[cfg(feature = "directory-listing")]
             dir_listing_order: 0,
+            #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
@@ -163,8 +174,11 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
+            #[cfg(feature = "directory-listing")]
             dir_listing: false,
+            #[cfg(feature = "directory-listing")]
             dir_listing_order: 0,
+            #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
             compression_static: false,
@@ -190,8 +204,11 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
+            #[cfg(feature = "directory-listing")]
             dir_listing: false,
+            #[cfg(feature = "directory-listing")]
             dir_listing_order: 0,
+            #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: false,
             compression_static: false,
@@ -222,8 +239,11 @@ mod tests {
                     base_path: &root_dir(),
                     uri_path: uri,
                     uri_query: None,
+                    #[cfg(feature = "directory-listing")]
                     dir_listing: false,
+                    #[cfg(feature = "directory-listing")]
                     dir_listing_order: 6,
+                    #[cfg(feature = "directory-listing")]
                     dir_listing_format: &DirListFmt::Html,
                     redirect_trailing_slash: true,
                     compression_static: false,
@@ -269,8 +289,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "/index%2ehtml",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -298,8 +321,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "/%2E%2e.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -330,8 +356,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -362,8 +391,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -397,8 +429,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -430,8 +465,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -461,8 +499,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -491,8 +532,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -535,8 +579,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -593,8 +640,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -653,8 +703,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -697,8 +750,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -741,8 +797,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -786,8 +845,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -823,8 +885,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -870,8 +935,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -914,8 +982,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -961,8 +1032,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -1006,8 +1080,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -1046,8 +1123,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -1097,8 +1177,11 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: false,
@@ -1140,8 +1223,11 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: ".dotfile",
                 uri_query: None,
+                #[cfg(feature = "directory-listing")]
                 dir_listing: false,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 redirect_trailing_slash: true,
                 compression_static: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a `directory-listing` Cargo feature in order to allow library users to turn on/off this SWS feature on demand.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Have more control over the default features provided when building `static-web-server`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
