### PR TITLE
`fallback-page` Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "directory-listing", "basic-auth"]
+default = ["compression", "http2", "directory-listing", "basic-auth", "fallback-page"]
 # HTTP2
 http2 = ["tokio-rustls", "rustls-pemfile"]
 # Compression
@@ -52,6 +52,8 @@ compression-zstd = ["async-compression/zstd"]
 directory-listing = ["humansize", "chrono"]
 # Basic HTTP Authorization
 basic-auth = ["bcrypt"]
+# Fallback Page
+fallback-page = []
 
 [dependencies]
 anyhow = "1.0"

--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -42,6 +42,8 @@ Feature | Description
 `directory-listing` | Activates the directory listing feature.
 [**Basic Authorization**](./features/basic-authentication.md) |
 `basic-auth` | Activates the Basic HTTP Authorization Schema feature.
+[**Fallback Page**](./features/error-pages.md#fallback-page-for-use-with-client-routers) |
+`fallback-page` | Activates the Fallback Page feature.
 
 ### Disable all default features
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@
 //! `directory-listing` | Activates the directory listing feature.
 //! [**Basic Authorization**](./features/basic-authentication.md) |
 //! `basic-auth` | Activates the Basic HTTP Authorization Schema feature.
+//! [**Fallback Page**](./features/error-pages.md#fallback-page-for-use-with-client-routers) |
+//! `fallback-page` | Activates the Fallback Page feature.
 //!
 
 #![deny(missing_docs)]
@@ -121,6 +123,8 @@ pub mod custom_headers;
 pub mod directory_listing;
 pub mod error_page;
 pub mod exts;
+#[cfg(feature = "fallback-page")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]
 pub mod fallback_page;
 pub mod handler;
 #[cfg(feature = "http2")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -152,19 +152,25 @@ impl Server {
         let page404 = helpers::read_bytes_default(&general.page404);
         let page50x = helpers::read_bytes_default(&general.page50x);
 
-        // Fallback page content
+        // Fallback page option
+        #[cfg(feature = "fallback-page")]
         let page_fallback_pbuf = general.page_fallback;
+        #[cfg(feature = "fallback-page")]
         let page_fallback = helpers::read_bytes_default(&page_fallback_pbuf);
-        let page_fallback_enabled = !page_fallback.is_empty();
-        let mut page_fallback_opt = "";
-        if page_fallback_enabled {
-            page_fallback_opt = page_fallback_pbuf.to_str().unwrap()
+        #[cfg(feature = "fallback-page")]
+        {
+            let page_fallback_enabled = !page_fallback.is_empty();
+            let mut page_fallback_opt = "";
+            if page_fallback_enabled {
+                page_fallback_opt = page_fallback_pbuf.to_str().unwrap()
+            }
+
+            tracing::info!(
+                "fallback page: enabled={}, value=\"{}\"",
+                page_fallback_enabled,
+                page_fallback_opt
+            );
         }
-        tracing::info!(
-            "fallback page: enabled={}, value=\"{}\"",
-            page_fallback_enabled,
-            page_fallback_opt
-        );
 
         // Number of worker threads option
         let threads = self.worker_threads;
@@ -268,6 +274,7 @@ impl Server {
                 cache_control_headers,
                 page404: page404.clone(),
                 page50x: page50x.clone(),
+                #[cfg(feature = "fallback-page")]
                 page_fallback,
                 #[cfg(feature = "basic-auth")]
                 basic_auth,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -8,8 +8,6 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use crate::Result;
-
 #[cfg(feature = "directory-listing")]
 use crate::directory_listing::DirListFmt;
 
@@ -117,6 +115,8 @@ pub struct General {
     /// HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
     pub page404: PathBuf,
 
+    #[cfg(feature = "fallback-page")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]
     #[arg(long, default_value = "", value_parser = value_parser_pathbuf, env = "SERVER_FALLBACK_PAGE")]
     /// HTML file path that is used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path is not specified or simply doesn't exist then this feature will not be active.
     pub page_fallback: PathBuf,
@@ -415,6 +415,7 @@ pub enum Commands {
     Uninstall {},
 }
 
-fn value_parser_pathbuf(s: &str) -> Result<PathBuf, String> {
+#[cfg(feature = "fallback-page")]
+fn value_parser_pathbuf(s: &str) -> crate::Result<PathBuf, String> {
     Ok(PathBuf::from(s))
 }

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -192,6 +192,8 @@ pub struct General {
     pub grace_period: Option<u8>,
 
     /// Page fallback feature.
+    #[cfg(feature = "fallback-page")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]
     pub page_fallback: Option<PathBuf>,
 
     /// Log remote address feature.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -120,7 +120,10 @@ impl Settings {
         let mut threads_multiplier = opts.threads_multiplier;
         let mut max_blocking_threads = opts.max_blocking_threads;
         let mut grace_period = opts.grace_period;
+
+        #[cfg(feature = "fallback-page")]
         let mut page_fallback = opts.page_fallback;
+
         let mut log_remote_address = opts.log_remote_address;
         let mut redirect_trailing_slash = opts.redirect_trailing_slash;
         let mut ignore_hidden_files = opts.ignore_hidden_files;
@@ -256,6 +259,7 @@ impl Settings {
                     if let Some(v) = general.grace_period {
                         grace_period = v
                     }
+                    #[cfg(feature = "fallback-page")]
                     if let Some(v) = general.page_fallback {
                         page_fallback = v
                     }
@@ -413,6 +417,7 @@ impl Settings {
                 threads_multiplier,
                 max_blocking_threads,
                 grace_period,
+                #[cfg(feature = "fallback-page")]
                 page_fallback,
                 log_remote_address,
                 redirect_trailing_slash,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a `fallback-page` Cargo feature in order to allow library users to turn on/off that SWS feature on demand.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Have more control over the default features provided when building `static-web-server`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
