### PR TITLE
`basic-auth` Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "directory-listing"]
+default = ["compression", "http2", "directory-listing", "basic-auth"]
 # HTTP2
 http2 = ["tokio-rustls", "rustls-pemfile"]
 # Compression
@@ -50,11 +50,13 @@ compression-gzip = ["async-compression/deflate"]
 compression-zstd = ["async-compression/zstd"]
 # Directory listing
 directory-listing = ["humansize", "chrono"]
+# Basic HTTP Authorization
+basic-auth = ["bcrypt"]
 
 [dependencies]
 anyhow = "1.0"
 async-compression = { version = "0.3", default-features = false, optional = true, features = ["brotli", "deflate", "gzip", "zstd", "tokio"] }
-bcrypt = "0.14"
+bcrypt = { version = "0.14", optional = true }
 bytes = "1.4"
 form_urlencoded = "1.1"
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }

--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -40,6 +40,8 @@ Feature | Description
 `compression-zstd` | Activates auto-compression/compression static with only the `zstd` algorithm.
 [**Directory Listing**](./features/directory-listing.md) |
 `directory-listing` | Activates the directory listing feature.
+[**Basic Authorization**](./features/basic-authentication.md) |
+`basic-auth` | Activates the Basic HTTP Authorization Schema feature.
 
 ### Disable all default features
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -7,14 +7,17 @@
 //!
 
 use headers::HeaderValue;
-use hyper::{header::WWW_AUTHENTICATE, Body, Request, Response, StatusCode};
+use hyper::{Body, Request, Response, StatusCode};
 use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc};
 
 #[cfg(feature = "compression")]
 use crate::compression;
 
+#[cfg(feature = "basic-auth")]
+use {crate::basic_auth, hyper::header::WWW_AUTHENTICATE};
+
 use crate::{
-    basic_auth, control_headers, cors, custom_headers, error_page,
+    control_headers, cors, custom_headers, error_page,
     exts::http::MethodExt,
     fallback_page, redirects, rewrites, security_headers,
     settings::Advanced,
@@ -56,6 +59,7 @@ pub struct RequestHandlerOpts {
     /// Page fallback feature.
     pub page_fallback: Vec<u8>,
     /// Basic auth feature.
+    #[cfg(feature = "basic-auth")]
     pub basic_auth: String,
     /// Log remote address feature.
     pub log_remote_address: bool,
@@ -156,6 +160,7 @@ impl RequestHandler {
                 };
             }
 
+            #[cfg(feature = "basic-auth")]
             // `Basic` HTTP Authorization Schema
             if !self.opts.basic_auth.is_empty() {
                 if let Some((user_id, password)) = self.opts.basic_auth.split_once(':') {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,8 @@
 //! `compression-zstd` | Activates auto-compression/compression static with only the `zstd` algorithm.
 //! [**Directory Listing**](https://static-web-server.net/features/directory-listing/) |
 //! `directory-listing` | Activates the directory listing feature.
+//! [**Basic Authorization**](./features/basic-authentication.md) |
+//! `basic-auth` | Activates the Basic HTTP Authorization Schema feature.
 //!
 
 #![deny(missing_docs)]
@@ -102,6 +104,8 @@ extern crate anyhow;
 extern crate serde;
 
 // Public modules
+#[cfg(feature = "basic-auth")]
+#[cfg_attr(docsrs, doc(cfg(feature = "basic-auth")))]
 pub mod basic_auth;
 #[cfg(feature = "compression")]
 #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -223,8 +223,10 @@ impl Server {
             general.cors_expose_headers.trim(),
         );
 
+        #[cfg(feature = "basic-auth")]
         // `Basic` HTTP Authentication Schema option
         let basic_auth = general.basic_auth.trim().to_owned();
+        #[cfg(feature = "basic-auth")]
         tracing::info!(
             "basic authentication: enabled={}",
             !general.basic_auth.is_empty()
@@ -267,6 +269,7 @@ impl Server {
                 page404: page404.clone(),
                 page50x: page50x.clone(),
                 page_fallback,
+                #[cfg(feature = "basic-auth")]
                 basic_auth,
                 log_remote_address,
                 redirect_trailing_slash,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -329,6 +329,7 @@ pub struct General {
     /// Enable cache control headers for incoming requests based on a set of file types. The file type list can be found on `src/control_headers.rs` file.
     pub cache_control_headers: bool,
 
+    #[cfg(feature = "basic-auth")]
     /// It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function.
     #[arg(long, default_value = "", env = "SERVER_BASIC_AUTH")]
     pub basic_auth: String,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -113,7 +113,9 @@ impl Settings {
         #[cfg(feature = "directory-listing")]
         let mut directory_listing_format = opts.directory_listing_format;
 
+        #[cfg(feature = "basic-auth")]
         let mut basic_auth = opts.basic_auth;
+
         let mut fd = opts.fd;
         let mut threads_multiplier = opts.threads_multiplier;
         let mut max_blocking_threads = opts.max_blocking_threads;
@@ -238,6 +240,7 @@ impl Settings {
                     if let Some(v) = general.directory_listing_format {
                         directory_listing_format = v
                     }
+                    #[cfg(feature = "basic-auth")]
                     if let Some(ref v) = general.basic_auth {
                         basic_auth = v.to_owned()
                     }
@@ -404,6 +407,7 @@ impl Settings {
                 directory_listing_order,
                 #[cfg(feature = "directory-listing")]
                 directory_listing_format,
+                #[cfg(feature = "basic-auth")]
                 basic_auth,
                 fd,
                 threads_multiplier,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds an `basic-auth` Cargo feature in order to allow library users to turn on/off that SWS feature on demand.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Have more control over the default features provided when building `static-web-server`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
