### PR TITLE
Drop Linux ppc64le/s390x support for Alpine and Scratch Docker images

### DIFF
--- a/.github/workflows/devel.docker.yml
+++ b/.github/workflows/devel.docker.yml
@@ -29,8 +29,6 @@ jobs:
           - linux/arm64
           - linux/arm/v7
           - linux/arm/v6
-          - linux/ppc64le
-          - linux/s390x
     runs-on: ubuntu-22.04
     services:
       registry:

--- a/.github/workflows/release.docker.yml
+++ b/.github/workflows/release.docker.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           file: ./docker/alpine/Dockerfile
           tags: ${{ steps.meta_alpine.outputs.tags }}
           build-args: |
@@ -177,7 +177,7 @@ jobs:
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
           file: ./docker/scratch/Dockerfile
           tags: ${{ steps.meta_scratch.outputs.tags }}
           build-args: |

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -13,8 +13,6 @@ RUN set -ex; \
         "linux/386") target='i686-unknown-linux-musl' ;; \
         "linux/arm/v7") target='armv7-unknown-linux-musleabihf' ;; \
         "linux/arm/v6") target='arm-unknown-linux-musleabihf' ;; \
-        "linux/ppc64le") target='powerpc64le-unknown-linux-gnu' ;; \
-        "linux/s390x") target='s390x-unknown-linux-gnu' ;; \
         *) echo >&2 "error: unsupported $TARGETPLATFORM architecture"; exit 1 ;; \
     esac; \
     wget --quiet -O /tmp/static-web-server.tar.gz "https://github.com/static-web-server/static-web-server/releases/download/v${SERVER_VERSION}/static-web-server-v${SERVER_VERSION}-${target}.tar.gz"; \
@@ -27,14 +25,8 @@ RUN set -ex \
     && echo "Testing Docker image..." \
     && uname -a \
     && cat /etc/os-release \
-    && case "$TARGETPLATFORM" in \
-        **ppc64*|*s390x*) \
-            echo "warn: can not run sws binary on $TARGETPLATFORM architecture" ;; \
-        *) \
-            static-web-server --version; \
-            static-web-server --help; \
-        ;; \
-    esac \
+    && static-web-server --version \
+    && static-web-server --help \
     && file /usr/local/bin/static-web-server \
     && true
 

--- a/docs/content/features/docker.md
+++ b/docs/content/features/docker.md
@@ -15,8 +15,8 @@ All Docker images are [Multi-Arch](https://www.docker.com/blog/how-to-rapidly-bu
 - `linux/arm/v6`
 - `linux/arm/v7`
 - `linux/arm64`
-- `linux/ppc64le`
-- `linux/s390x`
+- `linux/ppc64le` (Debian only)
+- `linux/s390x` (Debian only)
 
 !!! tip "SWS statically-linked binary"
     All the Docker images use the SWS statically-linked binary, meaning that the binary is highly optimized, performant, and dependency-free thanks to [musl libc](https://www.musl-libc.org/).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR drops support for ppc64le (`powerpc64le-unknown-linux-gnu`) and s590x (`s390x-unknown-linux-gnu`) of the SWS Alpine and Scratch Docker images.
Those two provide SWS dynamically linked binaries and it does **not** make so much sense to deliver them with either the Alpine (`musl`) or the Scratch images because they do not work properly (lack of OS dependencies) as of writing.

So we remove those two to avoid misunderstandings or future issues.

However, **the Debian Docker image should be preferred instead**, either `linux/ppc64le` or `linux/s390x` respectively.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This resolves #308

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
