### PR TITLE
Fix CORS does not work when used with Basic Auth

### DIFF
--- a/docs/content/features/cors.md
+++ b/docs/content/features/cors.md
@@ -26,7 +26,7 @@ The server also supports a list of [CORS allowed headers](https://developer.mozi
 This feature depends on `--cors-allow-origins` to be used along with this feature. It can be controlled by the string `-j, --cors-allow-headers` option or the equivalent [SERVER_CORS_ALLOW_HEADERS](../configuration/environment-variables.md#server_cors_allow_headers) env.
 
 !!! info "Tips"
-    - The default allowed headers value is `origin, content-type`.
+    - The default allowed headers value is `origin, content-type, authorization`.
     - The server also supports [preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) via the `OPTIONS` method. See [Preflighted requests in CORS](./http-methods.md#preflighted-requests-in-cors).
 
 Below is an example of how to CORS.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -245,7 +245,7 @@ impl RequestHandler {
 
             #[cfg(feature = "basic-auth")]
             // `Basic` HTTP Authorization Schema
-            if !self.opts.basic_auth.is_empty() {
+            if !self.opts.basic_auth.is_empty() && !method.is_options() {
                 if let Some((user_id, password)) = self.opts.basic_auth.split_once(':') {
                     if let Err(err) = basic_auth::check_request(headers, user_id, password) {
                         tracing::warn!("basic authentication failed {:?}", err);

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -135,7 +135,7 @@ pub struct General {
     #[arg(
         long,
         short = 'j',
-        default_value = "origin, content-type",
+        default_value = "origin, content-type, authorization",
         env = "SERVER_CORS_ALLOW_HEADERS"
     )]
     /// Specify an optional CORS list of allowed headers separated by commas. Default "origin, content-type". It requires `--cors-allow-origins` to be used along with.


### PR DESCRIPTION
This PR fixes #336 when CORS is used together with Basic Auth.

The `Authorization` header is now added to the `cors-allow-headers` list to work with the Basic Auth.
Also, the server will allow `OPTIONS` requests without an `Authorization` header since it is not required according to the [spec](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials).

Test cases will follow in a separate PR.
