### PR TITLE
Move metrics endpoint-related code into a separate file

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -26,7 +26,7 @@ use {crate::basic_auth, hyper::header::WWW_AUTHENTICATE};
 use crate::fallback_page;
 
 #[cfg(all(unix, feature = "experimental"))]
-use headers::{ContentType, HeaderMapExt};
+use crate::metrics;
 
 use crate::{
     control_headers, cors, custom_headers, error_page, health,
@@ -163,8 +163,6 @@ impl RequestHandler {
         let redirect_trailing_slash = self.opts.redirect_trailing_slash;
         let compression_static = self.opts.compression_static;
         let ignore_hidden_files = self.opts.ignore_hidden_files;
-        #[cfg(all(unix, feature = "experimental"))]
-        let experimental_metrics = self.opts.experimental_metrics;
         let index_files: Vec<&str> = self.opts.index_files.iter().map(|s| s.as_str()).collect();
 
         let mut cors_headers: Option<HeaderMap> = None;
@@ -220,29 +218,8 @@ impl RequestHandler {
 
             // Metrics endpoint check
             #[cfg(all(unix, feature = "experimental"))]
-            let metrics_request = experimental_metrics
-                && uri_path == "/metrics"
-                && (method.is_get() || method.is_head());
-
-            #[cfg(all(unix, feature = "experimental"))]
-            if metrics_request {
-                use prometheus::Encoder;
-
-                let body = if method.is_get() {
-                    let encoder = prometheus::TextEncoder::new();
-                    let mut buffer = Vec::new();
-                    encoder
-                        .encode(&prometheus::default_registry().gather(), &mut buffer)
-                        .unwrap();
-                    let data = String::from_utf8(buffer).unwrap();
-                    Body::from(data)
-                } else {
-                    Body::empty()
-                };
-                let mut resp = Response::new(body);
-                resp.headers_mut()
-                    .typed_insert(ContentType::from(mime_guess::mime::TEXT_PLAIN_UTF_8));
-                return Ok(resp);
+            if let Some(result) = metrics::pre_process(&self.opts, req) {
+                return result;
             }
 
             // CORS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,8 @@ extern crate anyhow;
 extern crate serde;
 
 // Public modules
+#[macro_use]
+pub mod logger;
 #[cfg(feature = "basic-auth")]
 #[cfg_attr(docsrs, doc(cfg(feature = "basic-auth")))]
 pub mod basic_auth;
@@ -147,6 +149,7 @@ pub mod compression;
     )))
 )]
 pub mod compression_static;
+pub(crate) mod conditional_headers;
 pub mod control_headers;
 pub mod cors;
 pub mod custom_headers;
@@ -157,19 +160,18 @@ pub mod error_page;
 #[cfg(feature = "fallback-page")]
 #[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]
 pub mod fallback_page;
-pub mod handler;
-pub(crate) mod health;
-#[cfg(feature = "http2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-pub mod https_redirect;
-#[macro_use]
-pub mod logger;
-pub(crate) mod conditional_headers;
 pub(crate) mod file_path;
 pub(crate) mod file_response;
 pub(crate) mod file_stream;
+pub mod handler;
+pub(crate) mod health;
 pub(crate) mod http_ext;
+#[cfg(feature = "http2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+pub mod https_redirect;
 pub mod maintenance_mode;
+#[cfg(all(unix, feature = "experimental"))]
+pub(crate) mod metrics;
 pub mod redirects;
 pub mod rewrites;
 pub mod security_headers;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,32 +3,40 @@
 // See https://static-web-server.net/ for more information
 // Copyright (C) 2019-present Jose Quintana <joseluisq.net>
 
-//! Module providing the health endpoint.
+//! Module providing the experimental metrics endpoint.
 //!
 
 use headers::{ContentType, HeaderMapExt};
 use hyper::{Body, Request, Response};
+use prometheus::{default_registry, Encoder, TextEncoder};
 
 use crate::{handler::RequestHandlerOpts, http_ext::MethodExt, Error};
 
-/// Initializes the health endpoint.
+/// Initializes the metrics endpoint.
 pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
-    handler_opts.health = enabled;
-    server_info!("health endpoint: enabled={enabled}");
+    handler_opts.experimental_metrics = enabled;
+    server_info!("metrics endpoint (experimental): enabled={enabled}");
+
+    if enabled {
+        default_registry()
+            .register(Box::new(
+                tokio_metrics_collector::default_runtime_collector(),
+            ))
+            .unwrap();
+    }
 }
 
-/// Handles health requests
+/// Handles metrics requests
 pub fn pre_process(
     opts: &RequestHandlerOpts,
     req: &Request<Body>,
-    remote_addr_str: &str,
 ) -> Option<Result<Response<Body>, Error>> {
-    if !opts.health {
+    if !opts.experimental_metrics {
         return None;
     }
 
     let uri = req.uri();
-    if uri.path() != "/health" {
+    if uri.path() != "/metrics" {
         return None;
     }
 
@@ -37,21 +45,20 @@ pub fn pre_process(
         return None;
     }
 
-    tracing::debug!(
-        "incoming request: method={} uri={}{}",
-        method,
-        uri,
-        remote_addr_str,
-    );
-
     let body = if method.is_get() {
-        Body::from("OK")
+        let encoder = TextEncoder::new();
+        let mut buffer = Vec::new();
+        encoder
+            .encode(&default_registry().gather(), &mut buffer)
+            .unwrap();
+        let data = String::from_utf8(buffer).unwrap();
+        Body::from(data)
     } else {
         Body::empty()
     };
-
     let mut resp = Response::new(body);
-    resp.headers_mut().typed_insert(ContentType::html());
+    resp.headers_mut()
+        .typed_insert(ContentType::from(mime_guess::mime::TEXT_PLAIN_UTF_8));
     Some(Ok(resp))
 }
 
@@ -70,14 +77,13 @@ mod tests {
     }
 
     #[test]
-    fn test_health_disabled() {
+    fn test_metrics_disabled() {
         assert!(pre_process(
             &RequestHandlerOpts {
-                health: false,
+                experimental_metrics: false,
                 ..Default::default()
             },
-            &make_request("GET", "/health"),
-            ""
+            &make_request("GET", "/metrics")
         )
         .is_none());
     }
@@ -86,11 +92,10 @@ mod tests {
     fn test_wrong_uri() {
         assert!(pre_process(
             &RequestHandlerOpts {
-                health: true,
+                experimental_metrics: true,
                 ..Default::default()
             },
-            &make_request("GET", "/health2"),
-            ""
+            &make_request("GET", "/metrics2")
         )
         .is_none());
     }
@@ -99,11 +104,10 @@ mod tests {
     fn test_wrong_method() {
         assert!(pre_process(
             &RequestHandlerOpts {
-                health: true,
+                experimental_metrics: true,
                 ..Default::default()
             },
-            &make_request("POST", "/health"),
-            ""
+            &make_request("POST", "/metrics")
         )
         .is_none());
     }
@@ -112,11 +116,10 @@ mod tests {
     fn test_correct_request() {
         assert!(pre_process(
             &RequestHandlerOpts {
-                health: true,
+                experimental_metrics: true,
                 ..Default::default()
             },
-            &make_request("GET", "/health"),
-            ""
+            &make_request("GET", "/metrics")
         )
         .is_some());
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use tokio::sync::{watch::Receiver, Mutex};
 
 use crate::handler::{RequestHandler, RequestHandlerOpts};
+#[cfg(all(unix, feature = "experimental"))]
+use crate::metrics;
 #[cfg(any(unix, windows))]
 use crate::signals;
 
@@ -378,21 +380,7 @@ impl Server {
 
         // Metrics endpoint option (experimental)
         #[cfg(all(unix, feature = "experimental"))]
-        {
-            handler_opts.experimental_metrics = general.experimental_metrics;
-            server_info!(
-                "metrics endpoint (experimental): enabled={}",
-                handler_opts.experimental_metrics
-            );
-
-            if handler_opts.experimental_metrics {
-                prometheus::default_registry()
-                    .register(Box::new(
-                        tokio_metrics_collector::default_runtime_collector(),
-                    ))
-                    .unwrap();
-            }
-        }
+        metrics::init(general.experimental_metrics, &mut handler_opts);
 
         // Maintenance mode option
         handler_opts.maintenance_mode = general.maintenance_mode;


### PR DESCRIPTION
## Description

This is largely analogous to #344.

Loading logger module in lib.rs was moved up for sake of consistency: modules loaded after it will have macros like `server_info` imported implicitly, the ones loaded before won't. Further alphabetical rearranging of modules was performed by rustfmt.

## Related Issue
This is another step towards fixing #342.

## How Has This Been Tested?
Tests pass, and I’ve added a few new tests as well. Functional testing on Linux didn’t show any issues.