### PR TITLE
Move most of maintenance mode logic into maintenance_mode module

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -249,12 +249,8 @@ impl RequestHandler {
             }
 
             // Maintenance Mode
-            if self.opts.maintenance_mode {
-                return maintenance_mode::get_response(
-                    method,
-                    &self.opts.maintenance_mode_status,
-                    &self.opts.maintenance_mode_file,
-                );
+            if let Some(response) = maintenance_mode::pre_process(&self.opts, req) {
+                return response;
             }
 
             // Advanced options

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,7 +29,7 @@ use {
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;
 
-use crate::{cors, health, helpers, Settings};
+use crate::{cors, health, helpers, maintenance_mode, Settings};
 use crate::{service::RouterService, Context, Result};
 
 /// Define a multi-threaded HTTP or HTTP/2 web server.
@@ -379,20 +379,11 @@ impl Server {
         basic_auth::init(&general.basic_auth, &mut handler_opts);
 
         // Maintenance mode option
-        handler_opts.maintenance_mode = general.maintenance_mode;
-        handler_opts.maintenance_mode_status = general.maintenance_mode_status;
-        handler_opts.maintenance_mode_file = general.maintenance_mode_file;
-        server_info!(
-            "maintenance mode: enabled={}",
-            handler_opts.maintenance_mode
-        );
-        server_info!(
-            "maintenance mode status: {}",
-            handler_opts.maintenance_mode_status.as_str()
-        );
-        server_info!(
-            "maintenance mode file: \"{}\"",
-            handler_opts.maintenance_mode_file.display()
+        maintenance_mode::init(
+            general.maintenance_mode,
+            general.maintenance_mode_status,
+            general.maintenance_mode_file,
+            &mut handler_opts,
         );
 
         // Create a service router for Hyper


### PR DESCRIPTION
## Description
This establishes the same internal API for maintenance mode as for `health` and `metrics`. While at it, I adjusted `get_response()` to make producing `body_content` more straightforward – no long a mutable variable that might or might not be overwritten but two straightforward branches. Side-effect: empty maintenance mode file will no longer result in default message. IMHO this makes sense because a) someone might actually show an empty message and b) the message about falling back to default message is only logged when the maintenance mode file doesn’t exist, not when it is empty.

I also changed `DEFAULT_BODY_CONTENT` because the old message is IMHO grammatically incorrect. It should be either “server is under maintenance” or “server is in maintenance mode” (I went with the latter).

## Related Issue
This is another step towards fixing #342.

## How Has This Been Tested?
I added some rudimentary unit tests. Functional testing on Linux was also successful.