### PR TITLE
Apply the usual post-processing to error responses for consistency

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -292,7 +292,7 @@ impl RequestHandler {
                             &status,
                             &self.opts.page404,
                             &self.opts.page50x,
-                        )?
+                        )?,
                     );
 
                     (resp, false, None)
@@ -348,12 +348,7 @@ impl RequestHandler {
             security_headers::post_process(&self.opts, req, &mut resp);
 
             // Add/update custom headers
-            custom_headers::post_process(
-                &self.opts,
-                req,
-                &mut resp,
-                file_path.as_ref(),
-            );
+            custom_headers::post_process(&self.opts, req, &mut resp, file_path.as_ref());
 
             Ok(resp)
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -252,7 +252,7 @@ impl RequestHandler {
             let index_files = index_files.as_ref();
 
             // Static files
-            match static_files::handle(&HandleOpts {
+            let (mut resp, _is_precompressed, file_path) = match static_files::handle(&HandleOpts {
                 method: req.method(),
                 headers: req.headers(),
                 base_path,
@@ -271,142 +271,91 @@ impl RequestHandler {
             })
             .await
             {
-                Ok(result) => {
-                    let _is_precompressed = result.is_precompressed;
-                    let mut resp = result.resp;
-
-                    // Append CORS headers if they are present
-                    cors::post_process(&self.opts, req, &mut resp);
-
-                    // Compression content encoding varies so use a `Vary` header
-                    #[cfg(any(
-                        feature = "compression",
-                        feature = "compression-gzip",
-                        feature = "compression-brotli",
-                        feature = "compression-zstd",
-                        feature = "compression-deflate"
-                    ))]
-                    if self.opts.compression || compression_static {
-                        resp.headers_mut().append(
-                            hyper::header::VARY,
-                            HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
-                        );
-                    }
-
-                    // Auto compression based on the `Accept-Encoding` header
-                    #[cfg(any(
-                        feature = "compression",
-                        feature = "compression-gzip",
-                        feature = "compression-brotli",
-                        feature = "compression-zstd",
-                        feature = "compression-deflate"
-                    ))]
-                    if self.opts.compression && !_is_precompressed {
-                        resp = match compression::auto(req.method(), req.headers(), resp) {
-                            Ok(res) => res,
-                            Err(err) => {
-                                tracing::error!("error during body compression: {:?}", err);
-                                return error_page::error_response(
-                                    req.uri(),
-                                    req.method(),
-                                    &StatusCode::INTERNAL_SERVER_ERROR,
-                                    &self.opts.page404,
-                                    &self.opts.page50x,
-                                );
-                            }
-                        };
-                    }
-
-                    // Append `Cache-Control` headers for web assets
-                    control_headers::post_process(&self.opts, req, &mut resp);
-
-                    // Append security headers
-                    security_headers::post_process(&self.opts, req, &mut resp);
-
-                    // Add/update custom headers
-                    custom_headers::post_process(
-                        &self.opts,
-                        req,
-                        &mut resp,
-                        Some(&result.file_path),
-                    );
-
-                    Ok(resp)
-                }
+                Ok(result) => (result.resp, result.is_precompressed, Some(result.file_path)),
                 Err(status) => {
+                    let mut resp = None;
+
                     // Check for a fallback response
                     #[cfg(feature = "fallback-page")]
                     if req.method().is_get()
                         && status == StatusCode::NOT_FOUND
                         && !self.opts.page_fallback.is_empty()
                     {
-                        // We use all modules as usual when the `page-fallback` feature is enabled
-                        let mut resp = fallback_page::fallback_response(&self.opts.page_fallback);
-
-                        // Append CORS headers if they are present
-                        cors::post_process(&self.opts, req, &mut resp);
-
-                        // Compression content encoding varies so use a `Vary` header
-                        #[cfg(any(
-                            feature = "compression",
-                            feature = "compression-gzip",
-                            feature = "compression-brotli",
-                            feature = "compression-zstd",
-                            feature = "compression-deflate"
-                        ))]
-                        if self.opts.compression || compression_static {
-                            resp.headers_mut().append(
-                                hyper::header::VARY,
-                                HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
-                            );
-                        }
-
-                        // Auto compression based on the `Accept-Encoding` header
-                        #[cfg(any(
-                            feature = "compression",
-                            feature = "compression-gzip",
-                            feature = "compression-brotli",
-                            feature = "compression-zstd",
-                            feature = "compression-deflate"
-                        ))]
-                        if self.opts.compression {
-                            resp = match compression::auto(req.method(), req.headers(), resp) {
-                                Ok(res) => res,
-                                Err(err) => {
-                                    tracing::error!("error during body compression: {:?}", err);
-                                    return error_page::error_response(
-                                        req.uri(),
-                                        req.method(),
-                                        &StatusCode::INTERNAL_SERVER_ERROR,
-                                        &self.opts.page404,
-                                        &self.opts.page50x,
-                                    );
-                                }
-                            };
-                        }
-
-                        // Append `Cache-Control` headers for web assets
-                        control_headers::post_process(&self.opts, req, &mut resp);
-
-                        // Append security headers
-                        security_headers::post_process(&self.opts, req, &mut resp);
-
-                        // Add/update custom headers
-                        custom_headers::post_process(&self.opts, req, &mut resp, None);
-
-                        return Ok(resp);
+                        resp = Some(fallback_page::fallback_response(&self.opts.page_fallback));
                     }
 
-                    // Otherwise return an error response
-                    error_page::error_response(
-                        req.uri(),
-                        req.method(),
-                        &status,
-                        &self.opts.page404,
-                        &self.opts.page50x,
-                    )
+                    let resp = resp.unwrap_or(
+                        // Otherwise return an error response
+                        error_page::error_response(
+                            req.uri(),
+                            req.method(),
+                            &status,
+                            &self.opts.page404,
+                            &self.opts.page50x,
+                        )?
+                    );
+
+                    (resp, false, None)
                 }
+            };
+
+            // Append CORS headers if they are present
+            cors::post_process(&self.opts, req, &mut resp);
+
+            // Compression content encoding varies so use a `Vary` header
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-gzip",
+                feature = "compression-brotli",
+                feature = "compression-zstd",
+                feature = "compression-deflate"
+            ))]
+            if self.opts.compression || compression_static {
+                resp.headers_mut().append(
+                    hyper::header::VARY,
+                    HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
+                );
             }
+
+            // Auto compression based on the `Accept-Encoding` header
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-gzip",
+                feature = "compression-brotli",
+                feature = "compression-zstd",
+                feature = "compression-deflate"
+            ))]
+            if self.opts.compression && !_is_precompressed {
+                resp = match compression::auto(req.method(), req.headers(), resp) {
+                    Ok(res) => res,
+                    Err(err) => {
+                        tracing::error!("error during body compression: {:?}", err);
+                        return error_page::error_response(
+                            req.uri(),
+                            req.method(),
+                            &StatusCode::INTERNAL_SERVER_ERROR,
+                            &self.opts.page404,
+                            &self.opts.page50x,
+                        );
+                    }
+                };
+            }
+
+            // Append `Cache-Control` headers for web assets
+            control_headers::post_process(&self.opts, req, &mut resp);
+
+            // Append security headers
+            security_headers::post_process(&self.opts, req, &mut resp);
+
+            // Add/update custom headers
+            custom_headers::post_process(
+                &self.opts,
+                req,
+                &mut resp,
+                file_path.as_ref(),
+            );
+
+            Ok(resp)
         }
     }
 }


### PR DESCRIPTION
## Description
This makes sure that the same post-processing applies to error pages as to regular responses. This leaves out the error page displayed if compression fails, I intend to fix this part with the #342 changes for compression.

## Related Issue
See https://github.com/static-web-server/static-web-server/pull/349#issuecomment-2067661389

## Motivation and Context
After thinking a bit more about this, I don’t see a reason to skip the usual post-processing for error pages. The steps in detail:

1. CORS: As already established in #349, this shouldn’t be skipped for error pages.
2. Compression: There is no harm in compressing error pages apart from slightly reduced performance, and other web servers seem to do it (granted, they also have larger default error pages). Note that currently compression is skipped because MIME type `text/html; charset=utf-8` doesn’t match the expected `text/html` – this is a bug which I intend to fix separately. IMHO this is the one step which we could explicitly skip for error pages, we should go by `resp.status()` then.
3. `Cache-Control` header: same caching strategy for errors as for other content seems appropriate.
4. Security headers: definitely necessary. Not having security headers on some of the responses is how these security measures are being circumvented.
5. Custom headers: these are typically used to custom security headers definitions, so these also should be applied consistently.

## How Has This Been Tested?
Tests pass, functional testing on Linux looks fine.