### PR TITLE
Support for `Range` requests out of bounds

### DIFF
--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -663,7 +663,6 @@ async fn response_body(
     }
 }
 
-#[derive(Debug)]
 struct BadRange;
 
 fn bytes_range(range: Option<Range>, max_len: u64) -> Result<(u64, u64), BadRange> {

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -663,6 +663,7 @@ async fn response_body(
     }
 }
 
+#[derive(Debug)]
 struct BadRange;
 
 fn bytes_range(range: Option<Range>, max_len: u64) -> Result<(u64, u64), BadRange> {
@@ -672,35 +673,60 @@ fn bytes_range(range: Option<Range>, max_len: u64) -> Result<(u64, u64), BadRang
         return Ok((0, max_len));
     };
 
-    let res = range
+    let resp = range
         .iter()
         .map(|(start, end)| {
+            tracing::trace!("range request received, {:?}-{:?}-{}", start, end, max_len);
+
             let (start, end) = match (start, end) {
                 (Bound::Unbounded, Bound::Unbounded) => (0, max_len),
                 (Bound::Included(a), Bound::Included(b)) => {
+                    // `start` can not be greater than `end`
+                    if a > b {
+                        return Err(BadRange);
+                    }
                     // For the special case where b == the file size
                     (a, if b == max_len { b } else { b + 1 })
                 }
                 (Bound::Included(a), Bound::Unbounded) => (a, max_len),
                 (Bound::Unbounded, Bound::Included(b)) => {
                     if b > max_len {
-                        return Err(BadRange);
+                        // `Range` request out of bounds, return only what's available
+                        tracing::trace!("unsatisfiable byte range: -{}/{}", b, max_len);
+                        tracing::trace!("returning only what's available: 0-{}", max_len);
+                        (0, max_len)
+                    } else {
+                        (max_len - b, max_len)
                     }
-                    (max_len - b, max_len)
                 }
                 _ => unreachable!(),
             };
 
             if start < end && end <= max_len {
-                Ok((start, end))
-            } else {
-                tracing::trace!("unsatisfiable byte range: {}-{}/{}", start, end, max_len);
-                Err(BadRange)
+                tracing::trace!("range request to return: {}-{}/{}", start, end, max_len);
+                return Ok((start, end));
             }
+
+            tracing::trace!("unsatisfiable byte range: {}-{}/{}", start, end, max_len);
+
+            if start < end && start <= max_len {
+                // `Range` request out of bounds, return only what's available
+                tracing::trace!(
+                    "returning only what's available: {}-{}/{}",
+                    start,
+                    max_len,
+                    max_len
+                );
+                return Ok((start, max_len));
+            }
+
+            Err(BadRange)
         })
         .next()
-        .unwrap_or(Ok((0, max_len)));
-    res
+        // NOTE: default to `BadRange` in case of wrong `Range` bytes format
+        .unwrap_or(Err(BadRange));
+
+    resp
 }
 
 #[cfg(test)]

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -833,13 +833,13 @@ mod tests {
                     assert_eq!(res.status(), 206);
                     assert_eq!(
                         res.headers()["content-range"],
-                        format!("bytes 100-535/{}", buf.len())
+                        format!("bytes 100-{}/{}", buf.len() - 1, buf.len())
                     );
-                    assert_eq!(res.headers().get("content-length").unwrap(), &"436");
+                    assert!(res.headers().get("content-length").is_some());
                     let body = hyper::body::to_bytes(res.body_mut())
                         .await
                         .expect("unexpected bytes error during `body` conversion");
-                    assert_eq!(body.len(), 436);
+                    assert!(body.len() > 400);
                 }
                 Err(_) => {
                     panic!("expected a normal response rather than a status error")
@@ -1072,11 +1072,11 @@ mod tests {
                         res.headers()["content-range"],
                         format!("bytes */{}", buf.len())
                     );
-                    assert_eq!(res.headers().get("content-length"), None);
+                    assert!(res.headers().get("content-length").is_none());
                     let body = hyper::body::to_bytes(res.body_mut())
                         .await
                         .expect("unexpected bytes error during `body` conversion");
-                    assert_eq!(body, "");
+                    assert!(body.is_empty());
                 }
                 Err(_) => {
                     panic!("expected a normal response rather than a status error")
@@ -1119,11 +1119,11 @@ mod tests {
             {
                 Ok((mut res, _)) => {
                     assert_eq!(res.status(), 200);
-                    assert_eq!(res.headers().get("content-length").unwrap(), &"536");
+                    assert!(res.headers().get("content-length").is_some());
                     let body = hyper::body::to_bytes(res.body_mut())
                         .await
                         .expect("unexpected bytes error during `body` conversion");
-                    assert_eq!(body.len(), 536);
+                    assert!(body.len() > 500);
                 }
                 Err(_) => {
                     panic!("expected a normal response rather than a status error")

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -830,16 +830,16 @@ mod tests {
             .await
             {
                 Ok((mut res, _)) => {
-                    assert_eq!(res.status(), 416);
+                    assert_eq!(res.status(), 206);
                     assert_eq!(
                         res.headers()["content-range"],
-                        format!("bytes */{}", buf.len())
+                        format!("bytes 100-535/{}", buf.len())
                     );
-                    assert_eq!(res.headers().get("content-length"), None);
+                    assert_eq!(res.headers().get("content-length").unwrap(), &"436");
                     let body = hyper::body::to_bytes(res.body_mut())
                         .await
                         .expect("unexpected bytes error during `body` conversion");
-                    assert_eq!(body, "");
+                    assert_eq!(body.len(), 436);
                 }
                 Err(_) => {
                     panic!("expected a normal response rather than a status error")
@@ -1038,16 +1038,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_byte_ranges_bad_2() {
+    async fn handle_byte_ranges_bad_non_numeric() {
+        let mut headers = HeaderMap::new();
+        headers.insert("range", "bytes=xyx-abc".parse().unwrap());
+
         let buf = fs::read(root_dir().join("index.html"))
             .expect("unexpected error during index.html reading");
         let buf = Bytes::from(buf);
-
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "range",
-            format!("bytes=-{}", buf.len() + 1).parse().unwrap(),
-        );
 
         for method in [Method::HEAD, Method::GET] {
             match static_files::handle(&HandleOpts {
@@ -1089,11 +1086,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_byte_ranges_bad_3() {
+    async fn handle_byte_ranges_bad_2() {
         let buf = fs::read(root_dir().join("index.html"))
             .expect("unexpected error during index.html reading");
         let buf = Bytes::from(buf);
 
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "range",
+            format!("bytes=-{}", buf.len() + 1).parse().unwrap(),
+        );
+
+        for method in [Method::HEAD, Method::GET] {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &headers,
+                base_path: &root_dir(),
+                uri_path: "index.html",
+                uri_query: None,
+                #[cfg(feature = "directory-listing")]
+                dir_listing: false,
+                #[cfg(feature = "directory-listing")]
+                dir_listing_order: 6,
+                #[cfg(feature = "directory-listing")]
+                dir_listing_format: &DirListFmt::Html,
+                redirect_trailing_slash: true,
+                compression_static: false,
+                ignore_hidden_files: false,
+                index_files: &[],
+            })
+            .await
+            {
+                Ok((mut res, _)) => {
+                    assert_eq!(res.status(), 200);
+                    assert_eq!(res.headers().get("content-length").unwrap(), &"536");
+                    let body = hyper::body::to_bytes(res.body_mut())
+                        .await
+                        .expect("unexpected bytes error during `body` conversion");
+                    assert_eq!(body.len(), 536);
+                }
+                Err(_) => {
+                    panic!("expected a normal response rather than a status error")
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_byte_ranges_bad_3() {
         let mut headers = HeaderMap::new();
         // Range::Unbounded for beginning and end
         headers.insert("range", "bytes=".parse().unwrap());
@@ -1118,12 +1158,8 @@ mod tests {
             })
             .await
             {
-                Ok((mut res, _)) => {
-                    assert_eq!(res.status(), 200);
-                    let body = hyper::body::to_bytes(res.body_mut())
-                        .await
-                        .expect("unexpected bytes error during `body` conversion");
-                    assert_eq!(body, buf);
+                Ok((res, _)) => {
+                    assert_eq!(res.status(), 416);
                 }
                 Err(_) => {
                     panic!("expected a normal response rather than a status error")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR adds support for allowing `Range` requests out of bounds. SWS will make sure to return only what's available in that case.
`Range` requests out of bounds seems to be a very common behavior across web servers.

For example, previously exceeding the length of a file returned  `416 Requested Range Not Satisfiable`. Now it will return what's available.

```sh
$ curl -IH "Range: bytes=50-99999" http://localhost/index.html
# HTTP/1.1 206 Partial Content
# content-range: bytes 50-535/536
# content-length: 486
# content-type: text/html
# accept-ranges: bytes
# last-modified: Fri, 15 Dec 2023 13:00:02 GMT
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Mon, 29 Jan 2024 08:57:42 GMT

$ curl -IH "Range: bytes=-99999" http://localhost/index.html
# HTTP/1.1 200 OK
# content-length: 536
# content-type: text/html
# accept-ranges: bytes
# last-modified: Fri, 15 Dec 2023 13:00:02 GMT
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Thu, 01 Feb 2024 08:24:44 GMT

$ curl -IH "Range: bytes=20-80" http://localhost/index.html
# HTTP/1.1 206 Partial Content
# content-range: bytes 20-80/536
# content-length: 61
# content-type: text/html
# accept-ranges: bytes
# last-modified: Fri, 15 Dec 2023 13:00:02 GMT
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Thu, 01 Feb 2024 08:32:31 GMT
```

**Note** that SWS will also reply with `416 Requested Range Not Satisfiable` for bad range requests.

```sh
$ curl -IH "Range: bytes=9999-" http://localhost/index.html
# HTTP/1.1 416 Range Not Satisfiable
# content-range: bytes */536
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Thu, 01 Feb 2024 08:26:24 GMT

$ curl -IH "Range: bytes=9999-y" http://localhost/index.html
# HTTP/1.1 416 Range Not Satisfiable
# content-range: bytes */536
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Thu, 01 Feb 2024 08:26:32 GMT

$ curl -IH "Range: bytes=x-y" http://localhost/index.html
# HTTP/1.1 416 Range Not Satisfiable
# content-range: bytes */536
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Thu, 01 Feb 2024 08:27:52 GMT

$ curl -IH "Range: bytes=" http://localhost/index.html
# HTTP/1.1 416 Range Not Satisfiable
# content-range: bytes */536
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Thu, 01 Feb 2024 08:29:04 GMT

$ curl -IH "Range: bytes=50" http://localhost/index.html
# HTTP/1.1 416 Range Not Satisfiable
# content-range: bytes */536
# vary: accept-encoding
# cache-control: public, max-age=86400
# date: Thu, 01 Feb 2024 08:30:01 GMT
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Related to https://github.com/orgs/static-web-server/discussions/145

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #295

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
