### PR TITLE
Improve server maintenance mode logging

### DIFF
--- a/docs/content/features/maintenance-mode.md
+++ b/docs/content/features/maintenance-mode.md
@@ -25,6 +25,9 @@ The value should be an existing local HTML file path. When not provided a generi
 !!! tip "Optional"
     Remember that either `--maintenance-mode-status` and `--maintenance-mode-file` are optional and can be omitted as needed.
 
+!!! info "Independent path"
+    The `--maintenance-mode-file` is an independent file path and not relative to the root.
+
 ## Example
 
 For instance, the server will respond with a `503 Service Unavailable` status code and a custom message.

--- a/src/maintenance_mode.rs
+++ b/src/maintenance_mode.rs
@@ -22,13 +22,18 @@ pub fn get_response(
     file_path: &Path,
 ) -> Result<Response<Body>> {
     tracing::debug!("server has entered into maintenance mode");
+    tracing::debug!("maintenance mode file path to use: {}", file_path.display());
 
     let mut body_content = String::new();
-    if file_path.exists() {
+    if file_path.is_file() {
         body_content = String::from_utf8_lossy(&helpers::read_bytes_default(file_path))
             .to_string()
             .trim()
             .to_owned();
+    } else {
+        tracing::debug!(
+            "maintenance mode file path not found or not a regular file, using a default message"
+        );
     }
 
     if body_content.is_empty() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->
This PR just adds more debug logs for better information when using the server _maintenance mode_ feature.

Additionally, it clarifies `--maintenance-mode-file` argument in the docs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
