### PR TITLE
Shut-down ability for `server::Server::run_server_on_rt` and `server::Server::run_standalone` functions

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -37,7 +37,7 @@ fn main() -> Result {
     }
 
     // Run the server by default
-    static_web_server::Server::new(opts)?.run_standalone()?;
+    static_web_server::Server::new(opts)?.run_standalone(None)?;
 
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR enhances the `server::Server::run_server_on_rt` and `server::Server::run_standalone` functions to support cancellation to shut down the server gracefully on demand as a complement to the termination signals handling in Linux/Unix systems.

Updated function signatures:

```rs
/// NOTE:
/// Now it will also handle server cancellation via the `cancel_recv` param in Linux/Unix systems
/// similar to what Windows does.
pub fn run_server_on_rt<F>(self, cancel_recv: Option<Receiver<()>>, cancel_fn: F) -> Result

/// NOTE:
/// Now it also accepts a `cancel` param to shut down the server in Linux/Unix systems
/// similar to what Windows does.
pub fn run_standalone(self, cancel: Option<Receiver<()>>) -> Result

```

As a result, the termination signals function (`signals::wait_for_signals`) will wait for incoming signals or a manual cancellation (`cancel: Option<Receiver<()>>`) to delegate the graceful shutdown process.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This feature should be convenient for library users to be able to shut down the server gracefully on demand.

See https://github.com/orgs/static-web-server/discussions/315

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
