### PR TITLE
Auto-config file detection at startup

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -25,7 +25,7 @@ fn main() -> Result {
         if let Some(commands) = opts.general.commands {
             match commands {
                 Commands::Install {} => {
-                    return winservice::install_service(opts.general.config_file);
+                    return winservice::install_service(&opts.general.config_file);
                 }
                 Commands::Uninstall {} => {
                     return winservice::uninstall_service();

--- a/src/server.rs
+++ b/src/server.rs
@@ -109,8 +109,14 @@ impl Server {
         server_info!("log level: {}", general.log_level);
 
         // Config file option
-        if let Some(config_file) = general.config_file {
-            server_info!("config file: {}", config_file.display());
+        let config_file = general.config_file;
+        if config_file.is_file() {
+            server_info!("config file used: {}", config_file.display());
+        } else {
+            tracing::debug!(
+                "config file path not found or not a regular file: {}",
+                config_file.display()
+            );
         }
 
         // Determine TCP listener either file descriptor or TCP socket

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 
 #[cfg(feature = "directory-listing")]
 use crate::directory_listing::DirListFmt;
+use crate::Result;
 
 /// General server configuration available in CLI and config file options.
 #[derive(Parser, Debug)]
@@ -344,9 +345,15 @@ pub struct General {
     /// Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to shut it down gracefully. The maximum value is 255 seconds.
     pub grace_period: u8,
 
-    #[arg(long, short = 'w', env = "SERVER_CONFIG_FILE")]
+    #[arg(
+        long,
+        short = 'w',
+        default_value = "./config.toml",
+        value_parser = value_parser_pathbuf,
+        env = "SERVER_CONFIG_FILE"
+    )]
     /// Server TOML configuration file path.
-    pub config_file: Option<PathBuf>,
+    pub config_file: PathBuf,
 
     #[arg(
         long,
@@ -466,7 +473,7 @@ pub enum Commands {
     Uninstall {},
 }
 
-fn value_parser_pathbuf(s: &str) -> crate::Result<PathBuf, String> {
+fn value_parser_pathbuf(s: &str) -> Result<PathBuf, String> {
     Ok(PathBuf::from(s))
 }
 

--- a/src/winservice.rs
+++ b/src/winservice.rs
@@ -9,7 +9,7 @@
 use std::ffi::OsString;
 use std::thread;
 use std::time::Duration;
-use std::{env, path::PathBuf};
+use std::{env, path::Path};
 
 use windows_service::{
     define_windows_service,
@@ -174,7 +174,7 @@ pub fn run_server_as_service() -> Result {
 }
 
 /// Install a Windows Service for SWS.
-pub fn install_service(config_file: Option<PathBuf>) -> Result {
+pub fn install_service(config_file: &Path) -> Result {
     let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
 
@@ -185,11 +185,9 @@ pub fn install_service(config_file: Option<PathBuf>) -> Result {
     let mut service_binary_arguments = vec![OsString::from("--windows-service=true")];
 
     // Append a `--config-file` path to the binary arguments if present
-    if let Some(f) = config_file {
-        let f = helpers::adjust_canonicalization(&f);
-        if !f.is_empty() {
-            service_binary_arguments.push(OsString::from(["--config-file=", &f].concat()));
-        }
+    let f = helpers::adjust_canonicalization(config_file);
+    if !f.is_empty() {
+        service_binary_arguments.push(OsString::from(["--config-file=", &f].concat()));
     }
 
     // Run the current service as `System` type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR provides TOML config file detection at startup time using a new default `./config.toml` value. 
It makes sure to check this file path and load it if found. Otherwise, the behavior continues as usual.

So it's not mandatory to provide a flag or env variable explicitly if the default file path is wanted.

Also, additional logging, debug information and file validations are provided.

```sh
  -w, --config-file <CONFIG_FILE>
          Server TOML configuration file path [env: SERVER_CONFIG_FILE=] [default: ./config.toml]
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Discussion #277

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
