### PR TITLE
Fix errors due to "unused code" when features are disabled

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,6 +6,14 @@
 //! Request handler module intended to manage incoming HTTP requests.
 //!
 
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
+use headers::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
 use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc};
 
@@ -16,7 +24,7 @@ use std::{future::Future, net::IpAddr, net::SocketAddr, path::PathBuf, sync::Arc
     feature = "compression-zstd",
     feature = "compression-deflate"
 ))]
-use {crate::compression, headers::HeaderValue};
+use crate::compression;
 
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -289,7 +289,6 @@ impl RequestHandler {
                         &self.opts.page50x,
                     )?;
 
-
                     // Check for a fallback response
                     #[cfg(feature = "fallback-page")]
                     let resp = if req.method().is_get()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,13 @@ pub(crate) mod file_path;
 pub(crate) mod file_response;
 pub(crate) mod file_stream;
 pub mod handler;
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
 pub(crate) mod headers_ext;
 pub(crate) mod health;
 pub(crate) mod http_ext;


### PR DESCRIPTION
## Description
Unfortunately, my previous changes caused some compile errors when compiling with `--no-default-features`. That’s mostly due to unused code, one error is because of a variable being unnecessarily mutable.

## Related Issue
#340, #342

## How Has This Been Tested?
Tests pass.