### PR TITLE
Fix typo in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
         - Security / Vulnerability
         - Docker / Kubernetes
         - Build target (binary)
-        - Libary (crate)
+        - Library (crate)
         - Script installer
         - Documentation
         - Usability / User Experience


### PR DESCRIPTION
I assume that this issue scope is meant to be “Library” rather than “Libary.” This got me a bit confused when I filed a bug, took me a bit of time to figure out what was meant here.