### PR TITLE
Move all of Basic authentication logic into basic_auth module

### DIFF
--- a/src/basic_auth.rs
+++ b/src/basic_auth.rs
@@ -10,7 +10,7 @@ use bcrypt::verify as bcrypt_verify;
 use headers::{authorization::Basic, Authorization, HeaderMap, HeaderMapExt};
 use hyper::{header::WWW_AUTHENTICATE, Body, Request, Response, StatusCode};
 
-use crate::{error_page, handler::RequestHandlerOpts, http_ext::MethodExt, server_info, Error};
+use crate::{error_page, handler::RequestHandlerOpts, http_ext::MethodExt, Error};
 
 /// Initializes `Basic` HTTP Authorization handling
 pub(crate) fn init(credentials: &str, handler_opts: &mut RequestHandlerOpts) {

--- a/src/basic_auth.rs
+++ b/src/basic_auth.rs
@@ -8,7 +8,64 @@
 
 use bcrypt::verify as bcrypt_verify;
 use headers::{authorization::Basic, Authorization, HeaderMap, HeaderMapExt};
-use hyper::StatusCode;
+use hyper::{header::WWW_AUTHENTICATE, Body, Request, Response, StatusCode};
+
+use crate::{error_page, handler::RequestHandlerOpts, http_ext::MethodExt, server_info, Error};
+
+/// Initializes `Basic` HTTP Authorization handling
+pub(crate) fn init(credentials: &str, handler_opts: &mut RequestHandlerOpts) {
+    credentials.trim().clone_into(&mut handler_opts.basic_auth);
+    server_info!(
+        "basic authentication: enabled={}",
+        !handler_opts.basic_auth.is_empty()
+    );
+}
+
+/// Handles `Basic` HTTP Authorization Schema
+pub(crate) fn pre_process(
+    opts: &RequestHandlerOpts,
+    req: &Request<Body>,
+) -> Option<Result<Response<Body>, Error>> {
+    if opts.basic_auth.is_empty() {
+        return None;
+    }
+
+    let method = req.method();
+    if method.is_options() {
+        return None;
+    }
+
+    let uri = req.uri();
+    if let Some((user_id, password)) = opts.basic_auth.split_once(':') {
+        let err = check_request(req.headers(), user_id, password).err()?;
+        tracing::warn!("basic authentication failed {:?}", err);
+        let mut result = error_page::error_response(
+            uri,
+            method,
+            &StatusCode::UNAUTHORIZED,
+            &opts.page404,
+            &opts.page50x,
+        );
+        if let Ok(ref mut resp) = result {
+            resp.headers_mut().insert(
+                WWW_AUTHENTICATE,
+                "Basic realm=\"Static Web Server\", charset=\"UTF-8\""
+                    .parse()
+                    .unwrap(),
+            );
+        }
+        Some(result)
+    } else {
+        tracing::error!("invalid basic authentication `user_id:password` pairs");
+        Some(error_page::error_response(
+            uri,
+            method,
+            &StatusCode::INTERNAL_SERVER_ERROR,
+            &opts.page404,
+            &opts.page50x,
+        ))
+    }
+}
 
 /// Check for a `Basic` HTTP Authorization Schema of an incoming request
 /// and uses `bcrypt` for password hashing verification.
@@ -33,8 +90,71 @@ pub fn check_request(headers: &HeaderMap, userid: &str, password: &str) -> Resul
 
 #[cfg(test)]
 mod tests {
-    use super::check_request;
+    use super::{check_request, pre_process};
+    use crate::{handler::RequestHandlerOpts, Error};
     use headers::HeaderMap;
+    use hyper::{header::WWW_AUTHENTICATE, Body, Request, Response, StatusCode};
+
+    fn make_request(method: &str, auth_header: &str) -> Request<Body> {
+        let mut builder = Request::builder();
+        if !auth_header.is_empty() {
+            builder = builder.header("Authorization", auth_header);
+        }
+        builder.method(method).uri("/").body(Body::empty()).unwrap()
+    }
+
+    fn is_401(result: Option<Result<Response<Body>, Error>>) -> bool {
+        if let Some(Ok(response)) = result {
+            response.status() == StatusCode::UNAUTHORIZED
+                && response.headers().get(WWW_AUTHENTICATE).is_some()
+        } else {
+            false
+        }
+    }
+
+    fn is_500(result: Option<Result<Response<Body>, Error>>) -> bool {
+        if let Some(Ok(response)) = result {
+            response.status() == StatusCode::INTERNAL_SERVER_ERROR
+        } else {
+            false
+        }
+    }
+
+    #[test]
+    fn test_auth_disabled() {
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "".into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_invalid_auth_configuration() {
+        assert!(is_500(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "xyz".into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )));
+    }
+
+    #[test]
+    fn test_options_request() {
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "jq:$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
+                    .into(),
+                ..Default::default()
+            },
+            &make_request("OPTIONS", "")
+        )
+        .is_none());
+    }
 
     #[test]
     fn test_valid_auth() {
@@ -46,12 +166,30 @@ mod tests {
             "$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
         )
         .is_ok());
+
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "jq:$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
+                    .into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )
+        .is_none());
     }
 
     #[test]
     fn test_invalid_auth_header() {
         let headers = HeaderMap::new();
         assert!(check_request(&headers, "jq", "").is_err());
+
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "jq:".into(),
+                ..Default::default()
+            },
+            &make_request("GET", "")
+        )));
     }
 
     #[test]
@@ -59,6 +197,14 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", "Basic anE6anE=".parse().unwrap());
         assert!(check_request(&headers, "xyz", "").is_err());
+
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "xyz:".into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )));
     }
 
     #[test]
@@ -74,6 +220,36 @@ mod tests {
         assert!(check_request(&headers, "jq", "password").is_err());
         assert!(check_request(&headers, "", "password").is_err());
         assert!(check_request(&headers, "jq", "").is_err());
+
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "abc:$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
+                    .into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )));
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "jq:password".into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )));
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: ":password".into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )));
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "jq:".into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic anE6anE=")
+        )));
     }
 
     #[test]
@@ -86,6 +262,15 @@ mod tests {
             "$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
         )
         .is_err());
+
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "jq:$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
+                    .into(),
+                ..Default::default()
+            },
+            &make_request("GET", "Basic xyz")
+        )));
     }
 
     #[test]
@@ -98,5 +283,14 @@ mod tests {
             "$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
         )
         .is_err());
+
+        assert!(is_401(pre_process(
+            &RequestHandlerOpts {
+                basic_auth: "jq:$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q"
+                    .into(),
+                ..Default::default()
+            },
+            &make_request("GET", "abcd")
+        )));
     }
 }

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -15,8 +15,6 @@ use headers::{
 use http::header;
 use std::collections::HashSet;
 
-use crate::server_info;
-
 /// It defines CORS instance.
 #[derive(Clone, Debug)]
 pub struct Cors {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -20,7 +20,7 @@ use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc
 use crate::compression;
 
 #[cfg(feature = "basic-auth")]
-use {crate::basic_auth, hyper::header::WWW_AUTHENTICATE};
+use crate::basic_auth;
 
 #[cfg(feature = "fallback-page")]
 use crate::fallback_page;
@@ -265,37 +265,10 @@ impl RequestHandler {
                 };
             }
 
-            #[cfg(feature = "basic-auth")]
             // `Basic` HTTP Authorization Schema
-            if !self.opts.basic_auth.is_empty() && !method.is_options() {
-                if let Some((user_id, password)) = self.opts.basic_auth.split_once(':') {
-                    if let Err(err) = basic_auth::check_request(headers, user_id, password) {
-                        tracing::warn!("basic authentication failed {:?}", err);
-                        let mut resp = error_page::error_response(
-                            uri,
-                            method,
-                            &StatusCode::UNAUTHORIZED,
-                            &self.opts.page404,
-                            &self.opts.page50x,
-                        )?;
-                        resp.headers_mut().insert(
-                            WWW_AUTHENTICATE,
-                            "Basic realm=\"Static Web Server\", charset=\"UTF-8\""
-                                .parse()
-                                .unwrap(),
-                        );
-                        return Ok(resp);
-                    }
-                } else {
-                    tracing::error!("invalid basic authentication `user_id:password` pairs");
-                    return error_page::error_response(
-                        uri,
-                        method,
-                        &StatusCode::INTERNAL_SERVER_ERROR,
-                        &self.opts.page404,
-                        &self.opts.page50x,
-                    );
-                }
+            #[cfg(feature = "basic-auth")]
+            if let Some(response) = basic_auth::pre_process(&self.opts, req) {
+                return response;
             }
 
             // Maintenance Mode


### PR DESCRIPTION
## Description
This establishes the same internal API for the `basic_auth` module as for `health` and `metrics` modules, the logic is now mostly self-contained in the module. While I hoped to avoid merge conflicts, there will be at least one merge conflict with #345 (importing `server_info` in `basic_auth.rs` will no longer be necessary).

## Related Issue
This is another step towards fixing #342.

## How Has This Been Tested?
Tests have been extended, so all the relevant scenarios should be tested automatically now. Functional testing on Linux didn’t show any issues.