### PR TITLE
Move all fallback page logic into the corresponding module

### DIFF
--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     compression, handler::RequestHandlerOpts, headers_ext::ContentCoding,
-    static_files::file_metadata,
+    static_files::file_metadata, Error,
 };
 
 /// It defines the pre-compressed file variant metadata of a particular file path.
@@ -39,10 +39,10 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 pub(crate) fn post_process(
     opts: &RequestHandlerOpts,
     _req: &Request<Body>,
-    resp: &mut Response<Body>,
-) {
+    mut resp: Response<Body>,
+) -> Result<Response<Body>, Error> {
     if !opts.compression_static {
-        return;
+        return Ok(resp);
     }
 
     // Compression content encoding varies so use a `Vary` header
@@ -50,6 +50,8 @@ pub(crate) fn post_process(
         hyper::header::VARY,
         HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
     );
+
+    Ok(resp)
 }
 
 /// Search for the pre-compressed variant of the given file path.

--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -9,7 +9,7 @@
 
 use hyper::{Body, Request, Response};
 
-use crate::handler::RequestHandlerOpts;
+use crate::{handler::RequestHandlerOpts, Error};
 
 // Cache-Control `max-age` variants
 const MAX_AGE_ONE_HOUR: u64 = 60 * 60;
@@ -33,11 +33,12 @@ pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 pub(crate) fn post_process(
     opts: &RequestHandlerOpts,
     req: &Request<Body>,
-    resp: &mut Response<Body>,
-) {
+    mut resp: Response<Body>,
+) -> Result<Response<Body>, Error> {
     if opts.cache_control_headers {
-        append_headers(req.uri().path(), resp);
+        append_headers(req.uri().path(), &mut resp);
     }
+    Ok(resp)
 }
 
 /// It appends a `Cache-Control` header to a response if that one is part of a set of file types.

--- a/src/custom_headers.rs
+++ b/src/custom_headers.rs
@@ -9,23 +9,24 @@
 use hyper::{Body, Request, Response};
 use std::{ffi::OsStr, path::PathBuf};
 
-use crate::{handler::RequestHandlerOpts, settings::Headers};
+use crate::{handler::RequestHandlerOpts, settings::Headers, Error};
 
 /// Appends custom HTTP headers to a response if necessary
 pub(crate) fn post_process(
     opts: &RequestHandlerOpts,
     req: &Request<Body>,
-    resp: &mut Response<Body>,
+    mut resp: Response<Body>,
     file_path: Option<&PathBuf>,
-) {
+) -> Result<Response<Body>, Error> {
     if let Some(advanced) = &opts.advanced_opts {
         append_headers(
             req.uri().path(),
             advanced.headers.as_deref(),
-            resp,
+            &mut resp,
             file_path,
         )
     }
+    Ok(resp)
 }
 
 /// Append custom HTTP headers to current response.

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -7,8 +7,40 @@
 //!
 
 use headers::{AcceptRanges, ContentLength, ContentType, HeaderMapExt};
-use hyper::{Body, Response, StatusCode};
+use hyper::{Body, Request, Response, StatusCode};
 use mime_guess::mime;
+use std::path::Path;
+
+use crate::{handler::RequestHandlerOpts, helpers, http_ext::MethodExt, Error};
+
+/// Initializes fallpack page processing
+pub(crate) fn init(path: &Path, handler_opts: &mut RequestHandlerOpts) {
+    handler_opts.page_fallback = helpers::read_bytes_default(path);
+
+    server_info!(
+        "fallback page: enabled={}, value=\"{}\"",
+        !handler_opts.page_fallback.is_empty(),
+        path.to_string_lossy()
+    );
+}
+
+/// Replace 404 Not Found by the configured fallback page
+pub(crate) fn post_process(
+    opts: &RequestHandlerOpts,
+    req: &Request<Body>,
+    resp: Response<Body>,
+) -> Result<Response<Body>, Error> {
+    Ok(
+        if req.method().is_get()
+            && resp.status() == StatusCode::NOT_FOUND
+            && !opts.page_fallback.is_empty()
+        {
+            fallback_response(&opts.page_fallback)
+        } else {
+            resp
+        },
+    )
+}
 
 /// Checks if a fallback response can be generated, i.e. if it is a `GET` request
 /// that would result in a `404` error and a fallback page is configured.
@@ -26,4 +58,134 @@ pub fn fallback_response(page_fallback: &[u8]) -> Response<Body> {
     resp.headers_mut().typed_insert(AcceptRanges::bytes());
 
     resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::post_process;
+    use crate::{error_page, handler::RequestHandlerOpts, Error};
+    use hyper::{Body, Method, Request, Response, StatusCode, Uri};
+    use std::path::PathBuf;
+
+    fn make_request(method: &str) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri("/")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn make_response(status: &StatusCode) -> Response<Body> {
+        error_page::error_response(
+            &Uri::try_from("/").unwrap(),
+            &Method::GET,
+            status,
+            &PathBuf::new(),
+            &PathBuf::new(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_success_code() -> Result<(), Error> {
+        let opts = RequestHandlerOpts {
+            page_fallback: vec![1, 2, 3],
+            ..Default::default()
+        };
+        let req = make_request("GET");
+        let resp = make_response(&StatusCode::OK);
+
+        let resp = post_process(&opts, &req, resp)?;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_ne!(
+            resp.headers()
+                .get("Content-Length")
+                .map(|v| v.to_str().unwrap())
+                .unwrap_or("3"),
+            "3"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wrong_error() -> Result<(), Error> {
+        let opts = RequestHandlerOpts {
+            page_fallback: vec![1, 2, 3],
+            ..Default::default()
+        };
+        let req = make_request("GET");
+        let resp = make_response(&StatusCode::INTERNAL_SERVER_ERROR);
+
+        let resp = post_process(&opts, &req, resp)?;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_ne!(
+            resp.headers()
+                .get("Content-Length")
+                .map(|v| v.to_str().unwrap())
+                .unwrap_or("3"),
+            "3"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wrong_method() -> Result<(), Error> {
+        let opts = RequestHandlerOpts {
+            page_fallback: vec![1, 2, 3],
+            ..Default::default()
+        };
+        let req = make_request("POST");
+        let resp = make_response(&StatusCode::NOT_FOUND);
+
+        let resp = post_process(&opts, &req, resp)?;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_ne!(
+            resp.headers()
+                .get("Content-Length")
+                .map(|v| v.to_str().unwrap())
+                .unwrap_or("3"),
+            "3"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unconfigured() -> Result<(), Error> {
+        let opts = RequestHandlerOpts {
+            page_fallback: Vec::new(),
+            ..Default::default()
+        };
+        let req = make_request("GET");
+        let resp = make_response(&StatusCode::NOT_FOUND);
+
+        let resp = post_process(&opts, &req, resp)?;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fallback() -> Result<(), Error> {
+        let opts = RequestHandlerOpts {
+            page_fallback: vec![1, 2, 3],
+            ..Default::default()
+        };
+        let req = make_request("GET");
+        let resp = make_response(&StatusCode::NOT_FOUND);
+
+        let resp = post_process(&opts, &req, resp)?;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("Content-Length")
+                .map(|v| v.to_str().unwrap())
+                .unwrap_or("3"),
+            "3"
+        );
+
+        Ok(())
+    }
 }

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 
 use crate::{handler::RequestHandlerOpts, helpers, http_ext::MethodExt, Error};
 
-/// Initializes fallpack page processing
+/// Initializes fallback page processing
 pub(crate) fn init(path: &Path, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.page_fallback = helpers::read_bytes_default(path);
 

--- a/src/security_headers.rs
+++ b/src/security_headers.rs
@@ -11,7 +11,7 @@ use http::header::{
 };
 use hyper::{Body, Request, Response};
 
-use crate::handler::RequestHandlerOpts;
+use crate::{handler::RequestHandlerOpts, Error};
 
 pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.security_headers = enabled;
@@ -22,11 +22,12 @@ pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 pub(crate) fn post_process(
     opts: &RequestHandlerOpts,
     _req: &Request<Body>,
-    resp: &mut Response<Body>,
-) {
+    mut resp: Response<Body>,
+) -> Result<Response<Body>, Error> {
     if opts.security_headers {
-        append_headers(resp);
+        append_headers(&mut resp);
     }
+    Ok(resp)
 }
 
 /// It appends security headers like `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2 years max-age),


### PR DESCRIPTION
## Description
I’ve made sure that fallback page logic is implemented in a generic way, with a `post_process()` call for the response. While at it, I’ve also unified the signatures of the various `post_process()` calls (well, almost).

## Related Issue
This is another step towards #342.

## How Has This Been Tested?
Tests pass, a few more tests have been added. Functional testing on Linux looks fine.