### PR TITLE
Fix Windows ARM64 binary does not run due to some missing DLLs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,9 @@
 [registries.crates-io]
 protocol = "sparse"
 
-# Statically link the C runtime on Windows MSVC x86_64,
+# Statically link the C runtime on Windows MSVC,
 # so that the resulting EXE doesn't depend on the VCRUNTIME140.dll.
 [target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->
This PR fixes a build issue when trying to run the latest `v2.24.0` ARM64 binary on a fresh Windows 11 ARM64 install due to missing Windows CRT DLLs.

Since it happens for example in fresh installs, we now statically-linked the Windows MSVC C runtime solving the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


In a fresh Windows 11 ARM64 installation.

ARM64 (before)

```sh
$ ldd static-web-server.exe
        ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffc41ff0000)
        KERNEL32.DLL => /c/Windows/System32/KERNEL32.DLL (0x7ffc408d0000)
        KERNELBASE.dll => /c/Windows/System32/KERNELBASE.dll (0x7ffc3d9b0000)
        advapi32.dll => /c/Windows/System32/advapi32.dll (0x7ffc406b0000)
        msvcrt.dll => /c/Windows/System32/msvcrt.dll (0x7ffc3f930000)
        sechost.dll => /c/Windows/System32/sechost.dll (0x7ffc3fe60000)
        RPCRT4.dll => /c/Windows/System32/RPCRT4.dll (0x7ffc3e5e0000)
        ws2_32.dll => /c/Windows/System32/ws2_32.dll (0x7ffc40800000)
        ucrtbase.dll => /c/Windows/System32/ucrtbase.dll (0x7ffc3e1e0000)
        bcrypt.dll => /c/Windows/SYSTEM32/bcrypt.dll (0x7ffc3c7f0000)
        VCRUNTIME140.dll => not found
        api-ms-win-crt-math-l1-1-0.dll => not found
        api-ms-win-crt-string-l1-1-0.dll => not found
        api-ms-win-crt-heap-l1-1-0.dll => not found
        api-ms-win-crt-runtime-l1-1-0.dll => not found
        api-ms-win-crt-stdio-l1-1-0.dll => not found
        api-ms-win-crt-locale-l1-1-0.dll => not found
```

ARM64 (after)

```sh
$ ldd static-web-server.exe
        ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffc41ff0000)
        KERNEL32.DLL => /c/Windows/System32/KERNEL32.DLL (0x7ffc408d0000)
        KERNELBASE.dll => /c/Windows/System32/KERNELBASE.dll (0x7ffc3d9b0000)
        advapi32.dll => /c/Windows/System32/advapi32.dll (0x7ffc406b0000)
        msvcrt.dll => /c/Windows/System32/msvcrt.dll (0x7ffc3f930000)
        sechost.dll => /c/Windows/System32/sechost.dll (0x7ffc3fe60000)
        RPCRT4.dll => /c/Windows/System32/RPCRT4.dll (0x7ffc3e5e0000)
        ws2_32.dll => /c/Windows/System32/ws2_32.dll (0x7ffc40800000)
        bcrypt.dll => /c/Windows/SYSTEM32/bcrypt.dll (0x7ffc3c7f0000)
        CRYPTBASE.DLL => /c/Windows/SYSTEM32/CRYPTBASE.DLL (0x7ffc3c550000)
```

## Screenshots (if appropriate):
