### PR TITLE
Do not mention request body type unnecessarily #340

### DIFF
--- a/src/basic_auth.rs
+++ b/src/basic_auth.rs
@@ -22,9 +22,9 @@ pub(crate) fn init(credentials: &str, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Handles `Basic` HTTP Authorization Schema
-pub(crate) fn pre_process(
+pub(crate) fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     if opts.basic_auth.is_empty() {
         return None;

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -87,9 +87,9 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Post-processing to dynamically compress the response if necessary.
-pub(crate) fn post_process(
+pub(crate) fn post_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
     mut resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
     if !opts.compression {

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -36,9 +36,9 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Post-processing to add Vary header if necessary.
-pub(crate) fn post_process(
+pub(crate) fn post_process<T>(
     opts: &RequestHandlerOpts,
-    _req: &Request<Body>,
+    _req: &Request<T>,
     mut resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
     if !opts.compression_static {

--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -30,9 +30,9 @@ pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Appends `Cache-Control` header to a response if necessary
-pub(crate) fn post_process(
+pub(crate) fn post_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
     mut resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
     if opts.cache_control_headers {

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -394,9 +394,9 @@ pub(crate) fn init(
 }
 
 /// Rejects requests with wrong CORS headers
-pub(crate) fn pre_process(
+pub(crate) fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     let cors = opts.cors.as_ref()?;
     match cors.check_request(req.method(), req.headers()) {
@@ -418,9 +418,9 @@ pub(crate) fn pre_process(
 }
 
 /// Adds CORS headers to response
-pub(crate) fn post_process(
+pub(crate) fn post_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
     mut resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
     if let Some(cors) = opts.cors.as_ref() {

--- a/src/custom_headers.rs
+++ b/src/custom_headers.rs
@@ -12,9 +12,9 @@ use std::{ffi::OsStr, path::PathBuf};
 use crate::{handler::RequestHandlerOpts, settings::Headers, Error};
 
 /// Appends custom HTTP headers to a response if necessary
-pub(crate) fn post_process(
+pub(crate) fn post_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
     mut resp: Response<Body>,
     file_path: Option<&PathBuf>,
 ) -> Result<Response<Body>, Error> {

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -25,9 +25,9 @@ pub(crate) fn init(path: &Path, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Replace 404 Not Found by the configured fallback page
-pub(crate) fn post_process(
+pub(crate) fn post_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
     resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
     Ok(

--- a/src/health.rs
+++ b/src/health.rs
@@ -18,9 +18,9 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Handles health requests
-pub fn pre_process(
+pub fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
     remote_addr_str: &str,
 ) -> Option<Result<Response<Body>, Error>> {
     if !opts.health {

--- a/src/https_redirect.rs
+++ b/src/https_redirect.rs
@@ -23,8 +23,8 @@ pub struct RedirectOpts {
 }
 
 /// It redirects all requests from HTTP to HTTPS.
-pub async fn redirect_to_https(
-    req: &Request<Body>,
+pub async fn redirect_to_https<T>(
+    req: &Request<T>,
     opts: Arc<RedirectOpts>,
 ) -> Result<Response<Body>, StatusCode> {
     if let Some(ref host) = req.headers().typed_get::<Host>() {

--- a/src/maintenance_mode.rs
+++ b/src/maintenance_mode.rs
@@ -40,9 +40,9 @@ pub(crate) fn init(
 }
 
 /// Produces maintenance mode response if necessary
-pub(crate) fn pre_process(
+pub(crate) fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     if opts.maintenance_mode {
         Some(get_response(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -27,9 +27,9 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Handles metrics requests
-pub fn pre_process(
+pub fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     if !opts.experimental_metrics {
         return None;

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -13,9 +13,9 @@ use regex::Regex;
 use crate::{error_page, handler::RequestHandlerOpts, settings::Redirects, Error};
 
 /// Applies redirect rules to a request if necessary.
-pub(crate) fn pre_process(
+pub(crate) fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     let redirects = opts.advanced_opts.as_ref()?.redirects.as_deref()?;
 
@@ -96,10 +96,10 @@ pub(crate) fn replace_placeholders(
 }
 
 /// Logs error and produces an Internal Server Error response.
-pub(crate) fn handle_error(
+pub(crate) fn handle_error<T>(
     err: Error,
     opts: &RequestHandlerOpts,
-    req: &Request<Body>,
+    req: &Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     tracing::error!("{err:?}");
     Some(error_page::error_response(

--- a/src/rewrites.rs
+++ b/src/rewrites.rs
@@ -17,9 +17,9 @@ use crate::{
 };
 
 /// Applies rewrite rules to a request if necessary.
-pub(crate) fn pre_process(
+pub(crate) fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &mut Request<Body>,
+    req: &mut Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     let rewrites = opts.advanced_opts.as_ref()?.rewrites.as_deref()?;
     let uri_path = req.uri().path();

--- a/src/security_headers.rs
+++ b/src/security_headers.rs
@@ -19,9 +19,9 @@ pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
 }
 
 /// Appends security headers to a response if necessary
-pub(crate) fn post_process(
+pub(crate) fn post_process<T>(
     opts: &RequestHandlerOpts,
-    _req: &Request<Body>,
+    _req: &Request<T>,
     mut resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
     if opts.security_headers {


### PR DESCRIPTION
## Description
This uses generics to avoid mentioning the `Body` type for requests since we don’t actually care about it. This will cut down on the compile errors to be addressed for #340.

Note that I revered the initially implemented changes to `handler.rs` and `service.rs`. The former is being used by integration tests, not specifying the body type there requires specifying it everywhere in the tests – not worth it.

## Related Issue
#340

## How Has This Been Tested?
Automated tests pass.