### PR TITLE
Statically link the C runtime for Windows MSVC x86

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,5 @@ protocol = "sparse"
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.aarch64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "link-arg=libvcruntime.lib"]


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but trying to be concise as possible -->

This PR statically links the C runtime for Windows MSVC x86 (32-bit) to avoid missing system DLLs on fresh Windows installs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In a fresh Windows 10 x86_64 installation.

i686 (before)

```sh
$ ldd static-web-server.exe
        ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffc41ff0000)
        ntdll.dll => /c/Windows/SyChpe32/ntdll.dll (0x77700000)
        wow64.dll => /c/Windows/System32/wow64.dll (0x7ffc3fa80000)
        wow64base.dll => /c/Windows/System32/wow64base.dll (0x7ffc3e800000)
        wow64win.dll => /c/Windows/System32/wow64win.dll (0x7ffc3f5d0000)
        wow64con.dll => /c/Windows/System32/wow64con.dll (0x7ffc3fe50000)
```

i686 (after)

```sh
$ ldd static-web-server.exe
        ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffe74db0000)
        KERNEL32.DLL => /c/Windows/System32/KERNEL32.DLL (0x7ffe73990000)
        KERNELBASE.dll => /c/Windows/System32/KERNELBASE.dll (0x7ffe72b10000)
        advapi32.dll => /c/Windows/System32/advapi32.dll (0x7ffe72f30000)
        msvcrt.dll => /c/Windows/System32/msvcrt.dll (0x7ffe74580000)
        sechost.dll => /c/Windows/System32/sechost.dll (0x7ffe74b80000)
        RPCRT4.dll => /c/Windows/System32/RPCRT4.dll (0x7ffe74450000)
        ws2_32.dll => /c/Windows/System32/ws2_32.dll (0x7ffe74c20000)
        bcrypt.dll => /c/Windows/System32/bcrypt.dll (0x7ffe72ae0000)
        CRYPTBASE.DLL => /c/Windows/SYSTEM32/CRYPTBASE.DLL (0x7ffe71d70000)
```

## Screenshots (if appropriate):
