### PR TITLE
Use sailfish templates for directory listings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,8 @@ dependencies = [
  "itoap",
  "ryu",
  "sailfish-macros",
+ "serde",
+ "serde_json",
  "version_check",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +710,12 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "itoap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9028f49264629065d057f340a86acb84867925865f73bbf8d47b4d149a7e88b8"
 
 [[package]]
 name = "jobserver"
@@ -1058,6 +1085,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "sailfish"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd5f4680149b62b3478f6af08a8f1c37794bc1bc577e28874a4d0c70084d600"
+dependencies = [
+ "itoap",
+ "ryu",
+ "sailfish-macros",
+ "version_check",
+]
+
+[[package]]
+name = "sailfish-compiler"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67087aca4a3886686a88cee6835089c53e6143a0b8c5be01e63e4fe2f6dfe7cb"
+dependencies = [
+ "filetime",
+ "home",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+]
+
+[[package]]
+name = "sailfish-macros"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47e31910c5f9230e99992568d05a5968fe4f42a635c3f912c993e9f66a619a5"
+dependencies = [
+ "proc-macro2",
+ "sailfish-compiler",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1297,7 @@ dependencies = [
  "prometheus",
  "regex",
  "rustls-pemfile",
+ "sailfish",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ percent-encoding = "2.3"
 pin-project = "1.1"
 regex = "1.10"
 rustls-pemfile = { version = "2.1", optional = true }
+sailfish = "0.8.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
 serde_repr = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ lto = "fat"
 opt-level = 3
 panic = "abort"
 rpath = false
-strip = true
+#strip = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ lto = "fat"
 opt-level = 3
 panic = "abort"
 rpath = false
-#strip = true
+strip = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ percent-encoding = "2.3"
 pin-project = "1.1"
 regex = "1.10"
 rustls-pemfile = { version = "2.1", optional = true }
-sailfish = { version = "0.8.3", optional = true }
+sailfish = { version = "0.8.3", features = ["json"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
 serde_repr = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ compression-deflate = ["async-compression/deflate"]
 compression-gzip = ["async-compression/deflate"]
 compression-zstd = ["async-compression/zstd"]
 # Directory listing
-directory-listing = ["humansize", "chrono"]
+directory-listing = ["humansize", "chrono", "sailfish"]
 # Basic HTTP Authorization
 basic-auth = ["bcrypt"]
 # Fallback Page
@@ -79,7 +79,7 @@ percent-encoding = "2.3"
 pin-project = "1.1"
 regex = "1.10"
 rustls-pemfile = { version = "2.1", optional = true }
-sailfish = "0.8.3"
+sailfish = { version = "0.8.3", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
 serde_repr = "0.1"

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -363,26 +363,6 @@ fn json_auto_index(entries: &mut [FileEntry], order_code: u8) -> Result<String> 
     Ok(DirListing { entries }.render_once()?)
 }
 
-/// Quotes a string value.
-fn json_quote_str(s: &str) -> String {
-    let mut r = String::from("\"");
-    for c in s.chars() {
-        match c {
-            '\\' => r.push_str("\\\\"),
-            '\u{0008}' => r.push_str("\\b"),
-            '\u{000c}' => r.push_str("\\f"),
-            '\n' => r.push_str("\\n"),
-            '\r' => r.push_str("\\r"),
-            '\t' => r.push_str("\\t"),
-            '"' => r.push_str("\\\""),
-            c if c.is_control() => r.push_str(format!("\\u{:04x}", c as u32).as_str()),
-            c => r.push(c),
-        };
-    }
-    r.push('\"');
-    r
-}
-
 /// Create an auto index in HTML format.
 fn html_auto_index<'a>(
     base_path: &'a str,

--- a/templates/directory_listing.html
+++ b/templates/directory_listing.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>Index of <%= current_path %></title>
+    <style>
+      html{background-color:#fff;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;min-width:20rem;text-rendering:optimizeLegibility;-webkit-text-size-adjust:100%;-moz-text-size-adjust:100%;text-size-adjust:100%}:after,:before{box-sizing:border-box;}body{padding:1rem;font-family:Consolas,'Liberation Mono',Menlo,monospace;font-size:.75rem;max-width:70rem;margin:0 auto;color:#4a4a4a;font-weight:400;line-height:1.5}h1{margin:0;padding:0;font-size:1rem;line-height:1.25;margin-bottom:0.5rem;}table{width:100%;table-layout:fixed;border-spacing: 0;}hr{border-style: none;border-bottom: solid 1px gray;}table th,table td{padding:.15rem 0;white-space:nowrap;vertical-align:top}table th a,table td a{display:inline-block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:95%;vertical-align:top;}table tr:hover td{background-color:#f5f5f5}footer{padding-top:0.5rem}table tr th{text-align:left;}@media (max-width:30rem){table th:first-child{width:20rem;}}
+    </style>
+  </head>
+  <body>
+    <h1>Index of <%= current_path %></h1>
+    <p><small>directories: <%= dirs_count %>, files: <%= files_count %></small></p>
+    <hr>
+    <div style="overflow-x: auto;">
+      <table>
+        <thead>
+          <tr>
+            <th><a href="?sort=<%= sort_attrs.name %>">Name</a></th>
+            <th style="width:10rem;"><a href="?sort=<%= sort_attrs.last_modified %>">Last modified</a></th>
+            <th style="width:6rem;text-align:right;"><a href="?sort=<%= sort_attrs.size %>">Size</a></th>
+          </tr>
+        </thead>
+        <% if base_path != "/" { %>
+          <tr><td colspan="3"><a href="../">../</a></td></tr>
+        <% } %>
+        <% for entry in entries { %>
+          <tr>
+            <td>
+              <a href="<%= entry.uri.as_ref().unwrap_or(&entry.name_encoded) %>">
+                <%= entry.name %><% if entry.is_dir { %>/<% } %>
+              </a>
+            </td>
+            <td>
+              <%= entry.modified.map_or("-".into(), |local_dt| {
+                local_dt.format(DATETIME_FORMAT_LOCAL).to_string()
+              }) %>
+            </td>
+            <td align="right">
+              <%=
+                if entry.filesize == 0 {
+                  "-".to_string()
+                } else {
+                  use humansize::FormatSize;
+                  entry.filesize.format_size(humansize::DECIMAL)
+                }
+              %>
+            </td>
+          </tr>
+        <% } %>
+      </table>
+    </div>
+    <hr>
+    <footer><small>Powered by Static Web Server (SWS) / static-web-server.net</small></footer>
+  </body>
+</html>

--- a/templates/directory_listing.json
+++ b/templates/directory_listing.json
@@ -1,0 +1,22 @@
+[
+  <% let mut first = true; %>
+  <% for entry in entries { %>
+    <% if !first { %>,<% } %>
+    <% if first {
+      first = false;
+    } %>
+    {
+      "name":<%= json_quote_str(&entry.name) %>,
+      "type":<% if entry.is_dir { %>"directory"<% } else { %>"file"<% } %>,
+      <% if !entry.is_dir { %>
+        "size":<%= entry.filesize %>,
+      <% } %>
+      "mtime":"<%= entry.modified.map_or("".to_owned(), |local_dt| {
+        local_dt
+            .with_timezone(&chrono::Utc)
+            .format(DATETIME_FORMAT_UTC)
+            .to_string()
+      }) %>"
+    }
+  <% } %>
+]

--- a/templates/directory_listing.json
+++ b/templates/directory_listing.json
@@ -6,17 +6,17 @@
       first = false;
     } %>
     {
-      "name":<%= json_quote_str(&entry.name) %>,
+      "name":<%= entry.name | json %>,
       "type":<% if entry.is_dir { %>"directory"<% } else { %>"file"<% } %>,
       <% if !entry.is_dir { %>
         "size":<%= entry.filesize %>,
       <% } %>
-      "mtime":"<%= entry.modified.map_or("".to_owned(), |local_dt| {
+      "mtime":<%= entry.modified.map_or("".to_owned(), |local_dt| {
         local_dt
             .with_timezone(&chrono::Utc)
             .format(DATETIME_FORMAT_UTC)
             .to_string()
-      }) %>"
+      }) | json %>
     }
   <% } %>
 ]

--- a/templates/directory_listing.json
+++ b/templates/directory_listing.json
@@ -1,10 +1,6 @@
 [
-  <% let mut first = true; %>
-  <% for entry in entries { %>
-    <% if !first { %>,<% } %>
-    <% if first {
-      first = false;
-    } %>
+  <% let mut entries = entries.iter().peekable(); %>
+  <% while let Some(entry) = entries.next() { %>
     {
       "name":<%= entry.name | json %>,
       "type":<% if entry.is_dir { %>"directory"<% } else { %>"file"<% } %>,
@@ -17,6 +13,6 @@
             .format(DATETIME_FORMAT_UTC)
             .to_string()
       }) | json %>
-    }
+    }<% if entries.peek().is_some() { %>,<% } %>
   <% } %>
 ]

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -213,7 +213,9 @@ mod tests {
 
                     assert_eq!(
                         body_str.contains(
-                            r#"<a href="sp%C3%A9cial%20direct%C3%B6ry/">spécial directöry/</a>"#
+                            r#"<a href="sp%C3%A9cial%20direct%C3%B6ry/">
+spécial directöry/
+</a>"#
                         ),
                         method == Method::GET
                     );


### PR DESCRIPTION
## Description
This uses sailfish crate to generate JSON and HTML directory listings instead of piecing things together manually. The advantage of sailfish is that it translates templates into Rust code at compile time which makes it fast. Local performance measurements indicate no change for HTML and a slight improvement (up to 5%) for JSON. The added benefit is automatic escaping in HTML. Downside is that `rm_whitespace` option only removes space characters and not newlines, so there are some of those in the listings now.

One thing to consider would be enabling the `json` feature for sailfish and using the corresponding filter instead of `json_quote_str()`. This functionality depends on serde_json which is already in the dependency tree.

## How Has This Been Tested?
Integration tests pass after being adjusted for the added newlines. Functional testing on Linux is also fine.