### PR TITLE
Add caddy to performance benchmarks

### DIFF
--- a/.github/workflows/perfcheck.yml
+++ b/.github/workflows/perfcheck.yml
@@ -40,6 +40,8 @@ jobs:
       VEGETA_VERSION: "12.11.1"
       # Command-line parameters for the vegeta binary
       VEGETA_FLAGS: "-workers=4 -connections=100 -rate=${{ matrix.rate }} -duration=10s"
+      # Version of the caddy binary
+      CADDY_VERSION: "2.7.6"
 
     strategy:
       matrix:
@@ -82,7 +84,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: static-web-server/benchmarks-setup
-        ref: v0.1
+        ref: v0.2
         path: benchmarks-setup
         fetch-depth: 1
 
@@ -101,6 +103,12 @@ jobs:
         curl -L https://github.com/tsenart/vegeta/releases/download/v${{ env.VEGETA_VERSION }}/vegeta_${{ env.VEGETA_VERSION }}_linux_amd64.tar.gz | tar xz
         echo "Downloaded vegeta"
         ./vegeta --version
+
+    - name: Install caddy binary
+      run: |
+        curl -L https://github.com/caddyserver/caddy/releases/download/v${{ env.CADDY_VERSION }}/caddy_${{ env.CADDY_VERSION }}_linux_amd64.tar.gz | tar xz caddy
+        echo "Downloaded caddy"
+        ./caddy --version
 
     - name: Install web server software
       uses: awalsh128/cache-apt-pkgs-action@latest
@@ -175,6 +183,17 @@ jobs:
         ./vegeta report -type=text $REPORT
         ./vegeta report -type=json $REPORT | jq --arg name "$NAME" -r -f scripts/ci/vegeta_report_to_csv.jq >> graph.csv
 
+    - name: Run caddy benchmark
+      run: |
+        NAME="caddy $(./caddy -v | sed 's/ .*//')"
+        REPORT=report_caddy.bin
+        ./caddy run -c `pwd`/benchmarks-setup/config/Caddyfile &
+        sleep 2
+        echo "GET ${{ matrix.url }}" | ./vegeta attack -name "$NAME" ${{ env.VEGETA_FLAGS }} > $REPORT
+        kill %1
+        ./vegeta report -type=text $REPORT
+        ./vegeta report -type=json $REPORT | jq --arg name "$NAME" -r -f scripts/ci/vegeta_report_to_csv.jq >> graph.csv
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -188,7 +207,7 @@ jobs:
         ./vegeta plot --title "${{ matrix.title }}" report_*.bin > detailed_plot.html
         cat graph.csv
         cat graph.csv | sed -e 's/,/|/g' -e 's/"//g' -e 's/^/|/' -e 's/$/|/' -e '2 i |-|-|-|-|-|-|-|-|' >> $GITHUB_STEP_SUMMARY
-        pipx run graph-cli --barh --bar-label --xlabel '' --ylabel 'Latency (ms)' --title "${{ matrix.title }}" --figsize 1200x700 --fontsize 10 --ytick-angle 45 --ytick-align top -o overview.png graph.csv
+        pipx run graph-cli --barh --bar-label --xlabel '' --ylabel 'Latency (ms)' --title "${{ matrix.title }}" --figsize 1200x800 --fontsize 10 --ytick-angle 45 --ytick-align top -o overview.png graph.csv
 
     - name: Upload benchmark plots
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description
I’ve already added `Caddyfile` to the benchmark-setups repository, this is now using it.

## Related Issue
#352

## How Has This Been Tested?
Works on my branch: https://github.com/palant/static-web-server/actions/runs/8874064610