### PR TITLE
URL Rewrites don't work without replacements 

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -333,11 +333,8 @@ impl Settings {
                                     })?
                                     .compile_matcher();
 
-                                // NOTE: we don’t need Unicode-aware word boundary assertions,
-                                // therefore we use (?-u:\b) instead of (?-u)
-                                // so the former uses an ASCII-only definition of a word character.
-                                // https://docs.rs/regex/latest/regex/#unicode-can-impact-memory-usage-and-search-speed
-                                let pattern = source.glob().regex().replace("(?-u)^", "(?-u:\\b)");
+                                let pattern =
+                                    source.glob().regex().trim_start_matches("(?-u)").to_owned();
                                 tracing::debug!(
                                     "url rewrites glob pattern: {}",
                                     &rewrites_entry.source
@@ -378,11 +375,8 @@ impl Settings {
                                     })?
                                     .compile_matcher();
 
-                                // NOTE: we don’t need Unicode-aware word boundary assertions,
-                                // therefore we use (?-u:\b) instead of (?-u)
-                                // so the former uses an ASCII-only definition of a word character.
-                                // https://docs.rs/regex/latest/regex/#unicode-can-impact-memory-usage-and-search-speed
-                                let pattern = source.glob().regex().replace("(?-u)^", "(?-u:\\b)");
+                                let pattern =
+                                    source.glob().regex().trim_start_matches("(?-u)").to_owned();
                                 tracing::debug!(
                                     "url rewrites glob pattern: {}",
                                     &redirects_entry.source

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -109,10 +109,20 @@ kind = 302
 ### URL Rewrites
 
 [[advanced.rewrites]]
+source = "/image.ico"
+destination = "/assets/favicon.ico"
+# redirect = 301
+
+[[advanced.rewrites]]
+source = "/{picture}.{ico,webp}"
+destination = "/assets/$1.$2"
+# redirect = 301
+
+[[advanced.rewrites]]
 source = "**/{*}.{png,gif}"
 destination = "/assets/$1.$2"
 # redirect = 301
 
 [[advanced.rewrites]]
-source = "**/*.{jpg,jpeg}"
+source = "/abc/**/*.{svg,jxl}"
 destination = "/assets/favicon.ico"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR fixes a regression on v2.20.0 when using URL Rewrites without replacements. 

Now we make sure that those cases below are covered.

```toml
[advanced]

[[advanced.rewrites]]
source = "/image.ico"
destination = "/assets/favicon.ico"
# redirect = 301

[[advanced.rewrites]]
source = "/{picture}.{ico,webp}"
destination = "/assets/$1.$2"
# redirect = 301

[[advanced.rewrites]]
source = "**/{*}.{png,gif}"
destination = "/assets/$1.$2"
# redirect = 301

[[advanced.rewrites]]
source = "/abc/**/*.{svg,jxl}"
destination = "/assets/favicon.ico"

``` 

## Related Issue
Fixes #243

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
