### PR TITLE
Fix build error when using specific or no Cargo compression features

### DIFF
--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -38,13 +38,13 @@ pub async fn precompressed_variant<'a>(
     // Determine prefered-encoding extension if available
     let comp_ext = match compression::get_prefered_encoding(headers) {
         // https://zlib.net/zlib_faq.html#faq39
-        #[cfg(feature = "compression-gzip")]
+        #[cfg(any(feature = "compression", feature = "compression-gzip"))]
         Some(ContentCoding::GZIP | ContentCoding::DEFLATE) => "gz",
         // https://peazip.github.io/brotli-compressed-file-format.html
-        #[cfg(feature = "compression-brotli")]
+        #[cfg(any(feature = "compression", feature = "compression-brotli"))]
         Some(ContentCoding::BROTLI) => "br",
         // https://datatracker.ietf.org/doc/html/rfc8878
-        #[cfg(feature = "compression-zstd")]
+        #[cfg(any(feature = "compression", feature = "compression-zstd"))]
         Some(ContentCoding::ZSTD) => "zst",
         _ => {
             tracing::trace!(

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -10,7 +10,13 @@ use headers::{ContentType, HeaderMap, HeaderMapExt, HeaderValue};
 use hyper::{Body, Request, Response, StatusCode};
 use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc};
 
-#[cfg(feature = "compression")]
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
 use crate::compression;
 
 #[cfg(feature = "basic-auth")]
@@ -457,7 +463,13 @@ impl RequestHandler {
                     }
 
                     // Compression content encoding varies so use a `Vary` header
-                    #[cfg(feature = "compression")]
+                    #[cfg(any(
+                        feature = "compression",
+                        feature = "compression-gzip",
+                        feature = "compression-brotli",
+                        feature = "compression-zstd",
+                        feature = "compression-deflate"
+                    ))]
                     if self.opts.compression || compression_static {
                         resp.headers_mut().append(
                             hyper::header::VARY,
@@ -466,7 +478,13 @@ impl RequestHandler {
                     }
 
                     // Auto compression based on the `Accept-Encoding` header
-                    #[cfg(feature = "compression")]
+                    #[cfg(any(
+                        feature = "compression",
+                        feature = "compression-gzip",
+                        feature = "compression-brotli",
+                        feature = "compression-zstd",
+                        feature = "compression-deflate"
+                    ))]
                     if self.opts.compression && !_is_precompressed {
                         resp = match compression::auto(method, headers, resp) {
                             Ok(res) => res,
@@ -526,7 +544,13 @@ impl RequestHandler {
                         }
 
                         // Compression content encoding varies so use a `Vary` header
-                        #[cfg(feature = "compression")]
+                        #[cfg(any(
+                            feature = "compression",
+                            feature = "compression-gzip",
+                            feature = "compression-brotli",
+                            feature = "compression-zstd",
+                            feature = "compression-deflate"
+                        ))]
                         if self.opts.compression || compression_static {
                             resp.headers_mut().append(
                                 hyper::header::VARY,
@@ -535,7 +559,13 @@ impl RequestHandler {
                         }
 
                         // Auto compression based on the `Accept-Encoding` header
-                        #[cfg(feature = "compression")]
+                        #[cfg(any(
+                            feature = "compression",
+                            feature = "compression-gzip",
+                            feature = "compression-brotli",
+                            feature = "compression-zstd",
+                            feature = "compression-deflate"
+                        ))]
                         if self.opts.compression {
                             resp = match compression::auto(method, headers, resp) {
                                 Ok(res) => res,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,11 +111,41 @@ extern crate serde;
 #[cfg(feature = "basic-auth")]
 #[cfg_attr(docsrs, doc(cfg(feature = "basic-auth")))]
 pub mod basic_auth;
-#[cfg(feature = "compression")]
-#[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    )))
+)]
 pub mod compression;
-#[cfg(feature = "compression")]
-#[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    )))
+)]
 pub mod compression_static;
 pub mod control_headers;
 pub mod cors;

--- a/src/server.rs
+++ b/src/server.rs
@@ -217,21 +217,67 @@ impl Server {
         let security_headers = general.security_headers;
         server_info!("security headers: enabled={}", security_headers);
 
-        // Auto compression based on the `Accept-Encoding` header
-        #[cfg(not(feature = "compression"))]
+        #[cfg(not(any(
+            feature = "compression",
+            feature = "compression-deflate",
+            feature = "compression-gzip",
+            feature = "compression-deflate",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+        )))]
         let compression = false;
-        #[cfg(feature = "compression")]
+        // Auto compression based on the `Accept-Encoding` header
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-deflate",
+            feature = "compression-gzip",
+            feature = "compression-deflate",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+        ))]
         let compression = general.compression;
-        #[cfg(feature = "compression")]
-        server_info!("auto compression: enabled={}", compression);
+
+        #[allow(unused_mut)]
+        let mut compression_formats = Vec::<&str>::with_capacity(5);
+        #[cfg(any(feature = "compression", feature = "compression-deflate"))]
+        compression_formats.push("deflate");
+        #[cfg(any(feature = "compression", feature = "compression-gzip"))]
+        compression_formats.push("gzip");
+        #[cfg(any(feature = "compression", feature = "compression-brotli"))]
+        compression_formats.push("brotli");
+        #[cfg(any(feature = "compression", feature = "compression-zstd"))]
+        compression_formats.push("zstd");
+        let compression_format = compression_formats.join(",");
+        server_info!(
+            "auto compression: enabled={}, formats={}",
+            compression,
+            compression_format
+        );
 
         // Check pre-compressed files based on the `Accept-Encoding` header
-        #[cfg(not(feature = "compression"))]
+        #[cfg(not(any(
+            feature = "compression",
+            feature = "compression-deflate",
+            feature = "compression-gzip",
+            feature = "compression-deflate",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+        )))]
         let compression_static = false;
-        #[cfg(feature = "compression")]
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-deflate",
+            feature = "compression-gzip",
+            feature = "compression-deflate",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+        ))]
         let compression_static = general.compression_static;
-        #[cfg(feature = "compression")]
-        server_info!("compression static: enabled={}", compression_static);
+        server_info!(
+            "compression static: enabled={}, formats={}",
+            compression_static,
+            compression_format
+        );
 
         // Directory listing options
         #[cfg(feature = "directory-listing")]

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -229,8 +229,23 @@ pub struct General {
     /// Files are checked in the specified order.
     pub index_files: String,
 
-    #[cfg(feature = "compression")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))
+    )]
     #[arg(
         long,
         short = 'x',
@@ -243,9 +258,23 @@ pub struct General {
     )]
     /// Gzip, Deflate, Brotli or Zstd compression on demand determined by the Accept-Encoding header and applied to text-based web file types only.
     pub compression: bool,
-
-    #[cfg(feature = "compression")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))
+    )]
     #[arg(
         long,
         default_value = "false",

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -135,13 +135,43 @@ pub struct General {
     pub cache_control_headers: Option<bool>,
 
     /// Compression.
-    #[cfg(feature = "compression")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))
+    )]
     pub compression: Option<bool>,
 
     /// Check for a pre-compressed file on disk.
-    #[cfg(feature = "compression")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))
+    )]
     pub compression_static: Option<bool>,
 
     /// Error 404 pages.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -98,9 +98,21 @@ impl Settings {
         let mut config_file = opts.config_file.clone();
         let mut cache_control_headers = opts.cache_control_headers;
 
-        #[cfg(feature = "compression")]
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        ))]
         let mut compression = opts.compression;
-        #[cfg(feature = "compression")]
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        ))]
         let mut compression_static = opts.compression_static;
 
         let mut page404 = opts.page404;
@@ -189,11 +201,23 @@ impl Settings {
                 if let Some(v) = general.cache_control_headers {
                     cache_control_headers = v
                 }
-                #[cfg(feature = "compression")]
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
                 if let Some(v) = general.compression {
                     compression = v
                 }
-                #[cfg(feature = "compression")]
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
                 if let Some(v) = general.compression_static {
                     compression_static = v
                 }
@@ -511,9 +535,21 @@ impl Settings {
                 log_level,
                 config_file,
                 cache_control_headers,
-                #[cfg(feature = "compression")]
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
                 compression,
-                #[cfg(feature = "compression")]
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
                 compression_static,
                 page404,
                 page50x,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -27,7 +27,14 @@ use crate::{
     http_ext::{MethodExt, HTTP_SUPPORTED_METHODS},
 };
 
-#[cfg(feature = "compression")]
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-deflate",
+    feature = "compression-gzip",
+    feature = "compression-deflate",
+    feature = "compression-brotli",
+    feature = "compression-zstd"
+))]
 use crate::compression_static;
 
 #[cfg(feature = "directory-listing")]
@@ -248,7 +255,14 @@ async fn get_composed_file_metadata<'a>(
                     file_path.push(index);
 
                     // Pre-compressed variant check for the autoindex
-                    #[cfg(feature = "compression")]
+                    #[cfg(any(
+                        feature = "compression",
+                        feature = "compression-deflate",
+                        feature = "compression-gzip",
+                        feature = "compression-deflate",
+                        feature = "compression-brotli",
+                        feature = "compression-zstd"
+                    ))]
                     if _compression_static {
                         if let Some(p) =
                             compression_static::precompressed_variant(file_path, _headers).await
@@ -289,7 +303,14 @@ async fn get_composed_file_metadata<'a>(
                 }
             } else {
                 // Fallback pre-compressed variant check for the specific file
-                #[cfg(feature = "compression")]
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-deflate",
+                    feature = "compression-gzip",
+                    feature = "compression-deflate",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd"
+                ))]
                 if _compression_static {
                     if let Some(p) =
                         compression_static::precompressed_variant(file_path, _headers).await
@@ -313,7 +334,14 @@ async fn get_composed_file_metadata<'a>(
         }
         Err(err) => {
             // Pre-compressed variant check for the file not found
-            #[cfg(feature = "compression")]
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-deflate",
+                feature = "compression-gzip",
+                feature = "compression-deflate",
+                feature = "compression-brotli",
+                feature = "compression-zstd"
+            ))]
             if _compression_static {
                 if let Some(p) =
                     compression_static::precompressed_variant(file_path, _headers).await
@@ -333,7 +361,14 @@ async fn get_composed_file_metadata<'a>(
             let new_meta: Option<Metadata>;
             (file_path, new_meta) = suffix_file_html_metadata(file_path);
 
-            #[cfg(feature = "compression")]
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-deflate",
+                feature = "compression-gzip",
+                feature = "compression-deflate",
+                feature = "compression-brotli",
+                feature = "compression-zstd"
+            ))]
             match new_meta {
                 Some(new_meta) => {
                     return Ok(FileMetadata {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -26,10 +26,43 @@ pub mod fixtures {
         std::env::set_var("SERVER_CONFIG_FILE", f);
         let opts = Settings::get(false).unwrap();
 
+        #[cfg(not(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))]
+        let compression = false;
+        #[cfg(not(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))]
+        let compression_static = false;
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        ))]
+        let compression = opts.general.compression;
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        ))]
+        let compression_static = opts.general.compression_static;
+
         let req_handler_opts = RequestHandlerOpts {
             root_dir: opts.general.root,
-            compression: opts.general.compression,
-            compression_static: opts.general.compression_static,
+            compression,
+            compression_static,
             #[cfg(feature = "directory-listing")]
             dir_listing: opts.general.directory_listing,
             #[cfg(feature = "directory-listing")]

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -3,7 +3,14 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
-#[cfg(feature = "compression")]
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-deflate",
+    feature = "compression-gzip",
+    feature = "compression-deflate",
+    feature = "compression-brotli",
+    feature = "compression-zstd"
+))]
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
@@ -45,7 +52,14 @@ mod tests {
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
-            #[cfg(feature = "compression")]
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-deflate",
+                feature = "compression-gzip",
+                feature = "compression-deflate",
+                feature = "compression-brotli",
+                feature = "compression-zstd"
+            ))]
             compression_static: true,
             ignore_hidden_files: false,
             index_files: &[],
@@ -105,7 +119,14 @@ mod tests {
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             redirect_trailing_slash: true,
-            #[cfg(feature = "compression")]
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-deflate",
+                feature = "compression-gzip",
+                feature = "compression-deflate",
+                feature = "compression-brotli",
+                feature = "compression-zstd"
+            ))]
             compression_static: true,
             ignore_hidden_files: false,
             index_files: &[],

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -11,7 +11,14 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
-    #[cfg(feature = "compression")]
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-deflate",
+        feature = "compression-gzip",
+        feature = "compression-deflate",
+        feature = "compression-brotli",
+        feature = "compression-zstd"
+    ))]
     use static_web_server::compression;
 
     #[cfg(feature = "directory-listing")]
@@ -654,7 +661,14 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "compression")]
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-deflate",
+        feature = "compression-gzip",
+        feature = "compression-deflate",
+        feature = "compression-brotli",
+        feature = "compression-zstd"
+    ))]
     #[tokio::test]
     async fn handle_file_compressions() {
         let encodings = ["gzip", "deflate", "br", "zstd", "xyz"];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR fixes a build issue when SWS is used as a dependency and the Cargo `compression` feature is disabled completely or just some specific compression features are enabled.

Also, if **only** one compression feature is enabled (e.g. `compression-gzip`) then the preferred encoding gets re-evaluated and assigned to that compression feature format (e.g. `gzip`) but only if it was part of the `accept-encoding` request header value.

For example, now the following scenarios will work:

```toml
#....
[dependencies]
static-web-server = { version = "2.28.0", default-features = false }
# or
static-web-server = { version = "2.28.0", default-features = false, features = ["compression-brotli"] }
```

In addition, some logs are added/improved to reflect the changes.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #338

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
