### PR TITLE
Improve recognition of text MIME types for compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ dependencies = [
  "http-serde",
  "humansize",
  "hyper",
+ "lazy_static",
  "listenfd",
  "mime_guess",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ http = "0.2"
 http-serde = "1.1"
 humansize = { version = "2.1", features = ["impl_style"], optional = true }
 hyper = { version = "0.14", features = ["stream", "http1", "http2", "tcp", "server"] }
+lazy_static = "1.4.0"
 listenfd = "1.0"
 mime_guess = "2.0"
 percent-encoding = "2.3"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -24,8 +24,10 @@ use hyper::{
     header::{CONTENT_ENCODING, CONTENT_LENGTH},
     Body, Method, Response,
 };
-use mime_guess::Mime;
+use lazy_static::lazy_static;
+use mime_guess::{mime, Mime};
 use pin_project::pin_project;
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio_util::io::{ReaderStream, StreamReader};
@@ -36,33 +38,19 @@ use crate::{
     Result,
 };
 
-/// Contains a fixed list of common text-based MIME types in order to apply compression.
-pub const TEXT_MIME_TYPES: [&str; 24] = [
-    "text/html",
-    "text/css",
-    "text/javascript",
-    "text/xml",
-    "text/plain",
-    "text/csv",
-    "text/calendar",
-    "text/markdown",
-    "text/x-yaml",
-    "text/x-toml",
-    "text/x-component",
-    "application/rtf",
-    "application/xhtml+xml",
-    "application/javascript",
-    "application/x-javascript",
-    "application/json",
-    "application/xml",
-    "application/rss+xml",
-    "application/atom+xml",
-    "font/truetype",
-    "font/opentype",
-    "application/vnd.ms-fontobject",
-    "image/svg+xml",
-    "application/wasm",
-];
+lazy_static! {
+    /// Contains a fixed list of common text-based MIME types that aren't recognizable in a generic way.
+    static ref TEXT_MIME_TYPES: HashSet<&'static str> = [
+        "application/rtf",
+        "application/javascript",
+        "application/json",
+        "application/xml",
+        "font/ttf",
+        "application/font-sfnt",
+        "application/vnd.ms-fontobject",
+        "application/wasm",
+    ].into_iter().collect();
+}
 
 /// Create a wrapping handler that compresses the Body of a [`hyper::Response`]
 /// using gzip, `deflate`, `brotli` or `zstd` if is specified in the `Accept-Encoding` header, adding
@@ -87,8 +75,7 @@ pub fn auto(
 
         // Skip compression for non-text-based MIME types
         if let Some(content_type) = resp.headers().typed_get::<ContentType>() {
-            let mime = Mime::from(content_type);
-            if !TEXT_MIME_TYPES.iter().any(|h| *h == mime) {
+            if !is_text(Mime::from(content_type)) {
                 return Ok(resp);
             }
         }
@@ -121,6 +108,15 @@ pub fn auto(
     }
 
     Ok(resp)
+}
+
+/// Checks whether the MIME type corresponds to any of the known text types.
+fn is_text(mime: Mime) -> bool {
+    mime.type_() == mime::TEXT
+        || mime
+            .suffix()
+            .is_some_and(|suffix| suffix == mime::XML || suffix == mime::JSON)
+        || TEXT_MIME_TYPES.contains(mime.essence_str())
 }
 
 /// Create a wrapping handler that compresses the Body of a [`Response`].


### PR DESCRIPTION
## Description
If you look at the [list of MIME types potentially produced by the `mime_guess` package](https://github.com/abonander/mime_guess/blob/master/src/mime_types.rs), the list in `compression::TEXT_MIME_TYPES` isn’t really great for recognizing text MIME types. This implements the following changes:

* Generic recognition for MIME types starting with `text/` or ending in `+xml`/`+json`
* Faster testing of the remaining MIME type list by using a `HashSet`
* Recognition no longer confused by `charset` parameter (a bug I mentioned in #359)
* Adjusted font MIME types to the ones actually produced by `mime_guess` and removed the outdated `application/x-javascript` type 

Note that `lazy_static` isn’t a new dependency, we already have it as a transitive dependency via `tracing-subscriber`.

## How Has This Been Tested?
Functional testing on Linux looks fine, and Rust files (`text/x-rust`) are now being compressed as well.