### PR TITLE
Load HTML error pages content at runtime

### DIFF
--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -28,9 +28,9 @@ Options:
   -d, --root <ROOT>
           Root directory path of static files [env: SERVER_ROOT=] [default: ./public]
       --page50x <PAGE50X>
-          HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message [env: SERVER_ERROR_PAGE_50X=] [default: ./public/50x.html]
+          HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory [env: SERVER_ERROR_PAGE_50X=] [default: ./50x.html]
       --page404 <PAGE404>
-          HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message [env: SERVER_ERROR_PAGE_404=] [default: ./public/404.html]
+          HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory [env: SERVER_ERROR_PAGE_404=] [default: ./404.html]
       --page-fallback <PAGE_FALLBACK>
           HTML file path that is used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path is not specified or simply doesn't exist then this feature will not be active [env: SERVER_FALLBACK_PAGE=] [default: ]
   -g, --log-level <LOG_LEVEL>
@@ -76,7 +76,7 @@ Options:
   -q, --grace-period <GRACE_PERIOD>
           Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to shut it down gracefully. The maximum value is 255 seconds [env: SERVER_GRACE_PERIOD=] [default: 0]
   -w, --config-file <CONFIG_FILE>
-          Server TOML configuration file path [env: SERVER_CONFIG_FILE=]
+          Server TOML configuration file path [env: SERVER_CONFIG_FILE=] [default: ./config.toml]
       --log-remote-address[=<LOG_REMOTE_ADDRESS>]
           Log incoming requests information along with its remote address if available using the `info` log level [env: SERVER_LOG_REMOTE_ADDRESS=] [default: false] [possible values: true, false]
       --redirect-trailing-slash[=<REDIRECT_TRAILING_SLASH>]

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -26,8 +26,9 @@ cache-control-headers = true
 compression = true
 
 #### Error pages
-page404 = "./public/404.html"
-page50x = "./public/50x.html"
+# Note: If a relative path is used then it will be resolved under the root directory.
+page404 = "./404.html"
+page50x = "./50x.html"
 
 #### HTTP/2 + TLS
 http2 = false

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -31,10 +31,12 @@ Specify a logging level in lower case. Possible values are `error`, `warn`, `inf
 Log incoming requests information along with its Remote Address (IP) if available using the `info` log level. Default `false`.
 
 ### SERVER_ERROR_PAGE_404
-HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. Default `./public/404.html`.
+HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
+If a relative path is used then it will be resolved under the root directory. Default `./404.html`.
 
 ### SERVER_ERROR_PAGE_50X
-HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. Default `./public/50x.html`
+HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
+If a relative path is used then it will be resolved under the root directory. Default `./50x.html`
 
 ### SERVER_FALLBACK_PAGE
 HTML file path that is used for `GET` requests when the requested path doesn't exist. The fallback page is served with a `200` status code, useful when using client routers (E.g `React Router`). If the path is not specified or simply doesn't exist then this feature will not be active.
@@ -110,10 +112,13 @@ Activate the health endpoint.
 
 ### SERVER_INDEX_FILES
 List of files that will be used as an index for requests ending with the slash character (‘/’). Files are checked in the specified order. Default `index.html`.
+
 ### SERVER_MAINTENANCE_MODE
 Enable the server's maintenance mode functionality.
+
 ### SERVER_MAINTENANCE_MODE_STATUS
 Provide a custom HTTP status code when entering into maintenance mode. Default `503`.
+
 ### SERVER_MAINTENANCE_MODE_FILE
 Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed.
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -59,9 +59,9 @@ pub struct RequestHandlerOpts {
     /// Cache control headers feature.
     pub cache_control_headers: bool,
     /// Page for 404 errors.
-    pub page404: Vec<u8>,
+    pub page404: PathBuf,
     /// Page for 50x errors.
-    pub page50x: Vec<u8>,
+    pub page50x: PathBuf,
     /// Page fallback feature.
     #[cfg(feature = "fallback-page")]
     #[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -159,9 +159,28 @@ impl Server {
         let root_dir = helpers::get_valid_dirpath(&general.root)
             .with_context(|| "root directory was not found or inaccessible")?;
 
-        // Custom error pages content
-        let page404 = helpers::read_bytes_default(&general.page404);
-        let page50x = helpers::read_bytes_default(&general.page50x);
+        // Custom HTML error page files
+        // NOTE: in the case of relative paths, they're joined to the root directory
+        let mut page404 = general.page404;
+        if page404.is_relative() && !page404.starts_with(&root_dir) {
+            page404 = root_dir.join(page404);
+        }
+        if !page404.is_file() {
+            tracing::debug!(
+                "404 file path not found or not a regular file: {}",
+                page404.display()
+            );
+        }
+        let mut page50x = general.page50x;
+        if page50x.is_relative() && !page50x.starts_with(&root_dir) {
+            page50x = root_dir.join(page50x);
+        }
+        if !page50x.is_file() {
+            tracing::debug!(
+                "50x file path not found or not a regular file: {}",
+                page50x.display()
+            );
+        }
 
         // Fallback page option
         #[cfg(feature = "fallback-page")]

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -101,20 +101,16 @@ pub struct General {
     /// Root directory path of static files.
     pub root: PathBuf,
 
-    #[arg(
-        long,
-        default_value = "./public/50x.html",
-        env = "SERVER_ERROR_PAGE_50X"
-    )]
-    /// HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
+    #[arg(long, default_value = "./50x.html", env = "SERVER_ERROR_PAGE_50X")]
+    /// HTML file path for 50x errors. If the path is not specified or simply doesn't exist
+    /// then the server will use a generic HTML error message.
+    /// If a relative path is used then it will be resolved under the root directory.
     pub page50x: PathBuf,
 
-    #[arg(
-        long,
-        default_value = "./public/404.html",
-        env = "SERVER_ERROR_PAGE_404"
-    )]
-    /// HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
+    #[arg(long, default_value = "./404.html", env = "SERVER_ERROR_PAGE_404")]
+    /// HTML file path for 404 errors. If the path is not specified or simply doesn't exist
+    /// then the server will use a generic HTML error message.
+    /// If a relative path is used then it will be resolved under the root directory.
     pub page404: PathBuf,
 
     #[cfg(feature = "fallback-page")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR makes it possible to load the HTML 404 (`--page404`) and 50x (`--page50x`) error page content at runtime. It allows changing the content of those HTML files on demand without restarting the server. 
Previously, the error pages were loaded at start-up time (basically they were static content).

**Some additional improvements:**

- If a relative path is used then it will be resolved under the root directory.
- Now the default error page values have been changed:
  - `--page50x=./50x.html`
  - `--page404=./404.html`

In case paths are not found then the server defaults to a generic HTML message (as before).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #98 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
