### PR TITLE
Add support for virtual hosting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ docker.image.debian:
 ########## Production tasks ###########
 #######################################
 
-# Compile release binary 
+# Compile release binary
 define build_release =
 	set -e
 	set -u
@@ -196,7 +196,7 @@ define build_release_shrink =
 	echo "Releases size shrinking completed!"
 endef
 
-# Creates release files (tarballs, zipballs) 
+# Creates release files (tarballs, zipballs)
 define build_release_files =
 	set -e
 	set -u

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -143,7 +143,7 @@ So they are equivalent to each other **except** for the `-w, --config-file` opti
 
 The TOML `[advanced]` section is intended for more complex features.
 
-For example [Custom HTTP Headers](../features/custom-http-headers.md) or [Custom URL Redirects](../features/url-redirects.md).
+For example [Custom HTTP Headers](../features/custom-http-headers.md), [Custom URL Redirects](../features/url-redirects.md), [URL Rewrites](../features/url-rewrites.md), or [Virtual Hosting](../features/virtual-hosting.md)
 
 ### Precedence
 

--- a/docs/content/features/virtual-hosting.md
+++ b/docs/content/features/virtual-hosting.md
@@ -1,0 +1,29 @@
+# Virtual Hosting
+
+**SWS** provides rudimentary support for name-based [virtual hosting](https://en.wikipedia.org/wiki/Virtual_hosting#Name-based). This allows you to serve files from different root directories depending on the ["Host" header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/host) of the request, with all other settings staying the same.
+
+!!! warning "All other settings are the same!"
+    Each virtual host has to have all the same settings (aside from `root`). If using TLS, your certificates will have to cover all virtual host names as Subject Alternative Names (SANs). Also, beware of other conflicting settings like redirects and rewrites. If you find yourself needing different settings for different virtual hosts, it is recommended to run multiple instances of SWS.
+
+Virtual hosting can be useful for serving more than one static website from the same SWS instance, if it's not otherwise feasible to run multiple instances of SWS. Browsers will automatically send a `Host` header which matches the hostname in the URL bar, which is how HTTP servers are able to tell which "virtual" host that the client is accessing.
+
+By default, SWS will always serve files from the main `root` directory. If you configure virtual hosting and the "Host" header matches, SWS will instead look for files in an alternate root directory you specify.
+
+## Examples
+
+```toml
+# By default, all requests are served from here
+root = "/var/www/html"
+
+[advanced]
+
+[[advanced.virtual-hosts]]
+# But if the "Host" header matches this...
+host = "sales.example.com"
+# ...then files will be served from here instead
+root = "/var/sales/html"
+
+[[advanced.virtual-hosts]]
+host = "blog.example.com"
+root = "/var/blog/html"
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
     - 'Trailing Slash Redirect': 'features/trailing-slash-redirect.md'
     - 'Ignore Files': 'features/ignore-files.md'
     - 'Health endpoint': 'features/health-endpoint.md'
+    - 'Virtual Hosting': 'features/virtual-hosting.md'
   - 'Platforms & Architectures': 'platforms-architectures.md'
   - 'Migrating from v1 to v2': 'migration.md'
   - 'Changelog v2 (stable)': 'https://github.com/static-web-server/static-web-server/blob/master/CHANGELOG.md'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ pub mod static_files;
 #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
 pub mod tls;
 pub mod transport;
+pub mod virtual_hosts;
 #[cfg(windows)]
 #[cfg_attr(docsrs, doc(cfg(windows)))]
 pub mod winservice;

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -90,6 +90,16 @@ pub struct Rewrites {
     pub redirect: Option<RedirectsKind>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+/// Represents virtual hosts with different root directories
+pub struct VirtualHosts {
+    /// The value to check for in the "Host" header
+    pub host: String,
+    /// The root directory for this virtual host
+    pub root: Option<PathBuf>,
+}
+
 /// Advanced server options only available in configuration file mode.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -100,6 +110,8 @@ pub struct Advanced {
     pub rewrites: Option<Vec<Rewrites>>,
     /// Redirects
     pub redirects: Option<Vec<Redirects>>,
+    /// Name-based virtual hosting
+    pub virtual_hosts: Option<Vec<VirtualHosts>>,
 }
 
 /// General server options available in configuration file mode.

--- a/src/virtual_hosts.rs
+++ b/src/virtual_hosts.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// This file is part of Static Web Server.
+// See https://static-web-server.net/ for more information
+// Copyright (C) 2019-present Jose Quintana <joseluisq.net>
+
+//! Module that allows to rewrite request URLs with pattern matching support.
+//!
+
+use hyper::{header::HOST, HeaderMap};
+use std::path::PathBuf;
+
+use crate::settings::VirtualHosts;
+
+/// It returns different root dir if the "Host" header matches a virtual hostname.
+pub fn get_real_root<'a>(
+    vhosts_vec: &'a Option<Vec<VirtualHosts>>,
+    headers: &HeaderMap,
+) -> Option<&'a PathBuf> {
+    if let Some(vhosts) = vhosts_vec {
+        if let Ok(host_str) = headers.get(HOST)?.to_str() {
+            for vhost in vhosts {
+                if vhost.host == host_str {
+                    return Some(&vhost.root);
+                }
+            }
+        }
+    }
+    None
+}

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -1,0 +1,28 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(dead_code)]
+
+#[cfg(test)]
+mod tests {
+    use static_web_server::settings::file::Settings;
+    use std::path::{Path, PathBuf};
+
+    #[tokio::test]
+    async fn toml_file_parsing() {
+        let config_path = Path::new("tests/toml/config.toml");
+        let settings = Settings::read(config_path).unwrap();
+        let root = settings.general.unwrap().root.unwrap();
+        assert_eq!(root, PathBuf::from("docker/public"));
+
+        let virtual_hosts = settings.advanced.unwrap().virtual_hosts.unwrap();
+        let expected_roots = [PathBuf::from("docker"), PathBuf::from("docker/abc")];
+        for vhost in virtual_hosts {
+            if let Some(other_root) = &vhost.root {
+                assert!(expected_roots.contains(other_root));
+            } else {
+                panic!("Could not determine value of advanced.virtual-hosts.root")
+            }
+        }
+    }
+}

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -126,3 +126,13 @@ destination = "/assets/$1.$2"
 [[advanced.rewrites]]
 source = "/abc/**/*.{svg,jxl}"
 destination = "/assets/favicon.ico"
+
+### Name-based virtual hosting
+
+[[advanced.virtual-hosts]]
+host = "example.com"
+root = "docker"
+
+[[advanced.virtual-hosts]]
+host = "localhost"
+root = "docker/abc"


### PR DESCRIPTION
## Description
This PR adds rudimentary support for virtual hosting. Users can specify a hostname and an alternate root dir, and SWS will serve files from that alternate root dir if the "Host" header matches. All other settings are the same between virtual hosts (seems it would exponentially complicate the code otherwise).

I apologize for any non-idiomatic Rust, I'm learning!

## Related Issue
Resolves #171 

## Motivation and Context
In places like NixOS, it's generally not possible to run more than one instance of a NixOS module on a single computer. Also resource-constrained environments (like my home router) can run SWS, but not two whole instances of SWS.

## How Has This Been Tested?

```
make build
./target/x86_64-unknown-linux-musl/release/static-web-server --config-file tests/toml/newconf.toml --log-level debug

curl localhost:80
# Returns ./docker/public/index.html

curl -H "Host: example.com" localhost:80
# Returns a directory listing of ./docker
```

I do wish I could make a unit test for this. Seems it's difficult to test any code implemented outside of `static_files::handle`, which is where the other advanced features take effect. I'm also a fan of integration tests, apparently people recommend [assert_cmd](https://docs.rs/assert_cmd/latest/assert_cmd/) for that.

## Screenshots (if appropriate):
<img width="1568" alt="Screenshot 2023-08-06 at 11 17 44 PM" src="https://github.com/static-web-server/static-web-server/assets/7581860/3a37386c-842c-4f9e-8250-c3832b45fedb">
