### PR TITLE
Fix Accept-Encoding handling to work correctly if only two compression schemes are available

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -238,7 +238,7 @@ pub fn create_encoding_header(existing: Option<HeaderValue>, coding: ContentCodi
 #[inline(always)]
 pub fn get_preferred_encoding(headers: &HeaderMap<HeaderValue>) -> Option<ContentCoding> {
     if let Some(ref accept_encoding) = headers.typed_get::<AcceptEncoding>() {
-        tracing::trace!("request with accept-ecoding header: {:?}", accept_encoding);
+        tracing::trace!("request with accept-encoding header: {:?}", accept_encoding);
 
         for encoding in accept_encoding.sorted_encodings() {
             if AVAILABLE_ENCODINGS.contains(&encoding) {

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -60,13 +60,14 @@ mod tests {
 
     #[test]
     fn from_static() {
-        let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9");
+        let val = HeaderValue::from_static("deflate, zstd;q=0.7, gzip;q=1.0, br;q=0.9");
         let accept_enc = AcceptEncoding(val.into());
 
         let mut encodings = accept_enc.sorted_encodings();
         assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));
         assert_eq!(encodings.next(), Some(ContentCoding::GZIP));
         assert_eq!(encodings.next(), Some(ContentCoding::BROTLI));
+        assert_eq!(encodings.next(), Some(ContentCoding::ZSTD));
         assert_eq!(encodings.next(), None);
     }
 }

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -48,12 +48,6 @@ impl Header for AcceptEncoding {
 }
 
 impl AcceptEncoding {
-    /// Returns the most preferred encoding that is specified by the header,
-    /// if one is specified.
-    pub(crate) fn preferred_encoding(&self) -> Option<ContentCoding> {
-        self.0.iter().next().map(ContentCoding::from)
-    }
-
     /// Returns a quality sorted iterator of the `ContentCoding`
     pub(crate) fn sorted_encodings(&self) -> impl Iterator<Item = ContentCoding> + '_ {
         self.0.iter().map(ContentCoding::from)
@@ -68,11 +62,6 @@ mod tests {
     fn from_static() {
         let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9");
         let accept_enc = AcceptEncoding(val.into());
-
-        assert_eq!(
-            accept_enc.preferred_encoding(),
-            Some(ContentCoding::DEFLATE)
-        );
 
         let mut encodings = accept_enc.sorted_encodings();
         assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -671,12 +671,25 @@ mod tests {
     ))]
     #[tokio::test]
     async fn handle_file_compressions() {
-        let encodings = ["gzip", "deflate", "br", "zstd", "xyz"];
+        let encodings = [
+            #[cfg(any(feature = "compression", feature = "compression-gzip"))]
+            "gzip",
+            #[cfg(any(feature = "compression", feature = "compression-deflate"))]
+            "deflate",
+            #[cfg(any(feature = "compression", feature = "compression-brotli"))]
+            "br",
+            #[cfg(any(feature = "compression", feature = "compression-zstd"))]
+            "zstd",
+            "xyz",
+        ];
         let method = &Method::GET;
 
         for enc in encodings {
             let mut headers = HeaderMap::new();
-            headers.insert(http::header::ACCEPT_ENCODING, enc.parse().unwrap());
+            headers.insert(
+                http::header::ACCEPT_ENCODING,
+                format!("identity, {enc}").parse().unwrap(),
+            );
 
             match static_files::handle(&HandleOpts {
                 method,


### PR DESCRIPTION
## Description
This fixes `compression::get_preferred_encoding()` to consider all encodings listed in `Accept-Encoding` header and not only the top one. While at it, I replaced dynamic construction of available encodings on each call by a constant.

## Motivation and Context
As things are right now, `compression::get_preferred_encoding()` only handles the scenarios “one compression scheme enabled” and “all compression schemes enabled” correctly, with the former being handled as a special case. If for example only `compression-deflate` and `compression-gzip` features are enabled and the client requests `Accept-Encoding: br, gzip`, it will return `None` because Brotli isn’t enabled – yet it should have recognized gzip being enabled.

## How Has This Been Tested?
I’ve adjusted the integration tests to explicitly test for the scenario where the top listed encoding isn’t something we support (`identity`). While at it, I fixed a bug in this test – it failed if only some compression features were enabled but not all.