### PR TITLE
Move all redirect handling logic into the redirects module

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -257,77 +257,13 @@ impl RequestHandler {
                 );
             }
 
+            // Redirects
+            if let Some(result) = redirects::pre_process(&self.opts, req) {
+                return result;
+            }
+
             // Advanced options
             if let Some(advanced) = &self.opts.advanced_opts {
-                // Redirects
-                let host = req
-                    .headers()
-                    .get(http::header::HOST)
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("");
-                let mut uri_host = uri.host().unwrap_or(host).to_owned();
-                if let Some(uri_port) = uri.port_u16() {
-                    uri_host.push_str(&format!(":{}", uri_port));
-                }
-                if let Some(redirects) = redirects::get_redirection(
-                    &uri_host,
-                    uri_path.clone().as_str(),
-                    advanced.redirects.as_deref(),
-                ) {
-                    // Redirects: Handle replacements (placeholders)
-                    if let Some(regex_caps) = redirects.source.captures(uri_path.as_str()) {
-                        let caps_range = 0..regex_caps.len();
-                        let caps = caps_range
-                            .clone()
-                            .filter_map(|i| regex_caps.get(i).map(|s| s.as_str()))
-                            .collect::<Vec<&str>>();
-
-                        let patterns = caps_range
-                            .map(|i| format!("${}", i))
-                            .collect::<Vec<String>>();
-
-                        let dest = redirects.destination.as_str();
-
-                        tracing::debug!("url redirects glob pattern: {:?}", patterns);
-                        tracing::debug!("url redirects regex equivalent: {}", redirects.source);
-                        tracing::debug!("url redirects glob pattern captures: {:?}", caps);
-                        tracing::debug!("url redirects glob pattern destination: {:?}", dest);
-
-                        if let Ok(ac) = aho_corasick::AhoCorasick::new(patterns) {
-                            if let Ok(dest) = ac.try_replace_all(dest, &caps) {
-                                tracing::debug!(
-                                    "url redirects glob pattern destination replaced: {:?}",
-                                    dest
-                                );
-                                uri_path = dest;
-                            }
-                        }
-                    }
-
-                    match HeaderValue::from_str(uri_path.as_str()) {
-                        Ok(loc) => {
-                            let mut resp = Response::new(Body::empty());
-                            resp.headers_mut().insert(hyper::header::LOCATION, loc);
-                            *resp.status_mut() = redirects.kind;
-                            tracing::trace!(
-                                "uri matches redirects glob pattern, redirecting with status '{}'",
-                                redirects.kind
-                            );
-                            return Ok(resp);
-                        }
-                        Err(err) => {
-                            tracing::error!("invalid header value from current uri: {:?}", err);
-                            return error_page::error_response(
-                                uri,
-                                method,
-                                &StatusCode::INTERNAL_SERVER_ERROR,
-                                &self.opts.page404,
-                                &self.opts.page50x,
-                            );
-                        }
-                    };
-                }
-
                 // Rewrites
                 if let Some(rewrite) = rewrites::rewrite_uri_path(
                     uri_path.clone().as_str(),

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -44,7 +44,7 @@ pub(crate) fn pre_process(
         let caps_range = 0..regex_caps.len();
         let caps = caps_range
             .clone()
-            .filter_map(|i| regex_caps.get(i).map(|s| s.as_str()))
+            .map(|i| regex_caps.get(i).map(|s| s.as_str()).unwrap_or(""))
             .collect::<Vec<&str>>();
 
         let patterns = caps_range
@@ -171,8 +171,8 @@ mod tests {
             },
             Redirects {
                 host: Some("example.info".into()),
-                source: Regex::new(r"/(source3)/(.*)").unwrap(),
-                destination: "/destination3/$1/$2".into(),
+                source: Regex::new(r"/(prefix/)?(source3)/(.*)").unwrap(),
+                destination: "/destination3/$2/$3".into(),
                 kind: StatusCode::MOVED_PERMANENTLY,
             },
         ]

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -6,7 +6,106 @@
 //! Redirection module to handle config redirect URLs with pattern matching support.
 //!
 
-use crate::settings::Redirects;
+use headers::HeaderValue;
+use hyper::{Body, Request, Response, StatusCode};
+
+use crate::{error_page, handler::RequestHandlerOpts, settings::Redirects, Error};
+
+pub(crate) fn pre_process(
+    opts: &RequestHandlerOpts,
+    req: &Request<Body>,
+) -> Option<Result<Response<Body>, Error>> {
+    let redirects = opts.advanced_opts.as_ref()?.redirects.as_deref()?;
+
+    let uri = req.uri();
+    let uri_path = uri.path();
+    let host = req
+        .headers()
+        .get(http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let mut uri_host = uri.host().unwrap_or(host).to_owned();
+    if let Some(uri_port) = uri.port_u16() {
+        uri_host.push_str(&format!(":{}", uri_port));
+    }
+    if let Some(matched) = get_redirection(&uri_host, uri_path, Some(redirects)) {
+        // Redirects: Handle replacements (placeholders)
+        let regex_caps = if let Some(regex_caps) = matched.source.captures(uri_path) {
+            regex_caps
+        } else {
+            return handle_error(
+                "unexpected regex failure",
+                "extracting captures failed",
+                opts,
+                req,
+            );
+        };
+
+        let caps_range = 0..regex_caps.len();
+        let caps = caps_range
+            .clone()
+            .filter_map(|i| regex_caps.get(i).map(|s| s.as_str()))
+            .collect::<Vec<&str>>();
+
+        let patterns = caps_range
+            .map(|i| format!("${}", i))
+            .collect::<Vec<String>>();
+
+        let dest = &matched.destination;
+
+        tracing::debug!("url redirects glob pattern: {:?}", patterns);
+        tracing::debug!("url redirects regex equivalent: {}", matched.source);
+        tracing::debug!("url redirects glob pattern captures: {:?}", caps);
+        tracing::debug!("url redirects glob pattern destination: {:?}", dest);
+
+        let ac = match aho_corasick::AhoCorasick::new(patterns) {
+            Ok(ac) => ac,
+            Err(err) => {
+                return handle_error("failed creating Aho-Corasick matcher", err, opts, req)
+            }
+        };
+        let dest = match ac.try_replace_all(dest, &caps) {
+            Ok(dest) => dest.to_string(),
+            Err(err) => return handle_error("failed replacing captures", err, opts, req),
+        };
+
+        tracing::debug!(
+            "url redirects glob pattern destination replaced: {:?}",
+            dest
+        );
+        match HeaderValue::from_str(&dest) {
+            Ok(loc) => {
+                let mut resp = Response::new(Body::empty());
+                resp.headers_mut().insert(hyper::header::LOCATION, loc);
+                *resp.status_mut() = matched.kind;
+                tracing::trace!(
+                    "uri matches redirects glob pattern, redirecting with status '{}'",
+                    matched.kind
+                );
+                Some(Ok(resp))
+            }
+            Err(err) => handle_error("invalid header value from current uri", err, opts, req),
+        }
+    } else {
+        None
+    }
+}
+
+fn handle_error<E: std::fmt::Display>(
+    msg: &str,
+    err: E,
+    opts: &RequestHandlerOpts,
+    req: &Request<Body>,
+) -> Option<Result<Response<Body>, Error>> {
+    tracing::error!("{msg}: {err}");
+    Some(error_page::error_response(
+        req.uri(),
+        req.method(),
+        &StatusCode::INTERNAL_SERVER_ERROR,
+        &opts.page404,
+        &opts.page50x,
+    ))
+}
 
 /// It returns a redirect's destination path and status code if the current request uri
 /// matches against the provided redirect's array.
@@ -35,4 +134,155 @@ pub fn get_redirection<'a>(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pre_process;
+    use crate::{
+        handler::RequestHandlerOpts,
+        settings::{Advanced, Redirects},
+        Error,
+    };
+    use hyper::{Body, Request, Response, StatusCode};
+    use regex::Regex;
+
+    fn make_request(host: &str, uri: &str) -> Request<Body> {
+        let mut builder = Request::builder();
+        if !host.is_empty() {
+            builder = builder.header("Host", host);
+        }
+        builder.method("GET").uri(uri).body(Body::empty()).unwrap()
+    }
+
+    fn get_redirects() -> Vec<Redirects> {
+        vec![
+            Redirects {
+                host: None,
+                source: Regex::new(r"/source1$").unwrap(),
+                destination: "/destination1".into(),
+                kind: StatusCode::FOUND,
+            },
+            Redirects {
+                host: Some("example.com".into()),
+                source: Regex::new(r"/source2$").unwrap(),
+                destination: "/destination2".into(),
+                kind: StatusCode::MOVED_PERMANENTLY,
+            },
+            Redirects {
+                host: Some("example.info".into()),
+                source: Regex::new(r"/(source3)/(.*)").unwrap(),
+                destination: "/destination3/$1/$2".into(),
+                kind: StatusCode::MOVED_PERMANENTLY,
+            },
+        ]
+    }
+
+    fn is_redirect(result: Option<Result<Response<Body>, Error>>) -> Option<(StatusCode, String)> {
+        if let Some(Ok(response)) = result {
+            let location = response.headers().get("Location")?.to_str().unwrap().into();
+            Some((response.status(), location))
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn test_no_redirects() {
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: None,
+                ..Default::default()
+            },
+            &make_request("", "/")
+        )
+        .is_none());
+
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: Some(Advanced {
+                    redirects: None,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &make_request("", "/")
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_no_match() {
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: Some(Advanced {
+                    redirects: Some(get_redirects()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &make_request("example.com", "/source2/whatever")
+        )
+        .is_none());
+
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: Some(Advanced {
+                    redirects: Some(get_redirects()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &make_request("", "/source2")
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_match() {
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("", "/source1")
+            )),
+            Some((StatusCode::FOUND, "/destination1".into()))
+        );
+
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("example.com", "/source2")
+            )),
+            Some((StatusCode::MOVED_PERMANENTLY, "/destination2".into()))
+        );
+
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("example.info", "/source3/whatever")
+            )),
+            Some((
+                StatusCode::MOVED_PERMANENTLY,
+                "/destination3/source3/whatever".into()
+            ))
+        );
+    }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -64,6 +64,7 @@ pub struct VirtualHosts {
 }
 
 /// The `advanced` file options.
+#[derive(Default)]
 pub struct Advanced {
     /// Headers list.
     pub headers: Option<Vec<Headers>>,


### PR DESCRIPTION
## Description
This establishes the same internal API for the `redirects` module as for `health` and `metrics` modules, the logic is now mostly self-contained in the module. The logic changed somewhat. On the one hand, `uri.path()` is no longer being cloned – cloning isn’t necessary unless there is an actual match. On the other hand, this addresses #347 for this code.

I would have changed `check_redirection()` signature to the following:

```rust
pub fn get_redirection<'a, 'b>(
    uri_host: &str,
    uri_path: &'b str,
    redirects_opts: &'a [Redirects],
) -> Option<(&'a Redirects, Captures<'b>)> {
```

But that’s a public function, so it would be a breaking change…

## Related Issue
This is another step towards fixing #342, also addresses one half of #347.

## How Has This Been Tested?
Existing integration tests pass, additional unit tests have been added for better test coverage.