### PR TITLE
Move health endpoint-related code into a separate file

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -106,33 +106,33 @@ pub struct RequestHandlerOpts {
 impl Default for RequestHandlerOpts {
     fn default() -> Self {
         Self {
-            root_dir: PathBuf::new(),
-            compression: false,
+            root_dir: PathBuf::from("./public"),
+            compression: true,
             compression_static: false,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
             #[cfg(feature = "directory-listing")]
-            dir_listing_order: 0, // name
+            dir_listing_order: 6, // unordered
             #[cfg(feature = "directory-listing")]
             dir_listing_format: DirListFmt::Html,
             cors: None,
             security_headers: false,
-            cache_control_headers: false,
-            page404: PathBuf::new(),
-            page50x: PathBuf::new(),
+            cache_control_headers: true,
+            page404: PathBuf::from("./404.html"),
+            page50x: PathBuf::from("./50x.html"),
             #[cfg(feature = "fallback-page")]
             page_fallback: Vec::new(),
             #[cfg(feature = "basic-auth")]
             basic_auth: String::new(),
-            index_files: Vec::new(),
+            index_files: vec!["index.html".into()],
             log_remote_address: false,
             redirect_trailing_slash: true,
-            ignore_hidden_files: true,
+            ignore_hidden_files: false,
             health: false,
             #[cfg(all(unix, feature = "experimental"))]
             experimental_metrics: false,
             maintenance_mode: false,
-            maintenance_mode_status: StatusCode::OK,
+            maintenance_mode_status: StatusCode::SERVICE_UNAVAILABLE,
             maintenance_mode_file: PathBuf::new(),
             advanced_opts: None,
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,7 +25,7 @@ use {crate::basic_auth, hyper::header::WWW_AUTHENTICATE};
 #[cfg(feature = "fallback-page")]
 use crate::fallback_page;
 
-#[cfg(feature = "experimental")]
+#[cfg(all(unix, feature = "experimental"))]
 use headers::{ContentType, HeaderMapExt};
 
 use crate::{

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -110,7 +110,7 @@ impl Default for RequestHandlerOpts {
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
             #[cfg(feature = "directory-listing")]
-            dir_listing_order: 0,   // name
+            dir_listing_order: 0, // name
             #[cfg(feature = "directory-listing")]
             dir_listing_format: DirListFmt::Html,
             cors: None,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -29,8 +29,7 @@ use crate::fallback_page;
 use headers::{ContentType, HeaderMapExt};
 
 use crate::{
-    control_headers, cors, custom_headers, error_page,
-    health::HealthHandler,
+    control_headers, cors, custom_headers, error_page, health,
     http_ext::MethodExt,
     maintenance_mode, redirects, rewrites, security_headers,
     settings::{file::RedirectsKind, Advanced},
@@ -189,7 +188,7 @@ impl RequestHandler {
         }
 
         async move {
-            if let Some(result) = HealthHandler::pre_process(&self.opts, req, &remote_addr_str) {
+            if let Some(result) = health::pre_process(&self.opts, req, &remote_addr_str) {
                 return result;
             }
 
@@ -200,7 +199,7 @@ impl RequestHandler {
             let mut uri_path = uri.path().to_owned();
             let uri_query = uri.query();
 
-            // Health requests aren't logged here but in HealthHandler.
+            // Health requests aren't logged here but in health module.
             tracing::info!(
                 "incoming request: method={} uri={}{}",
                 method,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,6 +25,9 @@ use {crate::basic_auth, hyper::header::WWW_AUTHENTICATE};
 #[cfg(feature = "fallback-page")]
 use crate::fallback_page;
 
+#[cfg(feature = "experimental")]
+use headers::{ContentType, HeaderMapExt};
+
 use crate::{
     control_headers, cors, custom_headers, error_page,
     health::HealthHandler,

--- a/src/health.rs
+++ b/src/health.rs
@@ -12,7 +12,8 @@ use hyper::{Body, Request, Response};
 use crate::{handler::RequestHandlerOpts, http_ext::MethodExt, server_info, Error};
 
 /// Initializes the health endpoint.
-pub fn init(enabled: bool) {
+pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
+    handler_opts.health = enabled;
     server_info!("health endpoint: enabled={enabled}");
 }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// This file is part of Static Web Server.
+// See https://static-web-server.net/ for more information
+// Copyright (C) 2019-present Jose Quintana <joseluisq.net>
+
+//! Module providing the health endpoint.
+//!
+
+use headers::{ContentType, HeaderMapExt};
+use hyper::{Body, Request, Response};
+
+use crate::{handler::RequestHandlerOpts, http_ext::MethodExt, server_info, Error};
+
+/// Encapsulates functionality required for the health handler.
+pub struct HealthHandler {}
+
+impl HealthHandler {
+    /// Initializes the health endpoint.
+    pub fn init(enabled: bool) {
+        server_info!("health endpoint: enabled={enabled}");
+    }
+
+    /// Handles health requests
+    pub fn pre_process(
+        opts: &RequestHandlerOpts,
+        req: &Request<Body>,
+        remote_addr_str: &str,
+    ) -> Option<Result<Response<Body>, Error>> {
+        if !opts.health {
+            return None;
+        }
+
+        let uri = req.uri();
+        if uri.path() != "/health" {
+            return None;
+        }
+
+        let method = req.method();
+        if !method.is_get() && !method.is_head() {
+            return None;
+        }
+
+        tracing::debug!(
+            "incoming request: method={} uri={}{}",
+            method,
+            uri,
+            remote_addr_str,
+        );
+
+        let body = if method.is_get() {
+            Body::from("OK")
+        } else {
+            Body::empty()
+        };
+
+        let mut resp = Response::new(body);
+        resp.headers_mut().typed_insert(ContentType::html());
+        Some(Ok(resp))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HealthHandler;
+    use hyper::{Body, Request};
+    use crate::handler::RequestHandlerOpts;
+
+    fn make_request(method: &str, uri: &str) -> Request<Body> {
+        Request::builder().method(method).uri(uri).body(Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn test_health_disabled() {
+        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
+            health: false,
+            ..Default::default()
+        }, &make_request("GET", "/health"), "").is_none());
+    }
+
+    #[test]
+    fn test_wrong_uri() {
+        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
+            health: true,
+            ..Default::default()
+        }, &make_request("GET", "/health2"), "").is_none());
+    }
+
+    #[test]
+    fn test_wrong_method() {
+        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
+            health: true,
+            ..Default::default()
+        }, &make_request("POST", "/health"), "").is_none());
+    }
+
+    #[test]
+    fn test_correct_request() {
+        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
+            health: true,
+            ..Default::default()
+        }, &make_request("GET", "/health"), "").is_some());
+    }
+}

--- a/src/health.rs
+++ b/src/health.rs
@@ -62,42 +62,66 @@ impl HealthHandler {
 #[cfg(test)]
 mod tests {
     use super::HealthHandler;
-    use hyper::{Body, Request};
     use crate::handler::RequestHandlerOpts;
+    use hyper::{Body, Request};
 
     fn make_request(method: &str, uri: &str) -> Request<Body> {
-        Request::builder().method(method).uri(uri).body(Body::empty()).unwrap()
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap()
     }
 
     #[test]
     fn test_health_disabled() {
-        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
-            health: false,
-            ..Default::default()
-        }, &make_request("GET", "/health"), "").is_none());
+        assert!(HealthHandler::pre_process(
+            &RequestHandlerOpts {
+                health: false,
+                ..Default::default()
+            },
+            &make_request("GET", "/health"),
+            ""
+        )
+        .is_none());
     }
 
     #[test]
     fn test_wrong_uri() {
-        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
-            health: true,
-            ..Default::default()
-        }, &make_request("GET", "/health2"), "").is_none());
+        assert!(HealthHandler::pre_process(
+            &RequestHandlerOpts {
+                health: true,
+                ..Default::default()
+            },
+            &make_request("GET", "/health2"),
+            ""
+        )
+        .is_none());
     }
 
     #[test]
     fn test_wrong_method() {
-        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
-            health: true,
-            ..Default::default()
-        }, &make_request("POST", "/health"), "").is_none());
+        assert!(HealthHandler::pre_process(
+            &RequestHandlerOpts {
+                health: true,
+                ..Default::default()
+            },
+            &make_request("POST", "/health"),
+            ""
+        )
+        .is_none());
     }
 
     #[test]
     fn test_correct_request() {
-        assert!(HealthHandler::pre_process(&RequestHandlerOpts {
-            health: true,
-            ..Default::default()
-        }, &make_request("GET", "/health"), "").is_some());
+        assert!(HealthHandler::pre_process(
+            &RequestHandlerOpts {
+                health: true,
+                ..Default::default()
+            },
+            &make_request("GET", "/health"),
+            ""
+        )
+        .is_some());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub mod error_page;
 #[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]
 pub mod fallback_page;
 pub mod handler;
-pub mod health;
+pub(crate) mod health;
 #[cfg(feature = "http2")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
 pub mod https_redirect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ pub mod error_page;
 #[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]
 pub mod fallback_page;
 pub mod handler;
+pub mod health;
 #[cfg(feature = "http2")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
 pub mod https_redirect;

--- a/src/server.rs
+++ b/src/server.rs
@@ -345,74 +345,75 @@ impl Server {
         }
         server_info!("index files: {}", general.index_files);
 
+        // Request handler options, to be filled
+        let mut handler_opts = RequestHandlerOpts {
+            root_dir,
+            compression,
+            compression_static,
+            #[cfg(feature = "directory-listing")]
+            dir_listing,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_order,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_format,
+            cors,
+            security_headers,
+            cache_control_headers,
+            page404: page404.clone(),
+            page50x: page50x.clone(),
+            #[cfg(feature = "fallback-page")]
+            page_fallback,
+            #[cfg(feature = "basic-auth")]
+            basic_auth,
+            log_remote_address,
+            redirect_trailing_slash,
+            ignore_hidden_files,
+            index_files,
+            advanced_opts,
+            ..Default::default()
+        };
+
         // Health endpoint option
-        health::init(general.health);
+        health::init(general.health, &mut handler_opts);
 
         // Metrics endpoint option (experimental)
         #[cfg(all(unix, feature = "experimental"))]
-        let experimental_metrics = general.experimental_metrics;
-        #[cfg(all(unix, feature = "experimental"))]
-        server_info!(
-            "metrics endpoint (experimental): enabled={}",
-            experimental_metrics
-        );
+        {
+            handler_opts.experimental_metrics = general.experimental_metrics;
+            server_info!(
+                "metrics endpoint (experimental): enabled={}",
+                handler_opts.experimental_metrics
+            );
 
-        #[cfg(all(unix, feature = "experimental"))]
-        if experimental_metrics {
-            prometheus::default_registry()
-                .register(Box::new(
-                    tokio_metrics_collector::default_runtime_collector(),
-                ))
-                .unwrap();
+            if handler_opts.experimental_metrics {
+                prometheus::default_registry()
+                    .register(Box::new(
+                        tokio_metrics_collector::default_runtime_collector(),
+                    ))
+                    .unwrap();
+            }
         }
 
         // Maintenance mode option
-        let maintenance_mode = general.maintenance_mode;
-        let maintenance_mode_status = general.maintenance_mode_status;
-        let maintenance_mode_file = general.maintenance_mode_file;
-        server_info!("maintenance mode: enabled={}", maintenance_mode);
+        handler_opts.maintenance_mode = general.maintenance_mode;
+        handler_opts.maintenance_mode_status = general.maintenance_mode_status;
+        handler_opts.maintenance_mode_file = general.maintenance_mode_file;
+        server_info!(
+            "maintenance mode: enabled={}",
+            handler_opts.maintenance_mode
+        );
         server_info!(
             "maintenance mode status: {}",
-            maintenance_mode_status.as_str()
+            handler_opts.maintenance_mode_status.as_str()
         );
         server_info!(
             "maintenance mode file: \"{}\"",
-            maintenance_mode_file.display()
+            handler_opts.maintenance_mode_file.display()
         );
 
         // Create a service router for Hyper
         let router_service = RouterService::new(RequestHandler {
-            opts: Arc::from(RequestHandlerOpts {
-                root_dir,
-                compression,
-                compression_static,
-                #[cfg(feature = "directory-listing")]
-                dir_listing,
-                #[cfg(feature = "directory-listing")]
-                dir_listing_order,
-                #[cfg(feature = "directory-listing")]
-                dir_listing_format,
-                cors,
-                security_headers,
-                cache_control_headers,
-                page404: page404.clone(),
-                page50x: page50x.clone(),
-                #[cfg(feature = "fallback-page")]
-                page_fallback,
-                #[cfg(feature = "basic-auth")]
-                basic_auth,
-                log_remote_address,
-                redirect_trailing_slash,
-                ignore_hidden_files,
-                index_files,
-                health: general.health,
-                #[cfg(all(unix, feature = "experimental"))]
-                experimental_metrics,
-                maintenance_mode,
-                maintenance_mode_status,
-                maintenance_mode_file,
-                advanced_opts,
-            }),
+            opts: Arc::from(handler_opts),
         });
 
         #[cfg(windows)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,7 @@ use {
     hyper::service::{make_service_fn, service_fn},
 };
 
-use crate::{cors, health::HealthHandler, helpers, Settings};
+use crate::{cors, health, helpers, Settings};
 use crate::{service::RouterService, Context, Result};
 
 /// Define a multi-threaded HTTP or HTTP/2 web server.
@@ -346,8 +346,7 @@ impl Server {
         server_info!("index files: {}", general.index_files);
 
         // Health endpoint option
-        let health = general.health;
-        HealthHandler::init(health);
+        health::init(general.health);
 
         // Metrics endpoint option (experimental)
         #[cfg(all(unix, feature = "experimental"))]
@@ -406,7 +405,7 @@ impl Server {
                 redirect_trailing_slash,
                 ignore_hidden_files,
                 index_files,
-                health,
+                health: general.health,
                 #[cfg(all(unix, feature = "experimental"))]
                 experimental_metrics,
                 maintenance_mode,

--- a/src/server.rs
+++ b/src/server.rs
@@ -345,7 +345,7 @@ impl Server {
         }
         server_info!("index files: {}", general.index_files);
 
-        // Request handler options, to be filled
+        // Request handler options, some settings will be filled in by modules
         let mut handler_opts = RequestHandlerOpts {
             root_dir,
             compression,

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,7 @@ use {
     hyper::service::{make_service_fn, service_fn},
 };
 
-use crate::{cors, helpers, Settings};
+use crate::{cors, health::HealthHandler, helpers, Settings};
 use crate::{service::RouterService, Context, Result};
 
 /// Define a multi-threaded HTTP or HTTP/2 web server.
@@ -347,7 +347,7 @@ impl Server {
 
         // Health endpoint option
         let health = general.health;
-        server_info!("health endpoint: enabled={}", health);
+        HealthHandler::init(health);
 
         // Metrics endpoint option (experimental)
         #[cfg(all(unix, feature = "experimental"))]


### PR DESCRIPTION
## Description

This creates a new module `health` responsible for the health endpoint. So far it handles the server initialization in the `init()` method and request processing in the `pre_process()` method. Ideally, handling of the health setting in CLI and config file will also be added here in future (not trivial given how parsing is tied to data structures).

## Related Issue
This is a tiny first step towards #342. 

## How Has This Been Tested?
Tests pass, and I’ve added a few new tests as well. I did not perform any functional testing at this point.