### PR TITLE
Fix wrong `directory` type for empty files in JSON directory listing 

### DIFF
--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -131,6 +131,7 @@ struct FileEntry {
     name_encoded: String,
     modified: Option<DateTime<Local>>,
     filesize: u64,
+    is_dir: bool,
     uri: Option<String>,
 }
 
@@ -286,11 +287,14 @@ async fn read_dir_entries(
                 None
             }
         };
+        let is_dir = meta.is_dir();
+
         file_entries.push(FileEntry {
             name,
             name_encoded,
             modified,
             filesize,
+            is_dir,
             uri,
         });
     }
@@ -364,8 +368,7 @@ fn json_auto_index(entries: &mut [FileEntry], order_code: u8) -> Result<String> 
     for entry in entries {
         let file_size = &entry.filesize;
         let file_name = &entry.name;
-        let is_empty = *file_size == 0_u64;
-        let file_type = if is_empty { "directory" } else { "file" };
+        let file_type = if entry.is_dir { "directory" } else { "file" };
         let file_modified = &entry.modified;
 
         json.push('{');
@@ -380,7 +383,7 @@ fn json_auto_index(entries: &mut [FileEntry], order_code: u8) -> Result<String> 
         });
         json.push_str(format!("\"mtime\":\"{file_modified_str}\"").as_str());
 
-        if !is_empty {
+        if !entry.is_dir {
             json.push_str(format!(",\"size\":{file_size}").as_str());
         }
         json.push_str("},");


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR fixes a wrong `directory` type entry for empty files when enabling the JSON directory listing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #270

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```sh
static-web-server -p 8787 -d docker/public/ -z --directory-listing-format=json
```

Expected behavior: 

```json
[
  {
    "name": "main.js",
    "type": "file",
    "mtime": "2023-10-02T21:34:41Z",
    "size": 52
  },
  {
    "name": "main.css",
    "type": "file",
    "mtime": "2023-10-02T21:34:41Z",
    "size": 171
  },
  {
    "name": "favicon.ico",
    "type": "file",
    "mtime": "2023-10-02T21:34:41Z",
    "size": 23229
  },
  {
    "name": "empty",
    "type": "file",
    "mtime": "2023-10-11T20:57:03Z",
    "size": 0
  }
]
``` 


## Screenshots (if appropriate):
