### PR TITLE
Replaced fork of the headers module by an in-tree handler for the Accept-Encoding header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,12 +381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,17 +530,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
-name = "headers-accept-encoding"
-version = "1.0.1"
+name = "headers"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb61b002873146872d7f6060e81296ecb6654c4e62179d987b5798ccb05e9485"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
  "http",
  "httpdate",
- "itertools",
  "mime",
  "sha1",
 ]
@@ -689,15 +682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1236,7 +1220,7 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "globset",
- "headers-accept-encoding",
+ "headers",
  "http",
  "http-serde",
  "humansize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 form_urlencoded = "1.2"
 futures-util = { version = "0.3", default-features = false }
 globset = { version = "0.4", features = ["serde1"] }
-headers = { package = "headers-accept-encoding", version = "=1.0" }
+headers = "0.3"
 http = "0.2"
 http-serde = "1.1"
 humansize = { version = "2.1", features = ["impl_style"], optional = true }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -215,7 +215,7 @@ pub fn zstd(
 pub fn create_encoding_header(existing: Option<HeaderValue>, coding: ContentCoding) -> HeaderValue {
     if let Some(val) = existing {
         if let Ok(str_val) = val.to_str() {
-            return HeaderValue::from_str(&[str_val, ", ", coding.to_static()].concat())
+            return HeaderValue::from_str(&[str_val, ", ", coding.as_str()].concat())
                 .unwrap_or_else(|_| coding.into());
         }
     }

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -6,14 +6,14 @@
 //! Compression static module to serve compressed files directly from the file system.
 //!
 
-use headers::{ContentCoding, HeaderMap, HeaderValue};
+use headers::{HeaderMap, HeaderValue};
 use std::{
     ffi::OsStr,
     fs::Metadata,
     path::{Path, PathBuf},
 };
 
-use crate::{compression, static_files::file_metadata};
+use crate::{compression, headers_ext::ContentCoding, static_files::file_metadata};
 
 /// It defines the pre-compressed file variant metadata of a particular file path.
 pub struct CompressedFileVariant<'a> {
@@ -35,8 +35,8 @@ pub async fn precompressed_variant<'a>(
         file_path.display()
     );
 
-    // Determine prefered-encoding extension if available
-    let comp_ext = match compression::get_prefered_encoding(headers) {
+    // Determine preferred-encoding extension if available
+    let comp_ext = match compression::get_preferred_encoding(headers) {
         // https://zlib.net/zlib_faq.html#faq39
         #[cfg(any(feature = "compression", feature = "compression-gzip"))]
         Some(ContentCoding::GZIP | ContentCoding::DEFLATE) => "gz",

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn from_static() {
-        let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9, *;q=0.1");
+        let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9");
         let accept_enc = AcceptEncoding(val.into());
 
         assert_eq!(
@@ -154,7 +154,6 @@ mod tests {
         assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));
         assert_eq!(encodings.next(), Some(ContentCoding::GZIP));
         assert_eq!(encodings.next(), Some(ContentCoding::BROTLI));
-        assert_eq!(encodings.next(), Some(ContentCoding::ANY));
         assert_eq!(encodings.next(), None);
     }
 

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -28,7 +28,7 @@ use super::{ContentCoding, QualityValue};
 /// * `br;q=1.0, gzip;q=0.8`
 ///
 #[derive(Clone, Debug)]
-pub struct AcceptEncoding(pub QualityValue);
+pub(crate) struct AcceptEncoding(QualityValue);
 
 impl Header for AcceptEncoding {
     fn name() -> &'static HeaderName {
@@ -50,12 +50,12 @@ impl Header for AcceptEncoding {
 impl AcceptEncoding {
     /// Returns the most preferred encoding that is specified by the header,
     /// if one is specified.
-    pub fn preferred_encoding(&self) -> Option<ContentCoding> {
+    pub(crate) fn preferred_encoding(&self) -> Option<ContentCoding> {
         self.0.iter().next().map(ContentCoding::from)
     }
 
     /// Returns a quality sorted iterator of the `ContentCoding`
-    pub fn sorted_encodings(&self) -> impl Iterator<Item = ContentCoding> + '_ {
+    pub(crate) fn sorted_encodings(&self) -> impl Iterator<Item = ContentCoding> + '_ {
         self.0.iter().map(ContentCoding::from)
     }
 }

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Original code by Parker Timmerman
+// Original code sourced from https://github.com/hyperium/headers/pull/70
+
 use headers::{Error, Header};
 use hyper::header::{HeaderName, HeaderValue, ACCEPT_ENCODING};
 

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn from_static() {
-        let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9");
+        let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9, *;q=0.1");
         let accept_enc = AcceptEncoding(val.into());
 
         assert_eq!(
@@ -154,6 +154,7 @@ mod tests {
         assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));
         assert_eq!(encodings.next(), Some(ContentCoding::GZIP));
         assert_eq!(encodings.next(), Some(ContentCoding::BROTLI));
+        assert_eq!(encodings.next(), Some(ContentCoding::ANY));
         assert_eq!(encodings.next(), None);
     }
 

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -48,12 +48,6 @@ impl Header for AcceptEncoding {
 }
 
 impl AcceptEncoding {
-    /// Convenience method to create an `Accept-Encoding: gzip` header
-    #[inline]
-    pub fn gzip() -> Self {
-        Self(HeaderValue::from_static("gzip").into())
-    }
-
     /// A convenience method to create an Accept-Encoding header from pairs of values and qualities
     ///
     /// # Example

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -1,0 +1,172 @@
+use headers::{Error, Header};
+use hyper::header::{HeaderName, HeaderValue, ACCEPT_ENCODING};
+
+use super::{ContentCoding, QualityValue};
+
+/// `Accept-Encoding` header, defined in
+/// [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.3.4)
+///
+/// The `Accept-Encoding` header field can be used by user agents to
+/// indicate what response content-codings are acceptable in the response.
+/// An "identity" token is used as a synonym for "no encoding" in
+/// order to communicate when no encoding is preferred.
+///
+/// # ABNF
+///
+/// ```text
+/// Accept-Encoding  = #( codings [ weight ] )
+/// codings          = content-coding / "identity" / "*"
+/// ```
+///
+/// # Example Values
+///
+/// * `gzip`
+/// * `br;q=1.0, gzip;q=0.8`
+///
+#[derive(Clone, Debug)]
+pub struct AcceptEncoding(pub QualityValue);
+
+impl Header for AcceptEncoding {
+    fn name() -> &'static HeaderName {
+        &ACCEPT_ENCODING
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        QualityValue::try_from_values(values).map(Self)
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        values.extend(std::iter::once((&self.0).into()))
+    }
+}
+
+impl AcceptEncoding {
+    /// Convenience method to create an `Accept-Encoding: gzip` header
+    #[inline]
+    pub fn gzip() -> Self {
+        Self(HeaderValue::from_static("gzip").into())
+    }
+
+    /// A convenience method to create an Accept-Encoding header from pairs of values and qualities
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use static_web_server::headers_ext::AcceptEncoding;
+    ///
+    /// let pairs = vec![("gzip", 1.0), ("deflate", 0.8)];
+    /// let header = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter());
+    /// ```
+    pub fn from_quality_pairs<'i, I>(pairs: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = (&'i str, f32)>,
+    {
+        let values: Vec<HeaderValue> = pairs
+            .map(|pair| {
+                QualityValue::try_from(pair).map(|qual: QualityValue| HeaderValue::from(qual))
+            })
+            .collect::<Result<Vec<HeaderValue>, Error>>()?;
+        let value = QualityValue::try_from_values(&mut values.iter())?;
+        Ok(Self(value))
+    }
+
+    /// Returns the most preferred encoding that is specified by the header,
+    /// if one is specified.
+    ///
+    /// Note: This peeks at the underlying iter, not modifying it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use static_web_server::headers_ext::{AcceptEncoding, ContentCoding};
+    ///
+    /// let pairs = vec![("gzip", 1.0), ("deflate", 0.8)];
+    /// let accept_enc = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter()).unwrap();
+    /// let mut encodings = accept_enc.sorted_encodings();
+    ///
+    /// assert_eq!(accept_enc.preferred_encoding(), Some(ContentCoding::GZIP));
+    /// ```
+    pub fn preferred_encoding(&self) -> Option<ContentCoding> {
+        self.0.iter().next().map(ContentCoding::from)
+    }
+
+    /// Returns a quality sorted iterator of the `ContentCoding`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use headers::HeaderValue;
+    /// use static_web_server::headers_ext::{AcceptEncoding, ContentCoding};
+    ///
+    /// let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.8");
+    /// let accept_enc = AcceptEncoding(val.into());
+    /// let mut encodings = accept_enc.sorted_encodings();
+    ///
+    /// assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));
+    /// assert_eq!(encodings.next(), Some(ContentCoding::GZIP));
+    /// assert_eq!(encodings.next(), Some(ContentCoding::BROTLI));
+    /// assert_eq!(encodings.next(), None);
+    /// ```
+    pub fn sorted_encodings(&self) -> impl Iterator<Item = ContentCoding> + '_ {
+        self.0.iter().map(ContentCoding::from)
+    }
+
+    /// Returns a quality sorted iterator of values
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use headers::HeaderValue;
+    /// use static_web_server::headers_ext::{AcceptEncoding, ContentCoding};
+    ///
+    /// let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.8");
+    /// let accept_enc = AcceptEncoding(val.into());
+    /// let mut encodings = accept_enc.sorted_values();
+    ///
+    /// assert_eq!(encodings.next(), Some("deflate"));
+    /// assert_eq!(encodings.next(), Some("gzip"));
+    /// assert_eq!(encodings.next(), Some("br"));
+    /// assert_eq!(encodings.next(), None);
+    /// ```
+    pub fn sorted_values(&self) -> impl Iterator<Item = &str> {
+        self.0.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_static() {
+        let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9");
+        let accept_enc = AcceptEncoding(val.into());
+
+        assert_eq!(
+            accept_enc.preferred_encoding(),
+            Some(ContentCoding::DEFLATE)
+        );
+
+        let mut encodings = accept_enc.sorted_encodings();
+        assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));
+        assert_eq!(encodings.next(), Some(ContentCoding::GZIP));
+        assert_eq!(encodings.next(), Some(ContentCoding::BROTLI));
+        assert_eq!(encodings.next(), None);
+    }
+
+    #[test]
+    fn from_pairs() {
+        let pairs = vec![("gzip", 1.0), ("br", 0.9)];
+        let accept_enc = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter()).unwrap();
+
+        assert_eq!(accept_enc.preferred_encoding(), Some(ContentCoding::GZIP));
+
+        let mut encodings = accept_enc.sorted_encodings();
+        assert_eq!(encodings.next(), Some(ContentCoding::GZIP));
+        assert_eq!(encodings.next(), Some(ContentCoding::BROTLI));
+        assert_eq!(encodings.next(), None);
+    }
+}

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -15,6 +15,7 @@ macro_rules! define_content_coding {
         /// [RFC7231](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml)
         pub enum ContentCoding {
             $(
+                #[allow(clippy::upper_case_acronyms)]
                 #[doc = $str]
                 $coding,
             )+
@@ -22,17 +23,8 @@ macro_rules! define_content_coding {
 
         impl ContentCoding {
             /// Returns a `&'static str` for a `ContentCoding`
-            ///
-            /// # Example
-            ///
-            /// ```
-            /// use static_web_server::headers_ext::ContentCoding;
-            ///
-            /// let coding = ContentCoding::BROTLI;
-            /// assert_eq!(coding.to_static(), "br");
-            /// ```
             #[inline]
-            pub fn to_static(&self) -> &'static str {
+            pub fn as_str(&self) -> &'static str {
                 match *self {
                     $(ContentCoding::$coding => $str,)+
                 }
@@ -45,18 +37,6 @@ macro_rules! define_content_coding {
             /// Note this will never fail, in the case of `&str` being an invalid content coding,
             /// will return `ContentCoding::IDENTITY` because `'identity'` is generally always an
             /// accepted coding.
-            ///
-            /// # Example
-            ///
-            /// ```
-            /// use static_web_server::headers_ext::ContentCoding;
-            ///
-            /// let invalid = ContentCoding::from("not a valid coding");
-            /// assert_eq!(invalid, ContentCoding::IDENTITY);
-            ///
-            /// let valid = ContentCoding::from("gzip");
-            /// assert_eq!(valid, ContentCoding::GZIP);
-            /// ```
             #[inline]
             fn from(s: &str) -> Self {
                 ContentCoding::from_str(s).unwrap_or_else(|_| ContentCoding::IDENTITY)
@@ -68,21 +48,8 @@ macro_rules! define_content_coding {
 
             /// Given a `&str` will try to return a `ContentCoding`
             ///
-            /// Different from `ContentCoding::from_str(&str)`, if `&str` is an invalid content
+            /// Different from `ContentCoding::from(&str)`, if `&str` is an invalid content
             /// coding, it will return `Err(())`
-            ///
-            /// # Example
-            ///
-            /// ```
-            /// use static_web_server::headers_ext::ContentCoding;
-            /// use std::str::FromStr;
-            ///
-            /// let invalid = ContentCoding::from_str("not a valid coding");
-            /// assert!(invalid.is_err());
-            ///
-            /// let valid = ContentCoding::from_str("gzip");
-            /// assert_eq!(valid.unwrap(), ContentCoding::GZIP);
-            /// ```
             #[inline]
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
@@ -129,8 +96,8 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn to_static() {
-        assert_eq!(ContentCoding::GZIP.to_static(), "gzip");
+    fn as_str() {
+        assert_eq!(ContentCoding::GZIP.as_str(), "gzip");
     }
 
     #[test]

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -1,0 +1,152 @@
+// Derives an enum to represent content codings and some helpful impls
+macro_rules! define_content_coding {
+    ($($coding:ident; $str:expr,)+) => {
+        use hyper::header::HeaderValue;
+        use std::str::FromStr;
+
+        #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+        /// Values that are used with headers like [`Content-Encoding`](self::ContentEncoding) or
+        /// [`Accept-Encoding`](self::AcceptEncoding)
+        ///
+        /// [RFC7231](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml)
+        pub enum ContentCoding {
+            $(
+                #[doc = $str]
+                $coding,
+            )+
+        }
+
+        impl ContentCoding {
+            /// Returns a `&'static str` for a `ContentCoding`
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use static_web_server::headers_ext::ContentCoding;
+            ///
+            /// let coding = ContentCoding::BROTLI;
+            /// assert_eq!(coding.to_static(), "br");
+            /// ```
+            #[inline]
+            pub fn to_static(&self) -> &'static str {
+                match *self {
+                    $(ContentCoding::$coding => $str,)+
+                }
+            }
+        }
+
+        impl From<&str> for ContentCoding {
+            /// Given a `&str` returns a `ContentCoding`
+            ///
+            /// Note this will never fail, in the case of `&str` being an invalid content coding,
+            /// will return `ContentCoding::IDENTITY` because `'identity'` is generally always an
+            /// accepted coding.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use static_web_server::headers_ext::ContentCoding;
+            ///
+            /// let invalid = ContentCoding::from("not a valid coding");
+            /// assert_eq!(invalid, ContentCoding::IDENTITY);
+            ///
+            /// let valid = ContentCoding::from("gzip");
+            /// assert_eq!(valid, ContentCoding::GZIP);
+            /// ```
+            #[inline]
+            fn from(s: &str) -> Self {
+                ContentCoding::from_str(s).unwrap_or_else(|_| ContentCoding::IDENTITY)
+            }
+        }
+
+        impl FromStr for ContentCoding {
+            type Err = ();
+
+            /// Given a `&str` will try to return a `ContentCoding`
+            ///
+            /// Different from `ContentCoding::from_str(&str)`, if `&str` is an invalid content
+            /// coding, it will return `Err(())`
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use static_web_server::headers_ext::ContentCoding;
+            /// use std::str::FromStr;
+            ///
+            /// let invalid = ContentCoding::from_str("not a valid coding");
+            /// assert!(invalid.is_err());
+            ///
+            /// let valid = ContentCoding::from_str("gzip");
+            /// assert_eq!(valid.unwrap(), ContentCoding::GZIP);
+            /// ```
+            #[inline]
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    $(
+                        stringify!($coding)
+                        | $str => Ok(Self::$coding),
+                    )+
+                    _ => Err(())
+                }
+            }
+        }
+
+        impl std::fmt::Display for ContentCoding {
+            #[inline]
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+                write!(f, "{}", match *self {
+                    $(ContentCoding::$coding => $str.to_string(),)+
+                })
+            }
+        }
+
+        impl From<ContentCoding> for HeaderValue {
+            fn from(coding: ContentCoding) -> HeaderValue {
+                match coding {
+                    $(ContentCoding::$coding => HeaderValue::from_static($str),)+
+                }
+            }
+        }
+    }
+}
+
+define_content_coding! {
+    ANY; "*",
+    BROTLI; "br",
+    COMPRESS; "compress",
+    DEFLATE; "deflate",
+    GZIP; "gzip",
+    IDENTITY; "identity",
+    ZSTD; "zstd",
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContentCoding;
+    use std::str::FromStr;
+
+    #[test]
+    fn to_static() {
+        assert_eq!(ContentCoding::GZIP.to_static(), "gzip");
+    }
+
+    #[test]
+    fn to_string() {
+        assert_eq!(ContentCoding::DEFLATE.to_string(), "deflate".to_string());
+    }
+
+    #[test]
+    fn from() {
+        assert_eq!(ContentCoding::from("br"), ContentCoding::BROTLI);
+        assert_eq!(ContentCoding::from("GZIP"), ContentCoding::GZIP);
+        assert_eq!(ContentCoding::from("zstd"), ContentCoding::ZSTD);
+        assert_eq!(ContentCoding::from("blah blah"), ContentCoding::IDENTITY);
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(ContentCoding::from_str("br"), Ok(ContentCoding::BROTLI));
+        assert_eq!(ContentCoding::from_str("zstd"), Ok(ContentCoding::ZSTD));
+        assert_eq!(ContentCoding::from_str("blah blah"), Err(()));
+    }
+}

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Original code by Parker Timmerman
+// Original code sourced from https://github.com/hyperium/headers/pull/70
+
 // Derives an enum to represent content codings and some helpful impls
 macro_rules! define_content_coding {
     ($($coding:ident; $str:expr,)+) => {

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -24,7 +24,7 @@ macro_rules! define_content_coding {
         impl ContentCoding {
             /// Returns a `&'static str` for a `ContentCoding`
             #[inline]
-            pub fn as_str(&self) -> &'static str {
+            pub(crate) fn as_str(&self) -> &'static str {
                 match *self {
                     $(ContentCoding::$coding => $str,)+
                 }

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -140,6 +140,7 @@ mod tests {
         assert_eq!(ContentCoding::from("br"), ContentCoding::BROTLI);
         assert_eq!(ContentCoding::from("GZIP"), ContentCoding::GZIP);
         assert_eq!(ContentCoding::from("zstd"), ContentCoding::ZSTD);
+        assert_eq!(ContentCoding::from("*"), ContentCoding::ANY);
         assert_eq!(ContentCoding::from("blah blah"), ContentCoding::IDENTITY);
     }
 
@@ -147,6 +148,7 @@ mod tests {
     fn from_str() {
         assert_eq!(ContentCoding::from_str("br"), Ok(ContentCoding::BROTLI));
         assert_eq!(ContentCoding::from_str("zstd"), Ok(ContentCoding::ZSTD));
+        assert_eq!(ContentCoding::from_str("*"), Ok(ContentCoding::ANY));
         assert_eq!(ContentCoding::from_str("blah blah"), Err(()));
     }
 }

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -5,8 +5,8 @@ macro_rules! define_content_coding {
         use std::str::FromStr;
 
         #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-        /// Values that are used with headers like [`Content-Encoding`](self::ContentEncoding) or
-        /// [`Accept-Encoding`](self::AcceptEncoding)
+        /// Values that are used with headers like [`Content-Encoding`](headers::ContentEncoding) or
+        /// [`Accept-Encoding`](super::AcceptEncoding)
         ///
         /// [RFC7231](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml)
         pub enum ContentCoding {

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -111,7 +111,6 @@ macro_rules! define_content_coding {
 }
 
 define_content_coding! {
-    ANY; "*",
     BROTLI; "br",
     COMPRESS; "compress",
     DEFLATE; "deflate",
@@ -140,7 +139,6 @@ mod tests {
         assert_eq!(ContentCoding::from("br"), ContentCoding::BROTLI);
         assert_eq!(ContentCoding::from("GZIP"), ContentCoding::GZIP);
         assert_eq!(ContentCoding::from("zstd"), ContentCoding::ZSTD);
-        assert_eq!(ContentCoding::from("*"), ContentCoding::ANY);
         assert_eq!(ContentCoding::from("blah blah"), ContentCoding::IDENTITY);
     }
 
@@ -148,7 +146,6 @@ mod tests {
     fn from_str() {
         assert_eq!(ContentCoding::from_str("br"), Ok(ContentCoding::BROTLI));
         assert_eq!(ContentCoding::from_str("zstd"), Ok(ContentCoding::ZSTD));
-        assert_eq!(ContentCoding::from_str("*"), Ok(ContentCoding::ANY));
         assert_eq!(ContentCoding::from_str("blah blah"), Err(()));
     }
 }

--- a/src/headers_ext/mod.rs
+++ b/src/headers_ext/mod.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// This file is part of Static Web Server.
+// See https://static-web-server.net/ for more information
+// Copyright (C) 2019-present Jose Quintana <joseluisq.net>
+
+//! Additional types for the headers module in order to handle Accept-Encoding
+//! header.
+//!
+
+mod accept_encoding;
+mod content_coding;
+mod quality_value;
+
+pub use accept_encoding::AcceptEncoding;
+pub use content_coding::ContentCoding;
+pub use quality_value::QualityValue;

--- a/src/headers_ext/mod.rs
+++ b/src/headers_ext/mod.rs
@@ -11,6 +11,6 @@ mod accept_encoding;
 mod content_coding;
 mod quality_value;
 
-pub use accept_encoding::AcceptEncoding;
-pub use content_coding::ContentCoding;
-pub use quality_value::QualityValue;
+pub(crate) use accept_encoding::AcceptEncoding;
+pub(crate) use content_coding::ContentCoding;
+pub(crate) use quality_value::QualityValue;

--- a/src/headers_ext/quality_value.rs
+++ b/src/headers_ext/quality_value.rs
@@ -1,0 +1,192 @@
+use bytes::BytesMut;
+use headers::Error;
+use hyper::header::HeaderValue;
+use std::cmp::Ordering;
+
+/// A CSV list that respects the Quality Values syntax defined in
+/// [RFC7321](https://tools.ietf.org/html/rfc7231#section-5.3.1)
+///
+/// Many of the request header fields for proactive negotiation use a
+/// common parameter, named "q" (case-insensitive), to assign a relative
+/// "weight" to the preference for that associated kind of content.  This
+/// weight is referred to as a "quality value" (or "qvalue") because the
+/// same parameter name is often used within server configurations to
+/// assign a weight to the relative quality of the various
+/// representations that can be selected for a resource.
+///
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct QualityValue {
+    value: HeaderValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct QualityMeta<'a> {
+    pub data: &'a str,
+    pub quality: u16,
+}
+
+impl Ord for QualityMeta<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.quality.cmp(&self.quality)
+    }
+}
+
+impl PartialOrd for QualityMeta<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a> TryFrom<&'a str> for QualityMeta<'a> {
+    type Error = Error;
+
+    fn try_from(val: &'a str) -> Result<Self, Error> {
+        let parts: Vec<_> = val.split(';').collect();
+        let data = parts.first().ok_or(Error::invalid())?.trim();
+
+        // Default quality value is 1
+        let mut quality = 1000u16;
+        for part in parts {
+            let part = part.trim_start();
+            if let Some(value) = part.strip_prefix("q=") {
+                let parsed: f32 = match value.parse() {
+                    Ok(parsed) => parsed,
+                    Err(_) => continue,
+                };
+                quality = (parsed * 1000_f32) as u16;
+            }
+        }
+
+        Ok(QualityMeta { data, quality })
+    }
+}
+
+impl QualityValue {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
+        let mut items: Vec<_> = self
+            .value
+            .to_str()
+            .ok()
+            .into_iter()
+            .flat_map(|value_str| value_str.split(','))
+            .filter_map(|v| QualityMeta::try_from(v).ok())
+            .collect();
+        items.sort();
+        items.into_iter().map(|pair| pair.data)
+    }
+
+    pub(crate) fn try_from_values<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        let mut values = values.peekable();
+        let first = match values.next() {
+            Some(item) => item,
+            None => return Ok(HeaderValue::from_static("").into()),
+        };
+
+        if values.peek().is_none() {
+            // Only one item, can be returned directly
+            return Ok(first.into());
+        }
+
+        let mut buf = BytesMut::from(first.as_bytes());
+        for value in values {
+            buf.extend_from_slice(", ".as_bytes());
+            buf.extend_from_slice(value.as_bytes());
+        }
+
+        Ok(HeaderValue::from_maybe_shared(buf.freeze())
+            .map_err(|_| Error::invalid())?
+            .into())
+    }
+}
+
+impl<F: Into<f32>> TryFrom<(&str, F)> for QualityValue {
+    type Error = Error;
+
+    fn try_from(pair: (&str, F)) -> Result<Self, Error> {
+        let (data, quality) = pair;
+        let value = HeaderValue::try_from(format!("{data};q={}", quality.into()))
+            .map_err(|_e| Error::invalid())?;
+        Ok(Self::from(value))
+    }
+}
+
+impl From<HeaderValue> for QualityValue {
+    fn from(value: HeaderValue) -> Self {
+        QualityValue { value }
+    }
+}
+
+impl From<&HeaderValue> for QualityValue {
+    fn from(value: &HeaderValue) -> Self {
+        QualityValue {
+            value: value.clone(),
+        }
+    }
+}
+
+impl From<&QualityValue> for HeaderValue {
+    fn from(qual: &QualityValue) -> Self {
+        qual.value.clone()
+    }
+}
+
+impl From<QualityValue> for HeaderValue {
+    fn from(qual: QualityValue) -> Self {
+        qual.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multiple_qualities() {
+        let val = HeaderValue::from_static("gzip;q=1, br;q=0.8");
+        let qual = QualityValue::from(val);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn multiple_qualities_wrong_order() {
+        let val = HeaderValue::from_static("br;q=0.8, gzip;q=1.0");
+        let qual = QualityValue::from(val);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn multiple_values() {
+        let val = HeaderValue::from_static("deflate, gzip;q=1, br;q=0.8");
+        let qual = QualityValue::from(val);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("deflate"));
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn multiple_values_wrong_order() {
+        let val = HeaderValue::from_static("deflate, br;q=0.8, gzip;q=1, *;q=0.1");
+        let qual = QualityValue::from(val);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("deflate"));
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), Some("*"));
+        assert_eq!(values.next(), None);
+    }
+}

--- a/src/headers_ext/quality_value.rs
+++ b/src/headers_ext/quality_value.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// Original code by Parker Timmerman
+// Original code sourced from https://github.com/hyperium/headers/pull/70
+
 use bytes::BytesMut;
 use headers::Error;
 use hyper::header::HeaderValue;

--- a/src/headers_ext/quality_value.rs
+++ b/src/headers_ext/quality_value.rs
@@ -19,7 +19,7 @@ use std::cmp::Ordering;
 /// representations that can be selected for a resource.
 ///
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct QualityValue {
+pub(crate) struct QualityValue {
     value: HeaderValue,
 }
 

--- a/src/headers_ext/quality_value.rs
+++ b/src/headers_ext/quality_value.rs
@@ -49,7 +49,7 @@ impl<'a> TryFrom<&'a str> for QualityMeta<'a> {
         for part in parts {
             let part = part.trim_start();
             if let Some(value) = part.strip_prefix("q=") {
-                let parsed: f32 = match value.parse() {
+                let parsed: f32 = match value.trim().parse() {
                     Ok(parsed) => parsed,
                     Err(_) => continue,
                 };
@@ -168,6 +168,18 @@ mod tests {
     #[test]
     fn multiple_values() {
         let val = HeaderValue::from_static("deflate, gzip;q=1, br;q=0.8");
+        let qual = QualityValue::from(val);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("deflate"));
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn multiple_values_whitespace() {
+        let val = HeaderValue::from_static("deflate  ;q=0.9, br;   q=0.001 ,gzip  ;  q=0.8");
         let qual = QualityValue::from(val);
 
         let mut values = qual.iter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ pub(crate) mod file_path;
 pub(crate) mod file_response;
 pub(crate) mod file_stream;
 pub mod handler;
+pub mod headers_ext;
 pub(crate) mod health;
 pub(crate) mod http_ext;
 #[cfg(feature = "http2")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub(crate) mod file_path;
 pub(crate) mod file_response;
 pub(crate) mod file_stream;
 pub mod handler;
-pub mod headers_ext;
+pub(crate) mod headers_ext;
 pub(crate) mod health;
 pub(crate) mod http_ext;
 #[cfg(feature = "http2")]


### PR DESCRIPTION
## Description
It isn’t necessary to fork `headers` module just to implement handling of a single header, it can be done externally. I’ve moved and simplified the relevant code from the `headers-accept-encoding` module into the tree, this should make upgrading to a current version of the `headers` module considerably simpler.

Note that the original code had issues, clippy in particular complained about quite a few things. For example, I made `ContentCoding` implement the standard `From`, `FromStr` and `Display` traits. Iterator chains were also unnecessarily complicated in a few cases.

As to parsing, I didn’t merely drop configuration of separators for reasons of simplicity. Parsing was also incorrect, it allowed quoting comma-separated values which `Accept-Encoding` header doesn’t. Also, `;q=` isn’t actually a separator, it’s a parameter. The syntax allows whitespace between `;` and `q=`, and the syntax also in principle allows for other parameters to be present. There is still an issue with the range: in principle, this code allows arbitrarily large values for q, and the values up to 65.535 will also be treated differently (everything above that value is considered the same). I didn’t consider that worth fixing.

I’ve also added `ContentCoding::ANY` (corresponds to `Accept-Encoding: *`). This is a valid value which probably needs to be considered by SWS at some point.

Tests are largely unchanged. I changed method names (`prefered_encoding` => `preferred_encoding`, `from_str` => `from`, `try_from_str` => `from_str`), added `quality_values::tests::multiple_values_whitespace` test and some tests for `ContentCoding::ANY`.

Licensing is still an open question, I didn’t look into it. `headers` module is licensed under MIT, I don’t know whether their code can be licensed under Apache-2.0 as well.

## Related Issue
This is a step towards fixing #340.

## How Has This Been Tested?
All tests pass.