### PR TITLE
Don't percent-encode unreserved characters for directory listing links

### DIFF
--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -213,7 +213,7 @@ mod tests {
 
                     assert_eq!(
                         body_str.contains(
-                            r#"<a href="sp%C3%A9cial%20direct%C3%B6ry/">spécial directöry/</a>"#
+                            r#"<a href="sp%C3%A9cial-direct%C3%B6ry.net/">spécial-directöry.net/</a>"#
                         ),
                         method == Method::GET
                     );
@@ -269,7 +269,7 @@ mod tests {
                         assert_eq!(entries.len(), 3);
 
                         let first_entry = entries.first().unwrap();
-                        assert_eq!(first_entry.name, "spécial directöry");
+                        assert_eq!(first_entry.name, "spécial-directöry.net");
                         assert_eq!(first_entry.typed, "directory");
                         assert!(!first_entry.mtime.is_empty());
                         assert!(first_entry.size.is_none());


### PR DESCRIPTION
 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->
Previously we were percent-encoding the whole file and directory entry links when listing a directory regardless if those characters can be allowed to be in a URI "as is".

This PR prevents percent-encoding the following characters (a.k.a unreserved marks): `_-.~`

https://www.ietf.org/rfc/rfc3986.txt
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/static-web-server/static-web-server/issues/332#issuecomment-2075858645

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Improve directory listing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

Functional testing and integration tests adjusted accordingly.

## Screenshots (if appropriate):
