### PR TITLE
Optional `redirect` for URL Rewrites feature

### DIFF
--- a/docs/content/features/url-rewrites.md
+++ b/docs/content/features/url-rewrites.md
@@ -1,6 +1,6 @@
 # URL Rewrites 
 
-**SWS** provides the ability to rewrite request URLs with pattern matching support.
+**SWS** provides the ability to rewrite request URLs with pattern-matching support.
 
 URI rewrites are particularly useful with pattern matching ([globs](https://en.wikipedia.org/wiki/Glob_(programming))), as the server can accept any URL that matches the pattern and let the client-side code decide what to display.
 
@@ -12,6 +12,7 @@ Each table entry should have two key/value pairs:
 
 - One `source` key containing a string _glob pattern_.
 - One `destination` string containing the local file path.
+- Optional `redirect` number containing the HTTP response code.
 
 !!! info "Note"
     The incoming request(s) will reach the `destination` only if the request(s) URI matches the `source` pattern.
@@ -22,7 +23,15 @@ The source is a [Glob pattern](https://en.wikipedia.org/wiki/Glob_(programming))
 
 ### Destination
 
-A local file path which must exist. It has to look something like `/some/directory/file.html`. It is worth noting that the `/` at the beginning indicates the server's root directory.
+A local file path must exist. It has to look something like `/some/directory/file.html`. It is worth noting that the `/` at the beginning indicates the server's root directory.
+
+### Redirect
+
+An optional number that indicates the HTTP response code (redirect).
+The values can be:
+
+- `301` for "Moved Permanently"
+- `302` for "Found" (Temporary Redirect)
 
 ## Examples
 
@@ -38,4 +47,5 @@ destination = "/assets/generic1.png"
 [[advanced.rewrites]]
 source = "**/*.{jpg,jpeg}"
 destination = "/images/generic2.png"
+redirect = 302
 ```

--- a/src/rewrites.rs
+++ b/src/rewrites.rs
@@ -13,12 +13,12 @@ use crate::settings::Rewrites;
 pub fn rewrite_uri_path<'a>(
     uri_path: &'a str,
     rewrites_opts_vec: &'a Option<Vec<Rewrites>>,
-) -> Option<&'a str> {
+) -> Option<&'a Rewrites> {
     if let Some(rewrites_vec) = rewrites_opts_vec {
         for rewrites_entry in rewrites_vec.iter() {
             // Match source glob pattern against request uri path
             if rewrites_entry.source.is_match(uri_path) {
-                return Some(rewrites_entry.destination.as_str());
+                return Some(rewrites_entry);
             }
         }
     }

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -74,7 +74,7 @@ pub struct Redirects {
     pub source: String,
     /// Redirect destination.
     pub destination: String,
-    /// Redirect type.
+    /// Redirect type either 301 (Moved Permanently) or 302 (Found).
     pub kind: RedirectsKind,
 }
 
@@ -86,6 +86,8 @@ pub struct Rewrites {
     pub source: String,
     /// Rewrite destination.
     pub destination: String,
+    /// Optional redirect type either 301 (Moved Permanently) or 302 (Found).
+    pub redirect: Option<RedirectsKind>,
 }
 
 /// Advanced server options only available in configuration file mode.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -21,6 +21,8 @@ pub use cli::Commands;
 
 use cli::General;
 
+use self::file::RedirectsKind;
+
 /// The `headers` file options.
 pub struct Headers {
     /// Source pattern glob matcher
@@ -35,6 +37,8 @@ pub struct Rewrites {
     pub source: GlobMatcher,
     /// A local file that must exist
     pub destination: String,
+    /// Optional redirect type either 301 (Moved Permanently) or 302 (Found).
+    pub redirect: Option<RedirectsKind>,
 }
 
 /// The `Redirects` file options.
@@ -327,6 +331,7 @@ impl Settings {
                                 rewrites_vec.push(Rewrites {
                                     source,
                                     destination: rewrites_entry.destination.to_owned(),
+                                    redirect: rewrites_entry.redirect.to_owned(),
                                 });
                             }
                             Some(rewrites_vec)

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -109,9 +109,10 @@ kind = 302
 ### URL Rewrites
 
 [[advanced.rewrites]]
-source = "**/*.{png,ico,gif}"
+source = "**/*.{png,gif}"
 destination = "/assets/favicon.ico"
+# redirect = 301
 
 [[advanced.rewrites]]
 source = "**/*.{jpg,jpeg}"
-destination = "/images/nomad.png"
+destination = "/assets/favicon.ico"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->
This PR introduces a new `redirect` option for the [URL Rewrites](https://static-web-server.net/features/url-rewrites/) feature via the config file.

The values can be:
- `301` for "Moved Permanently"
- `302` for "Found" (Temporary Redirect)

Example:

```toml
[advanced]

### URL Rewrites

[[advanced.rewrites]]
source = "**/*.{png,ico,gif}"
destination = "/assets/generic1.png"

[[advanced.rewrites]]
source = "**/*.{jpg,jpeg}"
destination = "/images/generic2.png"
# NOTE: it can also be omitted
redirect = 302
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to #228

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
