### PR TITLE
Prefer querying available cpus using Rust std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,6 @@ dependencies = [
  "hyper",
  "listenfd",
  "mime_guess",
- "num_cpus",
  "percent-encoding",
  "pin-project",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ humansize = { version = "2.1", features = ["impl_style"], optional = true }
 hyper = { version = "0.14", features = ["stream", "http1", "http2", "tcp", "server"] }
 listenfd = "1.0"
 mime_guess = "2.0"
-num_cpus = { version = "1.16" }
 percent-encoding = "2.3"
 pin-project = "1.1"
 regex = "1.10"

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,11 @@ impl Server {
     /// Create a new multi-threaded server instance.
     pub fn new(opts: Settings) -> Result<Server> {
         // Configure number of worker threads
-        let cpus = num_cpus::get();
+        let cpus = std::thread::available_parallelism()
+            .with_context(|| {
+                "unable to get current platform cpus or lack of permissions to query available parallelism"
+            })?
+            .get();
         let worker_threads = match opts.general.threads_multiplier {
             0 | 1 => cpus,
             n => cpus * n,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

Since Rust 1.59.0 [std::thread::available_parallelism](https://doc.rust-lang.org/std/thread/fn.available_parallelism.html) can do the job of the `num_cpus` crate. So it is good enough for our use case and means one dependency less.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
