### PR TITLE
Move various code related to header handling to the respective modules

### DIFF
--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -7,7 +7,9 @@
 //! for incoming requests based on a set of file types.
 //!
 
-use hyper::{Body, Response};
+use hyper::{Body, Request, Response};
+
+use crate::handler::RequestHandlerOpts;
 
 // Cache-Control `max-age` variants
 const MAX_AGE_ONE_HOUR: u64 = 60 * 60;
@@ -21,6 +23,22 @@ const CACHE_EXT_ONE_YEAR: [&str; 32] = [
     "map", "mjs", "mp3", "mp4", "ogg", "ogv", "pdf", "png", "rar", "rtf", "tar", "tgz", "wav",
     "weba", "webm", "webp", "woff", "woff2", "zip",
 ];
+
+pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
+    handler_opts.cache_control_headers = enabled;
+    server_info!("cache control headers: enabled={enabled}");
+}
+
+/// Appends `Cache-Control` header to a response if necessary
+pub(crate) fn post_process(
+    opts: &RequestHandlerOpts,
+    req: &Request<Body>,
+    resp: &mut Response<Body>,
+) {
+    if opts.cache_control_headers {
+        append_headers(req.uri().path(), resp);
+    }
+}
 
 /// It appends a `Cache-Control` header to a response if that one is part of a set of file types.
 pub fn append_headers(uri: &str, resp: &mut Response<Body>) {

--- a/src/custom_headers.rs
+++ b/src/custom_headers.rs
@@ -6,10 +6,27 @@
 //! Module to append custom HTTP headers via TOML config file.
 //!
 
-use hyper::{Body, Response};
+use hyper::{Body, Request, Response};
 use std::{ffi::OsStr, path::PathBuf};
 
-use crate::settings::Headers;
+use crate::{handler::RequestHandlerOpts, settings::Headers};
+
+/// Appends custom HTTP headers to a response if necessary
+pub(crate) fn post_process(
+    opts: &RequestHandlerOpts,
+    req: &Request<Body>,
+    resp: &mut Response<Body>,
+    file_path: Option<&PathBuf>,
+) {
+    if let Some(advanced) = &opts.advanced_opts {
+        append_headers(
+            req.uri().path(),
+            advanced.headers.as_deref(),
+            resp,
+            file_path,
+        )
+    }
+}
 
 /// Append custom HTTP headers to current response.
 pub fn append_headers(

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -473,24 +473,18 @@ impl RequestHandler {
                     }
 
                     // Append `Cache-Control` headers for web assets
-                    if self.opts.cache_control_headers {
-                        control_headers::append_headers(uri_path, &mut resp);
-                    }
+                    control_headers::post_process(&self.opts, req, &mut resp);
 
                     // Append security headers
-                    if self.opts.security_headers {
-                        security_headers::append_headers(&mut resp);
-                    }
+                    security_headers::post_process(&self.opts, req, &mut resp);
 
                     // Add/update custom headers
-                    if let Some(advanced) = &self.opts.advanced_opts {
-                        custom_headers::append_headers(
-                            uri_path,
-                            advanced.headers.as_deref(),
-                            &mut resp,
-                            Some(&result.file_path),
-                        )
-                    }
+                    custom_headers::post_process(
+                        &self.opts,
+                        req,
+                        &mut resp,
+                        Some(&result.file_path),
+                    );
 
                     Ok(resp)
                 }
@@ -554,24 +548,13 @@ impl RequestHandler {
                         }
 
                         // Append `Cache-Control` headers for web assets
-                        if self.opts.cache_control_headers {
-                            control_headers::append_headers(uri_path, &mut resp);
-                        }
+                        control_headers::post_process(&self.opts, req, &mut resp);
 
                         // Append security headers
-                        if self.opts.security_headers {
-                            security_headers::append_headers(&mut resp);
-                        }
+                        security_headers::post_process(&self.opts, req, &mut resp);
 
                         // Add/update custom headers
-                        if let Some(advanced) = &self.opts.advanced_opts {
-                            custom_headers::append_headers(
-                                uri_path,
-                                advanced.headers.as_deref(),
-                                &mut resp,
-                                None,
-                            )
-                        }
+                        custom_headers::post_process(&self.opts, req, &mut resp, None);
 
                         return Ok(resp);
                     }

--- a/src/security_headers.rs
+++ b/src/security_headers.rs
@@ -9,7 +9,25 @@
 use http::header::{
     CONTENT_SECURITY_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
 };
-use hyper::{Body, Response};
+use hyper::{Body, Request, Response};
+
+use crate::handler::RequestHandlerOpts;
+
+pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
+    handler_opts.security_headers = enabled;
+    server_info!("security headers: enabled={enabled}");
+}
+
+/// Appends security headers to a response if necessary
+pub(crate) fn post_process(
+    opts: &RequestHandlerOpts,
+    _req: &Request<Body>,
+    resp: &mut Response<Body>,
+) {
+    if opts.security_headers {
+        append_headers(resp);
+    }
+}
 
 /// It appends security headers like `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2 years max-age),
 ///`X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'self'`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,7 +29,7 @@ use {
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;
 
-use crate::{cors, health, helpers, Settings};
+use crate::{control_headers, cors, health, helpers, security_headers, Settings};
 use crate::{service::RouterService, Context, Result};
 
 /// Define a multi-threaded HTTP or HTTP/2 web server.
@@ -218,10 +218,6 @@ impl Server {
             );
         }
 
-        // Security Headers option
-        let security_headers = general.security_headers;
-        server_info!("security headers: enabled={}", security_headers);
-
         #[cfg(not(any(
             feature = "compression",
             feature = "compression-deflate",
@@ -300,10 +296,6 @@ impl Server {
         #[cfg(feature = "directory-listing")]
         server_info!("directory listing format: {:?}", dir_listing_format);
 
-        // Cache control headers option
-        let cache_control_headers = general.cache_control_headers;
-        server_info!("cache control headers: enabled={}", cache_control_headers);
-
         // CORS option
         let cors = cors::new(
             general.cors_allow_origins.trim(),
@@ -353,8 +345,6 @@ impl Server {
             #[cfg(feature = "directory-listing")]
             dir_listing_format,
             cors,
-            security_headers,
-            cache_control_headers,
             page404: page404.clone(),
             page50x: page50x.clone(),
             #[cfg(feature = "fallback-page")]
@@ -394,6 +384,12 @@ impl Server {
             "maintenance mode file: \"{}\"",
             handler_opts.maintenance_mode_file.display()
         );
+
+        // Cache control headers option
+        control_headers::init(general.cache_control_headers, &mut handler_opts);
+
+        // Security Headers option
+        security_headers::init(general.security_headers, &mut handler_opts);
 
         // Create a service router for Hyper
         let router_service = RouterService::new(RequestHandler {


### PR DESCRIPTION
## Description
This adds standard `post_process()` call to various header handling modules, similar to the internal API established in #349. Merely a tiny bit of code shuffling.

## Related Issue
This is another step towards fixing #342.

## How Has This Been Tested?
Existing tests pass. Functional testing on Linux looks fine.