### PR TITLE
Move most of CORS-related code into the cors module

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,7 +6,7 @@
 //! Request handler module intended to manage incoming HTTP requests.
 //!
 
-use headers::{HeaderMap, HeaderValue};
+use headers::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
 use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc};
 
@@ -165,8 +165,6 @@ impl RequestHandler {
         let ignore_hidden_files = self.opts.ignore_hidden_files;
         let index_files: Vec<&str> = self.opts.index_files.iter().map(|s| s.as_str()).collect();
 
-        let mut cors_headers: Option<HeaderMap> = None;
-
         // Log request information with its remote address if available
         let mut remote_addr_str = String::new();
         if log_remote_addr {
@@ -223,23 +221,8 @@ impl RequestHandler {
             }
 
             // CORS
-            if let Some(cors) = &self.opts.cors {
-                match cors.check_request(method, headers) {
-                    Ok((headers, state)) => {
-                        tracing::debug!("cors state: {:?}", state);
-                        cors_headers = Some(headers);
-                    }
-                    Err(err) => {
-                        tracing::error!("cors error kind: {:?}", err);
-                        return error_page::error_response(
-                            uri,
-                            method,
-                            &StatusCode::FORBIDDEN,
-                            &self.opts.page404,
-                            &self.opts.page50x,
-                        );
-                    }
-                };
+            if let Some(result) = cors::pre_process(&self.opts, req) {
+                return result;
             }
 
             // `Basic` HTTP Authorization Schema
@@ -424,14 +407,7 @@ impl RequestHandler {
                     let mut resp = result.resp;
 
                     // Append CORS headers if they are present
-                    if let Some(cors_headers) = cors_headers {
-                        if !cors_headers.is_empty() {
-                            for (k, v) in cors_headers.iter() {
-                                resp.headers_mut().insert(k, v.to_owned());
-                            }
-                            resp.headers_mut().remove(http::header::ALLOW);
-                        }
-                    }
+                    cors::post_process(&self.opts, req, &mut resp);
 
                     // Compression content encoding varies so use a `Vary` header
                     #[cfg(any(
@@ -505,14 +481,7 @@ impl RequestHandler {
                         let mut resp = fallback_page::fallback_response(&self.opts.page_fallback);
 
                         // Append CORS headers if they are present
-                        if let Some(cors_headers) = cors_headers {
-                            if !cors_headers.is_empty() {
-                                for (k, v) in cors_headers.iter() {
-                                    resp.headers_mut().insert(k, v.to_owned());
-                                }
-                                resp.headers_mut().remove(http::header::ALLOW);
-                            }
-                        }
+                        cors::post_process(&self.opts, req, &mut resp);
 
                         // Compression content encoding varies so use a `Vary` header
                         #[cfg(any(

--- a/src/server.rs
+++ b/src/server.rs
@@ -304,13 +304,6 @@ impl Server {
         let cache_control_headers = general.cache_control_headers;
         server_info!("cache control headers: enabled={}", cache_control_headers);
 
-        // CORS option
-        let cors = cors::new(
-            general.cors_allow_origins.trim(),
-            general.cors_allow_headers.trim(),
-            general.cors_expose_headers.trim(),
-        );
-
         // Log remote address option
         let log_remote_address = general.log_remote_address;
         server_info!("log remote address: enabled={}", log_remote_address);
@@ -352,7 +345,6 @@ impl Server {
             dir_listing_order,
             #[cfg(feature = "directory-listing")]
             dir_listing_format,
-            cors,
             security_headers,
             cache_control_headers,
             page404: page404.clone(),
@@ -373,6 +365,14 @@ impl Server {
         // Metrics endpoint option (experimental)
         #[cfg(all(unix, feature = "experimental"))]
         metrics::init(general.experimental_metrics, &mut handler_opts);
+
+        // CORS option
+        cors::init(
+            &general.cors_allow_origins,
+            &general.cors_allow_headers,
+            &general.cors_expose_headers,
+            &mut handler_opts,
+        );
 
         // `Basic` HTTP Authentication Schema option
         #[cfg(feature = "basic-auth")]


### PR DESCRIPTION
## Description
This establishes the same internal API for CORS handling as for `health` and `metrics`. The downside is that CORS processing has to run twice, I don’t see a good way to share state between `pre_process()` and `post_process()` at this point. Maybe with the future middleware approach this will be possible.

I also noticed something I consider a bug: error responses such as 404 only get CORS headers if there is a fallback page. It should be possible to retrieve error responses across domains boundaries as well, so that a web app can distinguish between a 404 and 503 error for example. Let me know if you want me to fix this as part of this PR (it’s a trivial addition) or a separate issue/PR.

## Related Issue
This is another step towards fixing #342.

## How Has This Been Tested?
Existing integration tests pass, additional unit tests have been added for better test coverage. Functional testing on Linux looks fine.