### PR TITLE
Use maud templates and serde_json for directory listings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "maud"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df518b75016b4289cdddffa1b01f2122f4a49802c93191f3133f6dc2472ebcaa"
+dependencies = [
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa453238ec218da0af6b11fc5978d3b5c3a45ed97b722391a2a11f3306274e18"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +933,29 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1226,6 +1271,7 @@ dependencies = [
  "humansize",
  "hyper",
  "listenfd",
+ "maud",
  "mime_guess",
  "percent-encoding",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ compression-deflate = ["async-compression/deflate"]
 compression-gzip = ["async-compression/deflate"]
 compression-zstd = ["async-compression/zstd"]
 # Directory listing
-directory-listing = ["humansize", "chrono"]
+directory-listing = ["humansize", "chrono", "maud"]
 # Basic HTTP Authorization
 basic-auth = ["bcrypt"]
 # Fallback Page
@@ -74,6 +74,7 @@ http-serde = "1.1"
 humansize = { version = "2.1", features = ["impl_style"], optional = true }
 hyper = { version = "0.14", features = ["stream", "http1", "http2", "tcp", "server"] }
 listenfd = "1.0"
+maud = { version = "0.26.0", optional = true }
 mime_guess = "2.0"
 percent-encoding = "2.3"
 pin-project = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ regex = "1.10"
 rustls-pemfile = { version = "2.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
+serde_json = "1.0"
 serde_repr = "0.1"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"] }
 tokio-rustls = { version = "0.25", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ regex = "1.10"
 rustls-pemfile = { version = "2.1", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
-serde_json = "1.0"
 serde_repr = "0.1"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"] }
 tokio-rustls = { version = "0.25", optional = true }

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -480,7 +480,10 @@ fn html_auto_index<'a>(
                                 }))
                             }
                             td align="right" {
-                                (entry.size.map(|size| size.format_size(humansize::DECIMAL)).unwrap_or("-".into()))
+                                (match entry.size.unwrap_or(0) {
+                                    0 => "-".to_owned(),
+                                    size => size.format_size(humansize::DECIMAL)
+                                })
                             }
                         }
                     }

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -14,7 +14,6 @@ use humansize::FormatSize;
 use hyper::{Body, Method, Response, StatusCode};
 use mime_guess::mime;
 use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
-use serde::{Serialize, Serializer};
 use std::future::Future;
 use std::io;
 use std::path::Path;
@@ -120,32 +119,14 @@ pub fn auto_index(
 const DATETIME_FORMAT_UTC: &str = "%FT%TZ";
 const DATETIME_FORMAT_LOCAL: &str = "%F %T";
 
-#[derive(Serialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-enum FileType {
-    Directory,
-    File,
-}
-
 /// Defines a file entry and its properties.
-#[derive(Serialize)]
 struct FileEntry {
     name: String,
-    #[serde(skip_serializing)]
     name_encoded: String,
-    #[serde(serialize_with = "serialize_mtime")]
-    mtime: Option<DateTime<Local>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    size: Option<u64>,
-    r#type: FileType,
-    #[serde(skip_serializing)]
+    modified: Option<DateTime<Local>>,
+    filesize: u64,
+    is_dir: bool,
     uri: Option<String>,
-}
-
-impl FileEntry {
-    fn is_dir(&self) -> bool {
-        self.r#type == FileType::Directory
-    }
 }
 
 /// Defines sorting attributes for file entries.
@@ -204,13 +185,13 @@ async fn read_dir_entries(
         }
 
         let mut name_encoded = utf8_percent_encode(&name, NON_ALPHANUMERIC).to_string();
-        let mut size = None;
+        let mut filesize = 0_u64;
 
         if meta.is_dir() {
             name_encoded.push('/');
             dirs_count += 1;
         } else if meta.is_file() {
-            size = Some(meta.len());
+            filesize = meta.len();
             files_count += 1;
         } else if meta.file_type().is_symlink() {
             // NOTE: we resolve the symlink path below to just know if is a directory or not.
@@ -244,7 +225,7 @@ async fn read_dir_entries(
                 name_encoded.push('/');
                 dirs_count += 1;
             } else {
-                size = Some(meta.len());
+                filesize = meta.len();
                 files_count += 1;
             }
         } else {
@@ -290,25 +271,21 @@ async fn read_dir_entries(
             uri = Some(base_str);
         }
 
-        let mtime = match parse_last_modified(meta.modified()?) {
+        let modified = match parse_last_modified(meta.modified()?) {
             Ok(local_dt) => Some(local_dt),
             Err(err) => {
                 tracing::error!("error determining the file's last modified: {:?}", err);
                 None
             }
         };
-        let r#type = if meta.is_dir() {
-            FileType::Directory
-        } else {
-            FileType::File
-        };
+        let is_dir = meta.is_dir();
 
         file_entries.push(FileEntry {
             name,
             name_encoded,
-            mtime,
-            size,
-            r#type,
+            modified,
+            filesize,
+            is_dir,
             uri,
         });
     }
@@ -377,22 +354,60 @@ async fn read_dir_entries(
 fn json_auto_index(entries: &mut [FileEntry], order_code: u8) -> Result<String> {
     sort_file_entries(entries, order_code);
 
-    Ok(serde_json::to_string(entries)?)
+    let mut json = String::from('[');
+
+    for entry in entries {
+        let file_size = &entry.filesize;
+        let file_name = &entry.name;
+        let file_type = if entry.is_dir { "directory" } else { "file" };
+        let file_modified = &entry.modified;
+
+        json.push('{');
+        json.push_str(format!("\"name\":{},", json_quote_str(file_name.as_str())).as_str());
+        json.push_str(format!("\"type\":\"{file_type}\",").as_str());
+
+        let file_modified_str = file_modified.map_or("".to_owned(), |local_dt| {
+            local_dt
+                .with_timezone(&Utc)
+                .format(DATETIME_FORMAT_UTC)
+                .to_string()
+        });
+        json.push_str(format!("\"mtime\":\"{file_modified_str}\"").as_str());
+
+        if !entry.is_dir {
+            json.push_str(format!(",\"size\":{file_size}").as_str());
+        }
+        json.push_str("},");
+    }
+
+    // Strip trailing comma out in case of available items
+    if json.len() > 1 {
+        json.pop();
+    }
+
+    json.push(']');
+
+    Ok(json)
 }
 
-/// Serialize FileEntry::mtime field
-fn serialize_mtime<S: Serializer>(
-    mtime: &Option<DateTime<Local>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    match mtime {
-        Some(dt) => serializer.serialize_str(
-            &dt.with_timezone(&Utc)
-                .format(DATETIME_FORMAT_UTC)
-                .to_string(),
-        ),
-        None => serializer.serialize_str(""),
+/// Quotes a string value.
+fn json_quote_str(s: &str) -> String {
+    let mut r = String::from("\"");
+    for c in s.chars() {
+        match c {
+            '\\' => r.push_str("\\\\"),
+            '\u{0008}' => r.push_str("\\b"),
+            '\u{000c}' => r.push_str("\\f"),
+            '\n' => r.push_str("\\n"),
+            '\r' => r.push_str("\\r"),
+            '\t' => r.push_str("\\t"),
+            '"' => r.push_str("\\\""),
+            c if c.is_control() => r.push_str(format!("\\u{:04x}", c as u32).as_str()),
+            c => r.push(c),
+        };
     }
+    r.push('\"');
+    r
 }
 
 /// Create an auto index in HTML format.
@@ -469,21 +484,22 @@ fn html_auto_index<'a>(
                             td {
                                 a href=(entry.uri.as_ref().unwrap_or(&entry.name_encoded)) {
                                     (entry.name)
-                                    @if entry.is_dir() {
+                                    @if entry.is_dir {
                                         "/"
                                     }
                                 }
                             }
                             td {
-                                (entry.mtime.map_or("-".to_owned(), |local_dt| {
+                                (entry.modified.map_or("-".to_owned(), |local_dt| {
                                     local_dt.format(DATETIME_FORMAT_LOCAL).to_string()
                                 }))
                             }
                             td align="right" {
-                                (match entry.size.unwrap_or(0) {
-                                    0 => "-".to_owned(),
-                                    size => size.format_size(humansize::DECIMAL)
-                                })
+                                @if entry.filesize == 0 {
+                                    "-"
+                                } @else {
+                                    (entry.filesize.format_size(humansize::DECIMAL))
+                                }
                             }
                         }
                     }
@@ -518,7 +534,7 @@ fn sort_file_entries(files: &mut [FileEntry], order_code: u8) -> SortingAttr<'_>
         }
         2 | 3 => {
             // Modified (asc, desc)
-            files.sort_by_key(|f| f.mtime);
+            files.sort_by_key(|f| f.modified);
             if order_code == 3 {
                 files.reverse();
             } else {
@@ -527,7 +543,7 @@ fn sort_file_entries(files: &mut [FileEntry], order_code: u8) -> SortingAttr<'_>
         }
         4 | 5 => {
             // File size (asc, desc)
-            files.sort_by_key(|f| f.size);
+            files.sort_by_key(|f| f.filesize);
             if order_code == 5 {
                 files.reverse();
             } else {

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -14,6 +14,7 @@ use humansize::FormatSize;
 use hyper::{Body, Method, Response, StatusCode};
 use mime_guess::mime;
 use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
+use serde::{Serialize, Serializer};
 use std::future::Future;
 use std::io;
 use std::path::Path;
@@ -119,14 +120,32 @@ pub fn auto_index(
 const DATETIME_FORMAT_UTC: &str = "%FT%TZ";
 const DATETIME_FORMAT_LOCAL: &str = "%F %T";
 
+#[derive(Serialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum FileType {
+    Directory,
+    File,
+}
+
 /// Defines a file entry and its properties.
+#[derive(Serialize)]
 struct FileEntry {
     name: String,
+    #[serde(skip_serializing)]
     name_encoded: String,
-    modified: Option<DateTime<Local>>,
-    filesize: u64,
-    is_dir: bool,
+    #[serde(serialize_with = "serialize_mtime")]
+    mtime: Option<DateTime<Local>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
+    r#type: FileType,
+    #[serde(skip_serializing)]
     uri: Option<String>,
+}
+
+impl FileEntry {
+    fn is_dir(&self) -> bool {
+        self.r#type == FileType::Directory
+    }
 }
 
 /// Defines sorting attributes for file entries.
@@ -185,13 +204,13 @@ async fn read_dir_entries(
         }
 
         let mut name_encoded = utf8_percent_encode(&name, NON_ALPHANUMERIC).to_string();
-        let mut filesize = 0_u64;
+        let mut size = None;
 
         if meta.is_dir() {
             name_encoded.push('/');
             dirs_count += 1;
         } else if meta.is_file() {
-            filesize = meta.len();
+            size = Some(meta.len());
             files_count += 1;
         } else if meta.file_type().is_symlink() {
             // NOTE: we resolve the symlink path below to just know if is a directory or not.
@@ -225,7 +244,7 @@ async fn read_dir_entries(
                 name_encoded.push('/');
                 dirs_count += 1;
             } else {
-                filesize = meta.len();
+                size = Some(meta.len());
                 files_count += 1;
             }
         } else {
@@ -271,21 +290,25 @@ async fn read_dir_entries(
             uri = Some(base_str);
         }
 
-        let modified = match parse_last_modified(meta.modified()?) {
+        let mtime = match parse_last_modified(meta.modified()?) {
             Ok(local_dt) => Some(local_dt),
             Err(err) => {
                 tracing::error!("error determining the file's last modified: {:?}", err);
                 None
             }
         };
-        let is_dir = meta.is_dir();
+        let r#type = if meta.is_dir() {
+            FileType::Directory
+        } else {
+            FileType::File
+        };
 
         file_entries.push(FileEntry {
             name,
             name_encoded,
-            modified,
-            filesize,
-            is_dir,
+            mtime,
+            size,
+            r#type,
             uri,
         });
     }
@@ -354,60 +377,22 @@ async fn read_dir_entries(
 fn json_auto_index(entries: &mut [FileEntry], order_code: u8) -> Result<String> {
     sort_file_entries(entries, order_code);
 
-    let mut json = String::from('[');
-
-    for entry in entries {
-        let file_size = &entry.filesize;
-        let file_name = &entry.name;
-        let file_type = if entry.is_dir { "directory" } else { "file" };
-        let file_modified = &entry.modified;
-
-        json.push('{');
-        json.push_str(format!("\"name\":{},", json_quote_str(file_name.as_str())).as_str());
-        json.push_str(format!("\"type\":\"{file_type}\",").as_str());
-
-        let file_modified_str = file_modified.map_or("".to_owned(), |local_dt| {
-            local_dt
-                .with_timezone(&Utc)
-                .format(DATETIME_FORMAT_UTC)
-                .to_string()
-        });
-        json.push_str(format!("\"mtime\":\"{file_modified_str}\"").as_str());
-
-        if !entry.is_dir {
-            json.push_str(format!(",\"size\":{file_size}").as_str());
-        }
-        json.push_str("},");
-    }
-
-    // Strip trailing comma out in case of available items
-    if json.len() > 1 {
-        json.pop();
-    }
-
-    json.push(']');
-
-    Ok(json)
+    Ok(serde_json::to_string(entries)?)
 }
 
-/// Quotes a string value.
-fn json_quote_str(s: &str) -> String {
-    let mut r = String::from("\"");
-    for c in s.chars() {
-        match c {
-            '\\' => r.push_str("\\\\"),
-            '\u{0008}' => r.push_str("\\b"),
-            '\u{000c}' => r.push_str("\\f"),
-            '\n' => r.push_str("\\n"),
-            '\r' => r.push_str("\\r"),
-            '\t' => r.push_str("\\t"),
-            '"' => r.push_str("\\\""),
-            c if c.is_control() => r.push_str(format!("\\u{:04x}", c as u32).as_str()),
-            c => r.push(c),
-        };
+/// Serialize FileEntry::mtime field
+fn serialize_mtime<S: Serializer>(
+    mtime: &Option<DateTime<Local>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match mtime {
+        Some(dt) => serializer.serialize_str(
+            &dt.with_timezone(&Utc)
+                .format(DATETIME_FORMAT_UTC)
+                .to_string(),
+        ),
+        None => serializer.serialize_str(""),
     }
-    r.push('\"');
-    r
 }
 
 /// Create an auto index in HTML format.
@@ -484,22 +469,18 @@ fn html_auto_index<'a>(
                             td {
                                 a href=(entry.uri.as_ref().unwrap_or(&entry.name_encoded)) {
                                     (entry.name)
-                                    @if entry.is_dir {
+                                    @if entry.is_dir() {
                                         "/"
                                     }
                                 }
                             }
                             td {
-                                (entry.modified.map_or("-".to_owned(), |local_dt| {
+                                (entry.mtime.map_or("-".to_owned(), |local_dt| {
                                     local_dt.format(DATETIME_FORMAT_LOCAL).to_string()
                                 }))
                             }
                             td align="right" {
-                                @if entry.filesize == 0 {
-                                    "-"
-                                } @else {
-                                    (entry.filesize.format_size(humansize::DECIMAL))
-                                }
+                                (entry.size.map(|size| size.format_size(humansize::DECIMAL)).unwrap_or("-".into()))
                             }
                         }
                     }
@@ -534,7 +515,7 @@ fn sort_file_entries(files: &mut [FileEntry], order_code: u8) -> SortingAttr<'_>
         }
         2 | 3 => {
             // Modified (asc, desc)
-            files.sort_by_key(|f| f.modified);
+            files.sort_by_key(|f| f.mtime);
             if order_code == 3 {
                 files.reverse();
             } else {
@@ -543,7 +524,7 @@ fn sort_file_entries(files: &mut [FileEntry], order_code: u8) -> SortingAttr<'_>
         }
         4 | 5 => {
             // File size (asc, desc)
-            files.sort_by_key(|f| f.filesize);
+            files.sort_by_key(|f| f.size);
             if order_code == 5 {
                 files.reverse();
             } else {

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -14,6 +14,7 @@ use humansize::FormatSize;
 use hyper::{Body, Method, Response, StatusCode};
 use mime_guess::mime;
 use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
+use serde::{Serialize, Serializer};
 use std::future::Future;
 use std::io;
 use std::path::Path;
@@ -119,14 +120,32 @@ pub fn auto_index(
 const DATETIME_FORMAT_UTC: &str = "%FT%TZ";
 const DATETIME_FORMAT_LOCAL: &str = "%F %T";
 
+#[derive(Serialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum FileType {
+    Directory,
+    File,
+}
+
 /// Defines a file entry and its properties.
+#[derive(Serialize)]
 struct FileEntry {
     name: String,
+    #[serde(skip_serializing)]
     name_encoded: String,
-    modified: Option<DateTime<Local>>,
-    filesize: u64,
-    is_dir: bool,
+    #[serde(serialize_with = "serialize_mtime")]
+    mtime: Option<DateTime<Local>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
+    r#type: FileType,
+    #[serde(skip_serializing)]
     uri: Option<String>,
+}
+
+impl FileEntry {
+    fn is_dir(&self) -> bool {
+        self.r#type == FileType::Directory
+    }
 }
 
 /// Defines sorting attributes for file entries.
@@ -185,13 +204,13 @@ async fn read_dir_entries(
         }
 
         let mut name_encoded = utf8_percent_encode(&name, NON_ALPHANUMERIC).to_string();
-        let mut filesize = 0_u64;
+        let mut size = None;
 
         if meta.is_dir() {
             name_encoded.push('/');
             dirs_count += 1;
         } else if meta.is_file() {
-            filesize = meta.len();
+            size = Some(meta.len());
             files_count += 1;
         } else if meta.file_type().is_symlink() {
             // NOTE: we resolve the symlink path below to just know if is a directory or not.
@@ -225,7 +244,7 @@ async fn read_dir_entries(
                 name_encoded.push('/');
                 dirs_count += 1;
             } else {
-                filesize = meta.len();
+                size = Some(meta.len());
                 files_count += 1;
             }
         } else {
@@ -271,21 +290,25 @@ async fn read_dir_entries(
             uri = Some(base_str);
         }
 
-        let modified = match parse_last_modified(meta.modified()?) {
+        let mtime = match parse_last_modified(meta.modified()?) {
             Ok(local_dt) => Some(local_dt),
             Err(err) => {
                 tracing::error!("error determining the file's last modified: {:?}", err);
                 None
             }
         };
-        let is_dir = meta.is_dir();
+        let r#type = if meta.is_dir() {
+            FileType::Directory
+        } else {
+            FileType::File
+        };
 
         file_entries.push(FileEntry {
             name,
             name_encoded,
-            modified,
-            filesize,
-            is_dir,
+            mtime,
+            size,
+            r#type,
             uri,
         });
     }
@@ -354,60 +377,22 @@ async fn read_dir_entries(
 fn json_auto_index(entries: &mut [FileEntry], order_code: u8) -> Result<String> {
     sort_file_entries(entries, order_code);
 
-    let mut json = String::from('[');
-
-    for entry in entries {
-        let file_size = &entry.filesize;
-        let file_name = &entry.name;
-        let file_type = if entry.is_dir { "directory" } else { "file" };
-        let file_modified = &entry.modified;
-
-        json.push('{');
-        json.push_str(format!("\"name\":{},", json_quote_str(file_name.as_str())).as_str());
-        json.push_str(format!("\"type\":\"{file_type}\",").as_str());
-
-        let file_modified_str = file_modified.map_or("".to_owned(), |local_dt| {
-            local_dt
-                .with_timezone(&Utc)
-                .format(DATETIME_FORMAT_UTC)
-                .to_string()
-        });
-        json.push_str(format!("\"mtime\":\"{file_modified_str}\"").as_str());
-
-        if !entry.is_dir {
-            json.push_str(format!(",\"size\":{file_size}").as_str());
-        }
-        json.push_str("},");
-    }
-
-    // Strip trailing comma out in case of available items
-    if json.len() > 1 {
-        json.pop();
-    }
-
-    json.push(']');
-
-    Ok(json)
+    Ok(serde_json::to_string(entries)?)
 }
 
-/// Quotes a string value.
-fn json_quote_str(s: &str) -> String {
-    let mut r = String::from("\"");
-    for c in s.chars() {
-        match c {
-            '\\' => r.push_str("\\\\"),
-            '\u{0008}' => r.push_str("\\b"),
-            '\u{000c}' => r.push_str("\\f"),
-            '\n' => r.push_str("\\n"),
-            '\r' => r.push_str("\\r"),
-            '\t' => r.push_str("\\t"),
-            '"' => r.push_str("\\\""),
-            c if c.is_control() => r.push_str(format!("\\u{:04x}", c as u32).as_str()),
-            c => r.push(c),
-        };
+/// Serialize FileEntry::mtime field
+fn serialize_mtime<S: Serializer>(
+    mtime: &Option<DateTime<Local>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match mtime {
+        Some(dt) => serializer.serialize_str(
+            &dt.with_timezone(&Utc)
+                .format(DATETIME_FORMAT_UTC)
+                .to_string(),
+        ),
+        None => serializer.serialize_str(""),
     }
-    r.push('\"');
-    r
 }
 
 /// Create an auto index in HTML format.
@@ -484,22 +469,21 @@ fn html_auto_index<'a>(
                             td {
                                 a href=(entry.uri.as_ref().unwrap_or(&entry.name_encoded)) {
                                     (entry.name)
-                                    @if entry.is_dir {
+                                    @if entry.is_dir() {
                                         "/"
                                     }
                                 }
                             }
                             td {
-                                (entry.modified.map_or("-".to_owned(), |local_dt| {
+                                (entry.mtime.map_or("-".to_owned(), |local_dt| {
                                     local_dt.format(DATETIME_FORMAT_LOCAL).to_string()
                                 }))
                             }
                             td align="right" {
-                                @if entry.filesize == 0 {
-                                    "-"
-                                } @else {
-                                    (entry.filesize.format_size(humansize::DECIMAL))
-                                }
+                                (match entry.size.unwrap_or(0) {
+                                    0 => "-".to_owned(),
+                                    size => size.format_size(humansize::DECIMAL)
+                                })
                             }
                         }
                     }
@@ -534,7 +518,7 @@ fn sort_file_entries(files: &mut [FileEntry], order_code: u8) -> SortingAttr<'_>
         }
         2 | 3 => {
             // Modified (asc, desc)
-            files.sort_by_key(|f| f.modified);
+            files.sort_by_key(|f| f.mtime);
             if order_code == 3 {
                 files.reverse();
             } else {
@@ -543,7 +527,7 @@ fn sort_file_entries(files: &mut [FileEntry], order_code: u8) -> SortingAttr<'_>
         }
         4 | 5 => {
             // File size (asc, desc)
-            files.sort_by_key(|f| f.filesize);
+            files.sort_by_key(|f| f.size);
             if order_code == 5 {
                 files.reverse();
             } else {


### PR DESCRIPTION
## Description
This is essentially the same as #365 but using maud templates. Maud provides a cleaner syntax than sailfish (IMHO), and it doesn’t masquerade as being separate from the code (sailfish templates also use variables which are in scope even when these are outside the template). Local testing indicates no performance difference here either. But unlike sailfish, using maud doesn’t result in additional whitespace.

Downside: maud is for HTML only, JSON logic remains as it was. Then again, maybe it’s better to just go to serde_json for a cleaner JSON generation approach.

## How Has This Been Tested?
Integration tests pass. Functional testing on Linux is also fine.