### PR TITLE
Fix wrong Glob brace expansion capture in URL Rewrites and Redirects

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -379,6 +379,8 @@ impl Settings {
                                 .regex()
                                 .trim_start_matches("(?-u)")
                                 .replace("?:.*", ".*")
+                                .replace("?:", "")
+                                .replace(".*.*", ".*")
                                 .to_owned();
                             tracing::debug!(
                                 "url rewrites glob pattern: {}",
@@ -425,6 +427,8 @@ impl Settings {
                                 .regex()
                                 .trim_start_matches("(?-u)")
                                 .replace("?:.*", ".*")
+                                .replace("?:", "")
+                                .replace(".*.*", ".*")
                                 .to_owned();
                             tracing::debug!(
                                 "url redirects glob pattern: {}",

--- a/tests/fixtures/toml/redirects.toml
+++ b/tests/fixtures/toml/redirects.toml
@@ -25,17 +25,23 @@ kind = 301
 
 # Glob groups 3
 [[advanced.redirects]]
+source = "/{rust,go,c}-lang.{rs,go,c}"
+destination = "http://localhost/new-languages/$1.lang.$2"
+kind = 302
+
+# Glob groups 4
+[[advanced.redirects]]
 source = "/assets/{*}.{js,mjs}"
 destination = "http://localhost/new-scripts/$1.$2"
 kind = 302
 
-# Glob groups 4
+# Glob groups 5
 [[advanced.redirects]]
 source = "**/{*}.{jpg,jpeg}"
 destination = "http://localhost/new-images/$2.$3"
 kind = 302
 
-# Glob groups 5
+# Glob groups 6
 [[advanced.redirects]]
 source = "**/{*}.{ttf,otf,woff}"
 destination = "http://localhost/new-fonts/$2.woff"

--- a/tests/fixtures/toml/redirects.toml
+++ b/tests/fixtures/toml/redirects.toml
@@ -4,14 +4,45 @@ root = "docker/public"
 
 [advanced]
 
-### URL Redirects
+# Host tests
 [[advanced.redirects]]
 host = "127.0.0.1:1234"
 source = "/{*}"
 destination = "http://localhost:1234/$1"
 kind = 301
 
+# Glob groups 1
+[[advanced.redirects]]
+source = "**/main.{css}"
+destination = "http://localhost/new-styles/style.$2"
+kind = 301
+
+# Glob groups 2
+[[advanced.redirects]]
+source = "/{main,style}.css"
+destination = "http://localhost/new-styles/$1.min.css"
+kind = 301
+
+# Glob groups 3
+[[advanced.redirects]]
+source = "/assets/{*}.{js,mjs}"
+destination = "http://localhost/new-scripts/$1.$2"
+kind = 302
+
+# Glob groups 4
+[[advanced.redirects]]
+source = "**/{*}.{jpg,jpeg}"
+destination = "http://localhost/new-images/$2.$3"
+kind = 302
+
+# Glob groups 5
+[[advanced.redirects]]
+source = "**/{*}.{ttf,otf,woff}"
+destination = "http://localhost/new-fonts/$2.woff"
+kind = 302
+
+# Glob groups generic 1
 [[advanced.redirects]]
 source = "**/{*}.{*}"
-destination = "http://localhost:1234/files/$1.$2"
-kind = 302
+destination = "http://localhost/new-generic/$2.$3"
+kind = 301

--- a/tests/fixtures/toml/rewrites.toml
+++ b/tests/fixtures/toml/rewrites.toml
@@ -1,0 +1,43 @@
+[general]
+
+root = "docker/public"
+
+[advanced]
+
+# Glob groups 1
+[[advanced.rewrites]]
+source = "**/error-page.{html}"
+destination = "/404.$2"
+
+# Glob groups 2
+[[advanced.rewrites]]
+source = "/error-page/{404,50x}.html"
+destination = "/$1.html"
+
+# Glob groups 3
+[[advanced.rewrites]]
+source = "/errors/{50}x.html"
+destination = "/$1x.html"
+
+# Glob groups 4
+[[advanced.rewrites]]
+source = "/scripts/{*}.{js,mjs}"
+destination = "/assets/$1.$2"
+
+# Glob groups 5 (redirect)
+[[advanced.rewrites]]
+source = "**/{*}.{ico}"
+destination = "/assets/favicon.$3"
+redirect = 302
+
+# Glob groups 6 (redirect)
+[[advanced.rewrites]]
+source = "**/{*}.{ttf,otf,woff}"
+destination = "http://localhost/new-fonts/$2.woff"
+redirect = 302
+
+# Glob groups generic 1 (redirect)
+[[advanced.rewrites]]
+source = "**/{*}.{*}"
+destination = "http://localhost/new-generic/$2.$3"
+redirect = 301

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -10,23 +10,20 @@ pub mod tests {
     use static_web_server::testing::fixtures::{fixture_req_handler, REMOTE_ADDR};
 
     #[tokio::test]
-    async fn redirects_default() {
+    async fn redirects_skipped() {
         let req_handler = fixture_req_handler("toml/redirects.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost:1234/assets/favicon.ico".parse().unwrap();
+        *req.uri_mut() = "http://localhost".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
-                assert_eq!(res.status(), 302);
-                assert_eq!(
-                    res.headers()["location"],
-                    "http://localhost:1234/files/assets/favicon.ico"
-                );
+                assert_eq!(res.status(), 200);
+                assert_eq!(res.headers()["content-type"], "text/html");
             }
             Err(status) => {
-                panic!("expected a status 302 but got {status}")
+                panic!("expected a status 200 but got {status}")
             }
         };
     }
@@ -51,20 +48,133 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn redirects_skipped() {
+    async fn redirects_glob_groups_1() {
         let req_handler = fixture_req_handler("toml/redirects.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost:1234".parse().unwrap();
+        *req.uri_mut() = "http://localhost/assets/main.css".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
-                assert_eq!(res.status(), 200);
-                assert_eq!(res.headers()["content-type"], "text/html");
+                assert_eq!(res.status(), 301);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost/new-styles/style.css"
+                );
             }
             Err(status) => {
-                panic!("expected a status 200 but got {status}")
+                panic!("expected a status 301 but got {status}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn redirects_glob_groups_2() {
+        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/style.css".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 301);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost/new-styles/style.min.css"
+                );
+            }
+            Err(status) => {
+                panic!("expected a status 301 but got {status}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn redirects_glob_groups_3() {
+        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/assets/main.js".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 302);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost/new-scripts/main.js"
+                );
+            }
+            Err(status) => {
+                panic!("expected a status 302 but got {status}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn redirects_glob_groups_4() {
+        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/images/avatar.jpeg".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 302);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost/new-images/images/avatar.jpeg"
+                );
+            }
+            Err(status) => {
+                panic!("expected a status 302 but got {status}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn redirects_glob_groups_5() {
+        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/fonts/title.ttf".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 302);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost/new-fonts/fonts/title.woff"
+                );
+            }
+            Err(status) => {
+                panic!("expected a status 302 but got {status}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn redirects_glob_groups_generic_1() {
+        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/generic-page.html".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 301);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost/new-generic/generic-page.html"
+                );
+            }
+            Err(status) => {
+                panic!("expected a status 301 but got {status}")
             }
         };
     }

--- a/tests/rewrites.rs
+++ b/tests/rewrites.rs
@@ -10,12 +10,12 @@ pub mod tests {
     use static_web_server::testing::fixtures::{fixture_req_handler, REMOTE_ADDR};
 
     #[tokio::test]
-    async fn redirects_skipped() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+    async fn rewrites_skipped() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost".parse().unwrap();
+        *req.uri_mut() = "http://development".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
@@ -29,17 +29,23 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn redirects_host() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+    async fn rewrites_glob_groups_1() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://127.0.0.1:1234".parse().unwrap();
+        *req.uri_mut() = "http://localhost/some/error-page.html".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
-            Ok(res) => {
-                assert_eq!(res.status(), 301);
-                assert_eq!(res.headers()["location"], "http://localhost:1234/");
+            Ok(mut res) => {
+                assert_eq!(res.status(), 200);
+                assert_eq!(res.headers()["content-type"], "text/html");
+
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
+                let body_str = std::str::from_utf8(&body).unwrap();
+                assert!(body_str.contains("404 Content"))
             }
             Err(err) => {
                 panic!("unexpected error: {err}")
@@ -48,20 +54,23 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn redirects_glob_groups_1() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+    async fn rewrites_glob_groups_2() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/assets/main.css".parse().unwrap();
+        *req.uri_mut() = "http://localhost/error-page/50x.html".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
-            Ok(res) => {
-                assert_eq!(res.status(), 301);
-                assert_eq!(
-                    res.headers()["location"],
-                    "http://localhost/new-styles/style.css"
-                );
+            Ok(mut res) => {
+                assert_eq!(res.status(), 200);
+                assert_eq!(res.headers()["content-type"], "text/html");
+
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
+                let body_str = std::str::from_utf8(&body).unwrap();
+                assert!(body_str.contains("50x Service Unavailable"))
             }
             Err(err) => {
                 panic!("unexpected error: {err}")
@@ -70,20 +79,23 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn redirects_glob_groups_2() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+    async fn rewrites_glob_groups_3() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/style.css".parse().unwrap();
+        *req.uri_mut() = "http://localhost/errors/50x.html".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
-            Ok(res) => {
-                assert_eq!(res.status(), 301);
-                assert_eq!(
-                    res.headers()["location"],
-                    "http://localhost/new-styles/style.min.css"
-                );
+            Ok(mut res) => {
+                assert_eq!(res.status(), 200);
+                assert_eq!(res.headers()["content-type"], "text/html");
+
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
+                let body_str = std::str::from_utf8(&body).unwrap();
+                assert!(body_str.contains("50x Service Unavailable"))
             }
             Err(err) => {
                 panic!("unexpected error: {err}")
@@ -92,19 +104,63 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn redirects_glob_groups_3() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+    async fn rewrites_glob_groups_4() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/rust-lang.rs".parse().unwrap();
+        *req.uri_mut() = "http://localhost/scripts/main.js".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(mut res) => {
+                assert_eq!(res.status(), 200);
+                assert_eq!(res.headers()["content-type"], "application/javascript");
+
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
+                let body_str = std::str::from_utf8(&body).unwrap();
+                assert!(body_str.contains("Static Web Server"))
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn rewrites_glob_groups_5() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/images/icon.ico".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 302);
+                assert_eq!(res.headers()["location"], "/assets/favicon.ico");
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn rewrites_glob_groups_6() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/fonts/text.ttf".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
                 assert_eq!(
                     res.headers()["location"],
-                    "http://localhost/new-languages/rust.lang.rs"
+                    "http://localhost/new-fonts/fonts/text.woff"
                 );
             }
             Err(err) => {
@@ -114,74 +170,8 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn redirects_glob_groups_4() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
-
-        let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/assets/main.js".parse().unwrap();
-
-        match req_handler.handle(&mut req, remote_addr).await {
-            Ok(res) => {
-                assert_eq!(res.status(), 302);
-                assert_eq!(
-                    res.headers()["location"],
-                    "http://localhost/new-scripts/main.js"
-                );
-            }
-            Err(err) => {
-                panic!("unexpected error: {err}")
-            }
-        };
-    }
-
-    #[tokio::test]
-    async fn redirects_glob_groups_5() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
-
-        let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/images/avatar.jpeg".parse().unwrap();
-
-        match req_handler.handle(&mut req, remote_addr).await {
-            Ok(res) => {
-                assert_eq!(res.status(), 302);
-                assert_eq!(
-                    res.headers()["location"],
-                    "http://localhost/new-images/images/avatar.jpeg"
-                );
-            }
-            Err(err) => {
-                panic!("unexpected error: {err}")
-            }
-        };
-    }
-
-    #[tokio::test]
-    async fn redirects_glob_groups_6() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
-
-        let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/fonts/title.ttf".parse().unwrap();
-
-        match req_handler.handle(&mut req, remote_addr).await {
-            Ok(res) => {
-                assert_eq!(res.status(), 302);
-                assert_eq!(
-                    res.headers()["location"],
-                    "http://localhost/new-fonts/fonts/title.woff"
-                );
-            }
-            Err(err) => {
-                panic!("unexpected error: {err}")
-            }
-        };
-    }
-
-    #[tokio::test]
-    async fn redirects_glob_groups_generic_1() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+    async fn rewrites_glob_groups_generic_1() {
+        let req_handler = fixture_req_handler("toml/rewrites.toml");
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a wrong glob capture when a URL Redirect (or Rewrite) `source` uses Glob groups with brace expansions (E.g. `**/{*}.{jpg,jpeg}`).

For example, the following configuration will work now as expected.

```toml
[advanced]

[[advanced.redirects]]
# Glob groups with brace expansions here 
source = "**/{*}.{jpg,jpeg}"
destination = "http://localhost/new-images/$2.$3"
kind = 302

[[advanced.rewrites]]
# Glob groups with brace expansions here 
source = "/scripts/{*}.{js,mjs}"
destination = "/assets/$1.$2"

```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

Via integration tests. See all variants covered in `tests/fixtures/toml/redirects.toml` and `tests/fixtures/toml/rewrites.toml`.

## Screenshots (if appropriate):
