### PR TITLE
Move all rewrite handling logic into the rewrites module

### DIFF
--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -101,7 +101,7 @@ pub(crate) fn handle_error(
     opts: &RequestHandlerOpts,
     req: &Request<Body>,
 ) -> Option<Result<Response<Body>, Error>> {
-    tracing::error!("{err}");
+    tracing::error!("{err:?}");
     Some(error_page::error_response(
         req.uri(),
         req.method(),

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -8,9 +8,11 @@
 
 use headers::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
+use regex::Regex;
 
 use crate::{error_page, handler::RequestHandlerOpts, settings::Redirects, Error};
 
+/// Applies redirect rules to a request if necessary.
 pub(crate) fn pre_process(
     opts: &RequestHandlerOpts,
     req: &Request<Body>,
@@ -28,76 +30,78 @@ pub(crate) fn pre_process(
     if let Some(uri_port) = uri.port_u16() {
         uri_host.push_str(&format!(":{}", uri_port));
     }
-    if let Some(matched) = get_redirection(&uri_host, uri_path, Some(redirects)) {
-        // Redirects: Handle replacements (placeholders)
-        let regex_caps = if let Some(regex_caps) = matched.source.captures(uri_path) {
-            regex_caps
-        } else {
-            return handle_error(
-                "unexpected regex failure",
-                "extracting captures failed",
-                opts,
-                req,
+    let matched = get_redirection(&uri_host, uri_path, Some(redirects))?;
+    let dest = match replace_placeholders(uri_path, &matched.source, &matched.destination) {
+        Ok(dest) => dest,
+        Err(err) => return handle_error(err, opts, req),
+    };
+
+    match HeaderValue::from_str(&dest) {
+        Ok(loc) => {
+            let mut resp = Response::new(Body::empty());
+            resp.headers_mut().insert(hyper::header::LOCATION, loc);
+            *resp.status_mut() = matched.kind;
+            tracing::trace!(
+                "uri matches redirects glob pattern, redirecting with status '{}'",
+                matched.kind
             );
-        };
-
-        let caps_range = 0..regex_caps.len();
-        let caps = caps_range
-            .clone()
-            .map(|i| regex_caps.get(i).map(|s| s.as_str()).unwrap_or(""))
-            .collect::<Vec<&str>>();
-
-        let patterns = caps_range
-            .map(|i| format!("${}", i))
-            .collect::<Vec<String>>();
-
-        let dest = &matched.destination;
-
-        tracing::debug!("url redirects glob pattern: {:?}", patterns);
-        tracing::debug!("url redirects regex equivalent: {}", matched.source);
-        tracing::debug!("url redirects glob pattern captures: {:?}", caps);
-        tracing::debug!("url redirects glob pattern destination: {:?}", dest);
-
-        let ac = match aho_corasick::AhoCorasick::new(patterns) {
-            Ok(ac) => ac,
-            Err(err) => {
-                return handle_error("failed creating Aho-Corasick matcher", err, opts, req)
-            }
-        };
-        let dest = match ac.try_replace_all(dest, &caps) {
-            Ok(dest) => dest.to_string(),
-            Err(err) => return handle_error("failed replacing captures", err, opts, req),
-        };
-
-        tracing::debug!(
-            "url redirects glob pattern destination replaced: {:?}",
-            dest
-        );
-        match HeaderValue::from_str(&dest) {
-            Ok(loc) => {
-                let mut resp = Response::new(Body::empty());
-                resp.headers_mut().insert(hyper::header::LOCATION, loc);
-                *resp.status_mut() = matched.kind;
-                tracing::trace!(
-                    "uri matches redirects glob pattern, redirecting with status '{}'",
-                    matched.kind
-                );
-                Some(Ok(resp))
-            }
-            Err(err) => handle_error("invalid header value from current uri", err, opts, req),
+            Some(Ok(resp))
         }
-    } else {
-        None
+        Err(err) => handle_error(
+            Error::new(err).context("invalid header value from current uri"),
+            opts,
+            req,
+        ),
     }
 }
 
-fn handle_error<E: std::fmt::Display>(
-    msg: &str,
-    err: E,
+/// Replaces placeholders in the destination URI by matching capture groups from the original URI.
+pub(crate) fn replace_placeholders(
+    orig_uri: &str,
+    regex: &Regex,
+    dest_uri: &str,
+) -> Result<String, Error> {
+    let regex_caps = if let Some(regex_caps) = regex.captures(orig_uri) {
+        regex_caps
+    } else {
+        return Err(Error::msg("regex didn't match, extracting captures failed"));
+    };
+
+    let caps_range = 0..regex_caps.len();
+    let caps = caps_range
+        .clone()
+        .map(|i| regex_caps.get(i).map(|s| s.as_str()).unwrap_or(""))
+        .collect::<Vec<&str>>();
+
+    let patterns = caps_range
+        .map(|i| format!("${}", i))
+        .collect::<Vec<String>>();
+
+    tracing::debug!("url redirects/rewrites glob pattern: {patterns:?}");
+    tracing::debug!("url redirects/rewrites regex equivalent: {regex}");
+    tracing::debug!("url redirects/rewrites glob pattern captures: {caps:?}");
+    tracing::debug!("url redirects/rewrites glob pattern destination: {dest_uri:?}");
+
+    let ac = match aho_corasick::AhoCorasick::new(patterns) {
+        Ok(ac) => ac,
+        Err(err) => return Err(Error::new(err).context("failed creating Aho-Corasick matcher")),
+    };
+    match ac.try_replace_all(dest_uri, &caps) {
+        Ok(dest) => {
+            tracing::debug!("url redirects/rewrites glob pattern destination replaced: {dest:?}");
+            Ok(dest.to_string())
+        }
+        Err(err) => Err(Error::new(err).context("failed replacing captures")),
+    }
+}
+
+/// Logs error and produces an Internal Server Error response.
+pub(crate) fn handle_error(
+    err: Error,
     opts: &RequestHandlerOpts,
     req: &Request<Body>,
 ) -> Option<Result<Response<Body>, Error>> {
-    tracing::error!("{msg}: {err}");
+    tracing::error!("{err}");
     Some(error_page::error_response(
         req.uri(),
         req.method(),

--- a/src/rewrites.rs
+++ b/src/rewrites.rs
@@ -6,7 +6,90 @@
 //! Module that allows to rewrite request URLs with pattern matching support.
 //!
 
-use crate::settings::Rewrites;
+use headers::HeaderValue;
+use hyper::{header::HOST, Body, Request, Response, StatusCode, Uri};
+
+use crate::{
+    handler::RequestHandlerOpts,
+    redirects::{handle_error, replace_placeholders},
+    settings::{file::RedirectsKind, Rewrites},
+    Error,
+};
+
+/// Applies rewrite rules to a request if necessary.
+pub(crate) fn pre_process(
+    opts: &RequestHandlerOpts,
+    req: &mut Request<Body>,
+) -> Option<Result<Response<Body>, Error>> {
+    let rewrites = opts.advanced_opts.as_ref()?.rewrites.as_deref()?;
+    let uri_path = req.uri().path();
+
+    let matched = rewrite_uri_path(uri_path, Some(rewrites))?;
+    let dest = match replace_placeholders(uri_path, &matched.source, &matched.destination) {
+        Ok(dest) => dest,
+        Err(err) => return handle_error(err, opts, req),
+    };
+
+    if let Some(redirect_type) = &matched.redirect {
+        // Handle redirects
+        let loc = match HeaderValue::from_str(&dest) {
+            Ok(val) => val,
+            Err(err) => {
+                return handle_error(
+                    Error::new(err).context("invalid header value from current uri"),
+                    opts,
+                    req,
+                )
+            }
+        };
+        let mut resp = Response::new(Body::empty());
+        resp.headers_mut().insert(hyper::header::LOCATION, loc);
+        *resp.status_mut() = match redirect_type {
+            RedirectsKind::Permanent => StatusCode::MOVED_PERMANENTLY,
+            RedirectsKind::Temporary => StatusCode::FOUND,
+        };
+        Some(Ok(resp))
+    } else {
+        // Handle internal rewrites
+        *req.uri_mut() = match merge_uris(req.uri(), &dest) {
+            Ok(uri) => uri,
+            Err(err) => {
+                return handle_error(
+                    err.context("invalid rewrite target from current uri"),
+                    opts,
+                    req,
+                )
+            }
+        };
+
+        // Adjust Host header to allow rewriting to a different virtual host
+        if let Some(host) = req.uri().host() {
+            let mut host = host.to_owned();
+            if let Some(port) = req.uri().port_u16() {
+                host.push_str(&format!(":{}", port));
+            }
+            if let Ok(host) = host.parse() {
+                req.headers_mut().insert(HOST, host);
+            }
+        }
+
+        None
+    }
+}
+
+fn merge_uris(orig_uri: &Uri, new_uri: &str) -> Result<Uri, Error> {
+    let mut parts = new_uri.parse::<Uri>()?.into_parts();
+    if parts.scheme.is_none() {
+        parts.scheme = orig_uri.scheme().cloned();
+    }
+    if parts.authority.is_none() {
+        parts.authority = orig_uri.authority().cloned();
+    }
+    if parts.path_and_query.is_none() {
+        parts.path_and_query = orig_uri.path_and_query().cloned();
+    }
+    Ok(Uri::from_parts(parts)?)
+}
 
 /// It returns a rewrite's destination path if the current request uri
 /// matches against the provided rewrites array.
@@ -24,4 +107,177 @@ pub fn rewrite_uri_path<'a>(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pre_process;
+    use crate::{
+        handler::RequestHandlerOpts,
+        settings::{file::RedirectsKind, Advanced, Rewrites},
+        Error,
+    };
+    use hyper::{header::HOST, Body, Request, Response, StatusCode};
+    use regex::Regex;
+
+    fn make_request(host: &str, uri: &str) -> Request<Body> {
+        let mut builder = Request::builder();
+        if !host.is_empty() {
+            builder = builder.header("Host", host);
+        }
+        builder.method("GET").uri(uri).body(Body::empty()).unwrap()
+    }
+
+    fn get_rewrites() -> Vec<Rewrites> {
+        vec![
+            Rewrites {
+                source: Regex::new(r"/source1$").unwrap(),
+                destination: "/destination1".into(),
+                redirect: None,
+            },
+            Rewrites {
+                source: Regex::new(r"/source2$").unwrap(),
+                destination: "/destination2".into(),
+                redirect: Some(RedirectsKind::Temporary),
+            },
+            Rewrites {
+                source: Regex::new(r"/(prefix/)?(source3)/(.*)").unwrap(),
+                destination: "/destination3/$2/$3".into(),
+                redirect: Some(RedirectsKind::Permanent),
+            },
+            Rewrites {
+                source: Regex::new(r"/(source4)/(.*)").unwrap(),
+                destination: "http://example.net:1234/destination4/$1/$2".into(),
+                redirect: None,
+            },
+        ]
+    }
+
+    fn is_redirect(result: Option<Result<Response<Body>, Error>>) -> Option<(StatusCode, String)> {
+        if let Some(Ok(response)) = result {
+            let location = response.headers().get("Location")?.to_str().unwrap().into();
+            Some((response.status(), location))
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn test_no_rewrites() {
+        let mut req = make_request("", "/");
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: None,
+                ..Default::default()
+            },
+            &mut req
+        )
+        .is_none());
+        assert_eq!(req.uri(), "/");
+
+        let mut req = make_request("", "/");
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: Some(Advanced {
+                    rewrites: None,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &mut req
+        )
+        .is_none());
+        assert_eq!(req.uri(), "/");
+    }
+
+    #[test]
+    fn test_no_match() {
+        let mut req = make_request("example.com", "/source2/whatever");
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: Some(Advanced {
+                    rewrites: Some(get_rewrites()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &mut req
+        )
+        .is_none());
+        assert_eq!(req.uri(), "/source2/whatever");
+    }
+
+    #[test]
+    fn test_match() {
+        let mut req = make_request("", "/source1");
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: Some(Advanced {
+                    rewrites: Some(get_rewrites()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &mut req
+        )
+        .is_none());
+        assert_eq!(req.uri(), "/destination1");
+
+        let mut req = make_request("", "/source2");
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        rewrites: Some(get_rewrites()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &mut req
+            )),
+            Some((StatusCode::FOUND, "/destination2".into()))
+        );
+
+        let mut req = make_request("", "/source3/whatever");
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        rewrites: Some(get_rewrites()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &mut req
+            )),
+            Some((
+                StatusCode::MOVED_PERMANENTLY,
+                "/destination3/source3/whatever".into()
+            ))
+        );
+
+        let mut req = make_request("example.com", "/source4/whatever");
+        assert!(pre_process(
+            &RequestHandlerOpts {
+                advanced_opts: Some(Advanced {
+                    rewrites: Some(get_rewrites()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            &mut req
+        )
+        .is_none());
+        assert_eq!(
+            req.uri(),
+            "http://example.net:1234/destination4/source4/whatever"
+        );
+        assert_eq!(
+            req.headers()
+                .get(HOST)
+                .map(|h| h.to_str().unwrap())
+                .unwrap_or(""),
+            "example.net:1234"
+        );
+    }
 }


### PR DESCRIPTION
## Description
This implements the same changes to rewrites as have been implemented for redirects in #348. As suggested, I merged the identical code so that it is only present in the `redirects` module now.

There are some changes to the handler: request fields can no longer be borrowed because we are now modifying the request. While I meant to implement these changes anyway, this unfortunately introduces a merge conflict with #351.

There are also some behavior changes due to the fact that destination is always being processed as a URL now and not merely in the redirect scenario:

1. Previously, internal rewrites kept the query string unchanged. Now the query string from the destination overrides the original query string if present. This actually matches the behavior of nginx rewrites. The impact should be limited because the only place where query strings currently matter is directory listings, and existing configurations shouldn’t have destinations with query strings anyway.
2. It is now possible to do an internal rewrite to a full URL which includes a different host name. IMHO that’s a useful feature because it allows defining virtual hosts that are normally only reachable via rewrite – so you can have a subdirectory mapped to a different root (similar to the nginx `alias` directive). Configuration example:
```toml
[advanced]

[[advanced.rewrites]]
source = "/test/{**}"
destination = "http://internal.local/test/$1"

[[advanced.virtual-hosts]]
host = "internal.local"
root = "/usr/srv/test"
```
This might be worth documenting. There are caveats however. First, it’s a good idea to rewrite to the same path and merely change the host name like I’ve done above, otherwise redirects when accessing directories will be a mess (this is generally an issue with rewrites). Second, someone who knows the name of the internal virtual host will still be able to access it by mapping this host name to the server’s IP address explicitly. So one should not expect anything under that host’s root to be hidden just because rewrites only map to some of the files there.

## Related Issue
This is another step towards fixing #342, also fixes the rest of #347.

## How Has This Been Tested?
Integration tests pass, some additional unit tests have been added as well. Functional testing on Linux looks fine.