### PR TITLE
Docker images support for GitHub Container Registry

### DIFF
--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -22,7 +22,9 @@ jobs:
         id: meta_alpine
         uses: docker/metadata-action@v4
         with:
-          images: joseluisq/static-web-server
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
           flavor: |
             latest=false
             suffix=-alpine
@@ -40,11 +42,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
         name: Prepare Docker envs
         shell: bash
         run: |
           echo "SERVER_VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
-          echo "SERVER_DOCKERFILE=./docker/alpine/Dockerfile" >> $GITHUB_ENV
       -
         name: Build and push (alpine)
         uses: docker/build-push-action@v4
@@ -52,7 +60,7 @@ jobs:
           push: true
           context: .
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
-          file: ${{ env.SERVER_DOCKERFILE }}
+          file: ./docker/alpine/Dockerfile
           tags: ${{ steps.meta_alpine.outputs.tags }}
           build-args: |
             SERVER_VERSION=${{ env.SERVER_VERSION }}
@@ -75,7 +83,9 @@ jobs:
         id: meta_debian
         uses: docker/metadata-action@v4
         with:
-          images: joseluisq/static-web-server
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
           flavor: |
             latest=false
             suffix=-debian
@@ -93,11 +103,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
         name: Prepare Docker envs
         shell: bash
         run: |
           echo "SERVER_VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
-          echo "SERVER_DOCKERFILE=./docker/debian/Dockerfile" >> $GITHUB_ENV
       -
         name: Build and push (debian)
         uses: docker/build-push-action@v4
@@ -105,7 +121,7 @@ jobs:
           push: true
           context: .
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
-          file: ${{ env.SERVER_DOCKERFILE }}
+          file: ./docker/debian/Dockerfile
           tags: ${{ steps.meta_debian.outputs.tags }}
           build-args: |
             SERVER_VERSION=${{ env.SERVER_VERSION }}
@@ -127,7 +143,9 @@ jobs:
         id: meta_scratch
         uses: docker/metadata-action@v4
         with:
-          images: joseluisq/static-web-server
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -142,11 +160,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
         name: Prepare Docker envs
         shell: bash
         run: |
           echo "SERVER_VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
-          echo "SERVER_DOCKERFILE=./docker/scratch/Dockerfile" >> $GITHUB_ENV
       -
         name: Build and push (scratch)
         uses: docker/build-push-action@v4
@@ -154,7 +178,7 @@ jobs:
           push: true
           context: .
           platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
-          file: ${{ env.SERVER_DOCKERFILE }}
+          file: ./docker/scratch/Dockerfile
           tags: ${{ steps.meta_scratch.outputs.tags }}
           build-args: |
             SERVER_VERSION=${{ env.SERVER_VERSION }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR adds support for [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) pushing all multi-arch Docker images to `ghcr.io` as part of the project's organization.

The Docker images base name is as follows:

``` 
ghcr.io/static-web-server/static-web-server:<tag-name>
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #225

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
