### PR TITLE
Fix the display format for file sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,15 +610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,12 +710,6 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "listenfd"
@@ -1268,7 +1253,6 @@ dependencies = [
  "headers",
  "http",
  "http-serde",
- "humansize",
  "hyper",
  "lazy_static",
  "listenfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ compression-deflate = ["async-compression/deflate"]
 compression-gzip = ["async-compression/deflate"]
 compression-zstd = ["async-compression/zstd"]
 # Directory listing
-directory-listing = ["humansize", "chrono", "maud"]
+directory-listing = ["chrono", "maud"]
 # Basic HTTP Authorization
 basic-auth = ["bcrypt"]
 # Fallback Page
@@ -71,7 +71,6 @@ globset = { version = "0.4", features = ["serde1"] }
 headers = "0.3"
 http = "0.2"
 http-serde = "1.1"
-humansize = { version = "2.1", features = ["impl_style"], optional = true }
 hyper = { version = "0.14", features = ["stream", "http1", "http2", "tcp", "server"] }
 lazy_static = "1.4.0"
 listenfd = "1.0"

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -3,7 +3,7 @@
 // See https://static-web-server.net/ for more information
 // Copyright (C) 2019-present Jose Quintana <joseluisq.net>
 
-//! It provides directory listig and auto-index support.
+//! It provides directory listing and auto-index support.
 //!
 
 use chrono::{DateTime, Local, Utc};
@@ -219,7 +219,7 @@ fn read_dir_entries(
             (FileType::File, Some(meta.len()))
         } else if meta.file_type().is_symlink() {
             // NOTE: we resolve the symlink path below to just know if is a directory or not.
-            // Hwever, we are still showing the symlink name but not the resolved name.
+            // However, we are still showing the symlink name but not the resolved name.
 
             let symlink = dir_entry.path();
             let symlink = match symlink.canonicalize() {

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -562,7 +562,7 @@ fn format_file_size(size: u64) -> String {
 
     if size_tmp < 1024 {
         // return the size with Byte
-        return format!("{} {}", size_tmp, "B");
+        return format!("{} {}", size_tmp, UNITS[0]);
     }
 
     for unit in &UNITS[1..UNITS.len() - 1] {


### PR DESCRIPTION
## Description
<!--- Describe your changes but try to be as concise as possible -->
Replace `humansize` with a function `format_file_size` in `src/directory_listing.rs`
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/static-web-server/static-web-server/issues/370

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
Add some test cases in `src/directory_listing.rs`
Compared and tested with local files