### PR TITLE
Fix missing glob groups capturing for URL Rewrites and Redirects

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -342,8 +342,12 @@ impl Settings {
                                 })?
                                 .compile_matcher();
 
-                            let pattern =
-                                source.glob().regex().trim_start_matches("(?-u)").to_owned();
+                            let pattern = source
+                                .glob()
+                                .regex()
+                                .trim_start_matches("(?-u)")
+                                .replace("?:.*", ".*")
+                                .to_owned();
                             tracing::debug!(
                                 "url rewrites glob pattern: {}",
                                 &rewrites_entry.source
@@ -384,8 +388,12 @@ impl Settings {
                                 })?
                                 .compile_matcher();
 
-                            let pattern =
-                                source.glob().regex().trim_start_matches("(?-u)").to_owned();
+                            let pattern = source
+                                .glob()
+                                .regex()
+                                .trim_start_matches("(?-u)")
+                                .replace("?:.*", ".*")
+                                .to_owned();
                             tracing::debug!(
                                 "url redirects glob pattern: {}",
                                 &redirects_entry.source

--- a/tests/toml/config.toml
+++ b/tests/toml/config.toml
@@ -127,6 +127,10 @@ destination = "/assets/$1.$2"
 source = "/abc/**/*.{svg,jxl}"
 destination = "/assets/favicon.ico"
 
+[[advanced.rewrites]]
+source = "/files/{*}"
+destination = "/$1"
+
 ### Name-based virtual hosting
 
 [[advanced.virtual-hosts]]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR fixes an issue when using glob groups via URL Rewrites and Redirects where those groups were not captured properly leading to 404s. Removing the non-capturing group that appeared during the glob to regex conversion fixes the issue.

The following glob example works now.

```toml
[advanced]

[[advanced.rewrites]]
# note the gob group here
source = "/files/{*}"
destination = "/$1"
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It fixes #264 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Based on the use case shown above.

```sh
curl -i http://localhost/files/assets/main.css
```
Server logs show correct glob groups capturing.

```log
2023-09-19T04:16:37.749255Z DEBUG hyper::proto::h1::io: parsed 3 headers
2023-09-19T04:16:37.749334Z DEBUG hyper::proto::h1::conn: incoming body is empty
2023-09-19T04:16:37.749414Z  INFO static_web_server::handler: incoming request: method=GET uri=/files/assets/main.css
2023-09-19T04:16:37.749536Z DEBUG static_web_server::handler: url rewrites glob pattern: ["$0", "$1"]
2023-09-19T04:16:37.749636Z DEBUG static_web_server::handler: url rewrites regex equivalent: ^/files/(.*)$
2023-09-19T04:16:37.749715Z DEBUG static_web_server::handler: url rewrites glob pattern captures: ["/files/assets/main.css", "assets/main.css"]
2023-09-19T04:16:37.749749Z DEBUG static_web_server::handler: url rewrites glob pattern destination: "/$1"
2023-09-19T04:16:37.750504Z DEBUG static_web_server::handler: url rewrites glob pattern destination replaced: "/assets/main.css"
2023-09-19T04:16:37.750627Z TRACE static_web_server::static_files: dir: base="docker/public", route="assets/main.css"
2023-09-19T04:16:37.750710Z TRACE static_web_server::static_files: getting metadata for file docker/public/assets/main.css
2023-09-19T04:16:37.757360Z TRACE static_web_server::static_files: file found: "docker/public/assets/main.css"
2023-09-19T04:16:37.758406Z TRACE encode_headers: hyper::proto::h1::role: Server::encode status=200, body=Some(Unknown), req_method=Some(GET)
2023-09-19T04:16:37.758546Z TRACE encode_headers: hyper::proto::h1::role: close time.busy=146µs time.idle=19.1µs
```