### PR TITLE
New compression level option support

### DIFF
--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -151,10 +151,10 @@ Options:
           Compression level to apply for Gzip, Deflate, Brotli or Zstd compression
 
           [env: SERVER_COMPRESSION_LEVEL=]
-          [default: fastest]
+          [default: default]
 
           Possible values:
-          - fastest: Fastest execution at the expense of larger file sizes (recommended)
+          - fastest: Fastest execution at the expense of larger file sizes
           - best:    Smallest file size but potentially slow
           - default: Algorithm-specific default compression level setting
 

--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -16,83 +16,260 @@ Usage: static-web-server [OPTIONS]
 
 Options:
   -a, --host <HOST>
-          Host address (E.g 127.0.0.1 or ::1) [env: SERVER_HOST=] [default: ::]
+          Host address (E.g 127.0.0.1 or ::1)
+
+          [env: SERVER_HOST=]
+          [default: ::]
+
   -p, --port <PORT>
-          Host port [env: SERVER_PORT=] [default: 80]
+          Host port
+
+          [env: SERVER_PORT=]
+          [default: 80]
+
   -f, --fd <FD>
-          Instead of binding to a TCP port, accept incoming connections to an already-bound TCP socket listener on the specified file descriptor number (usually zero). Requires that the parent process (e.g. inetd, launchd, or systemd) binds an address and port on behalf of static-web-server, before arranging for the resulting file descriptor to be inherited by static-web-server. Cannot be used in conjunction with the port and host arguments. The included systemd unit file utilises this feature to increase security by allowing the static-web-server to be sandboxed more completely [env: SERVER_LISTEN_FD=]
+          Instead of binding to a TCP port, accept incoming connections to an already-bound TCP socket listener on the specified file descriptor number (usually zero). Requires that the parent process (e.g. inetd, launchd, or systemd) binds an address and port on behalf of static-web-server, before arranging for the resulting file descriptor to be inherited by static-web-server. Cannot be used in conjunction with the port and host arguments. The included systemd unit file utilises this feature to increase security by allowing the static-web-server to be sandboxed more completely
+
+          [env: SERVER_LISTEN_FD=]
+
   -n, --threads-multiplier <THREADS_MULTIPLIER>
-          Number of worker threads multiplier that'll be multiplied by the number of system CPUs using the formula: `worker threads = number of CPUs * n` where `n` is the value that changes here. When multiplier value is 0 or 1 then one thread per core is used. Number of worker threads result should be a number between 1 and 32,768 though it is advised to keep this value on the smaller side [env: SERVER_THREADS_MULTIPLIER=] [default: 1]
+          Number of worker threads multiplier that'll be multiplied by the number of system CPUs using the formula: `worker threads = number of CPUs * n` where `n` is the value that changes here. When multiplier value is 0 or 1 then one thread per core is used. Number of worker threads result should be a number between 1 and 32,768 though it is advised to keep this value on the smaller side
+
+          [env: SERVER_THREADS_MULTIPLIER=]
+          [default: 1]
+
   -b, --max-blocking-threads <MAX_BLOCKING_THREADS>
-          Maximum number of blocking threads [env: SERVER_MAX_BLOCKING_THREADS=] [default: 512]
+          Maximum number of blocking threads
+
+          [env: SERVER_MAX_BLOCKING_THREADS=]
+          [default: 512]
+
   -d, --root <ROOT>
-          Root directory path of static files [env: SERVER_ROOT=] [default: ./public]
+          Root directory path of static files
+
+          [env: SERVER_ROOT=]
+          [default: ./public]
+
       --page50x <PAGE50X>
-          HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory [env: SERVER_ERROR_PAGE_50X=] [default: ./50x.html]
+          HTML file path for 50x errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory
+
+          [env: SERVER_ERROR_PAGE_50X=]
+          [default: ./50x.html]
+
       --page404 <PAGE404>
-          HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory [env: SERVER_ERROR_PAGE_404=] [default: ./404.html]
+          HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory
+
+          [env: SERVER_ERROR_PAGE_404=]
+          [default: ./404.html]
+
       --page-fallback <PAGE_FALLBACK>
-          HTML file path that is used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path is not specified or simply doesn't exist then this feature will not be active [env: SERVER_FALLBACK_PAGE=] [default: ]
+          HTML file path that is used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path is not specified or simply doesn't exist then this feature will not be active
+
+          [env: SERVER_FALLBACK_PAGE=]
+          [default: ]
+
   -g, --log-level <LOG_LEVEL>
-          Specify a logging level in lower case. Values: error, warn, info, debug or trace [env: SERVER_LOG_LEVEL=] [default: error]
+          Specify a logging level in lower case. Values: error, warn, info, debug or trace
+
+          [env: SERVER_LOG_LEVEL=]
+          [default: error]
+
   -c, --cors-allow-origins <CORS_ALLOW_ORIGINS>
-          Specify an optional CORS list of allowed origin hosts separated by commas. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host [env: SERVER_CORS_ALLOW_ORIGINS=] [default: ]
+          Specify an optional CORS list of allowed origin hosts separated by commas. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host
+
+          [env: SERVER_CORS_ALLOW_ORIGINS=]
+          [default: ]
+
   -j, --cors-allow-headers <CORS_ALLOW_HEADERS>
-          Specify an optional CORS list of allowed headers separated by commas. Default "origin, content-type". It requires `--cors-allow-origins` to be used along with [env: SERVER_CORS_ALLOW_HEADERS=] [default: "origin, content-type"]
+          Specify an optional CORS list of allowed headers separated by commas. Default "origin, content-type". It requires `--cors-allow-origins` to be used along with
+
+          [env: SERVER_CORS_ALLOW_HEADERS=]
+          [default: "origin, content-type, authorization"]
+
       --cors-expose-headers <CORS_EXPOSE_HEADERS>
-          Specify an optional CORS list of exposed headers separated by commas. Default "origin, content-type". It requires `--cors-expose-origins` to be used along with [env: SERVER_CORS_EXPOSE_HEADERS=] [default: "origin, content-type"]
+          Specify an optional CORS list of exposed headers separated by commas. Default "origin, content-type". It requires `--cors-expose-origins` to be used along with
+
+          [env: SERVER_CORS_EXPOSE_HEADERS=]
+          [default: "origin, content-type"]
+
   -t, --http2[=<HTTP2>]
-          Enable HTTP/2 with TLS support [env: SERVER_HTTP2_TLS=] [default: false] [possible values: true, false]
+          Enable HTTP/2 with TLS support
+
+          [env: SERVER_HTTP2_TLS=]
+          [default: false]
+          [possible values: true, false]
+
       --http2-tls-cert <HTTP2_TLS_CERT>
-          Specify the file path to read the certificate [env: SERVER_HTTP2_TLS_CERT=]
+          Specify the file path to read the certificate
+
+          [env: SERVER_HTTP2_TLS_CERT=]
+
       --http2-tls-key <HTTP2_TLS_KEY>
-          Specify the file path to read the private key [env: SERVER_HTTP2_TLS_KEY=]
+          Specify the file path to read the private key
+
+          [env: SERVER_HTTP2_TLS_KEY=]
+
       --https-redirect[=<HTTPS_REDIRECT>]
-          Redirect all requests with scheme "http" to "https" for the current server instance. It depends on "http2" to be enabled [env: SERVER_HTTPS_REDIRECT=] [default: false] [possible values: true, false]
+          Redirect all requests with scheme "http" to "https" for the current server instance. It depends on "http2" to be enabled
+
+          [env: SERVER_HTTPS_REDIRECT=]
+          [default: false]
+          [possible values: true, false]
+
       --https-redirect-host <HTTPS_REDIRECT_HOST>
-          Canonical host name or IP of the HTTPS (HTTPS/2) server. It depends on "https_redirect" to be enabled [env: SERVER_HTTPS_REDIRECT_HOST=] [default: localhost]
+          Canonical host name or IP of the HTTPS (HTTPS/2) server. It depends on "https_redirect" to be enabled
+
+          [env: SERVER_HTTPS_REDIRECT_HOST=]
+          [default: localhost]
+
       --https-redirect-from-port <HTTPS_REDIRECT_FROM_PORT>
-          HTTP host port where the redirect server will listen for requests to redirect them to HTTPS. It depends on "https_redirect" to be enabled [env: SERVER_HTTPS_REDIRECT_FROM_PORT=] [default: 80]
+          HTTP host port where the redirect server will listen for requests to redirect them to HTTPS. It depends on "https_redirect" to be enabled
+
+          [env: SERVER_HTTPS_REDIRECT_FROM_PORT=]
+          [default: 80]
+
       --https-redirect-from-hosts <HTTPS_REDIRECT_FROM_HOSTS>
-          List of host names or IPs allowed to redirect from. HTTP requests must contain the HTTP 'Host' header and match against this list. It depends on "https_redirect" to be enabled [env: SERVER_HTTPS_REDIRECT_FROM_HOSTS=] [default: localhost]
+          List of host names or IPs allowed to redirect from. HTTP requests must contain the HTTP 'Host' header and match against this list. It depends on "https_redirect" to be enabled
+
+          [env: SERVER_HTTPS_REDIRECT_FROM_HOSTS=]
+          [default: localhost]
+
       --index-files <INDEX_FILES>
-          List of files that will be used as an index for requests ending with the slash character (‘/’). Files are checked in the specified order [env: SERVER_INDEX_FILES=] [default: index.html]
+          List of files that will be used as an index for requests ending with the slash character (‘/’). Files are checked in the specified order
+
+          [env: SERVER_INDEX_FILES=]
+          [default: index.html]
+
   -x, --compression[=<COMPRESSION>]
-          Gzip, Deflate, Brotli or Zstd compression on demand determined by the Accept-Encoding header and applied to text-based web file types only [env: SERVER_COMPRESSION=] [default: true] [possible values: true, false]
+          Gzip, Deflate, Brotli or Zstd compression on demand determined by the Accept-Encoding header and applied to text-based web file types only
+
+          [env: SERVER_COMPRESSION=]
+          [default: true]
+          [possible values: true, false]
+
+      --compression-level <COMPRESSION_LEVEL>
+          Compression level to apply for Gzip, Deflate, Brotli or Zstd compression
+
+          [env: SERVER_COMPRESSION_LEVEL=]
+          [default: fastest]
+
+          Possible values:
+          - fastest: Fastest execution at the expense of larger file sizes (recommended)
+          - best:    Smallest file size but potentially slow
+          - default: Algorithm-specific default compression level setting
+
       --compression-static[=<COMPRESSION_STATIC>]
-          Look up the pre-compressed file variant (`.gz`, `.br` or `.zst`) on disk of a requested file and serves it directly if available. The compression type is determined by the `Accept-Encoding` header [env: SERVER_COMPRESSION_STATIC=] [default: false] [possible values: true, false]
+          Look up the pre-compressed file variant (`.gz`, `.br` or `.zst`) on disk of a requested file and serves it directly if available. The compression type is determined by the `Accept-Encoding` header
+
+          [env: SERVER_COMPRESSION_STATIC=]
+          [default: false]
+          [possible values: true, false]
+
   -z, --directory-listing[=<DIRECTORY_LISTING>]
-          Enable directory listing for all requests ending with the slash character (‘/’) [env: SERVER_DIRECTORY_LISTING=] [default: false] [possible values: true, false]
+          Enable directory listing for all requests ending with the slash character (‘/’)
+
+          [env: SERVER_DIRECTORY_LISTING=]
+          [default: false]
+          [possible values: true, false]
+
       --directory-listing-order <DIRECTORY_LISTING_ORDER>
-          Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size` attributes (columns). Code numbers supported: 0 (Name asc), 1 (Name desc), 2 (Last modified asc), 3 (Last modified desc), 4 (Size asc), 5 (Size desc). Default 6 (unordered) [env: SERVER_DIRECTORY_LISTING_ORDER=] [default: 6]
+          Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size` attributes (columns). Code numbers supported: 0 (Name asc), 1 (Name desc), 2 (Last modified asc), 3 (Last modified desc), 4 (Size asc), 5 (Size desc). Default 6 (unordered)
+
+          [env: SERVER_DIRECTORY_LISTING_ORDER=]
+          [default: 6]
+
       --directory-listing-format <DIRECTORY_LISTING_FORMAT>
-          Specify a content format for directory listing entries. Formats supported: "html" or "json". Default "html" [env: SERVER_DIRECTORY_LISTING_FORMAT=] [default: html] [possible values: html, json]
+          Specify a content format for directory listing entries. Formats supported: "html" or "json". Default "html"
+
+          [env: SERVER_DIRECTORY_LISTING_FORMAT=]
+          [default: html]
+
+          Possible values:
+          - html: HTML format to display (default)
+          - json: JSON format to display
+
       --security-headers[=<SECURITY_HEADERS>]
-          Enable security headers by default when HTTP/2 feature is activated. Headers included: "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age), "X-Frame-Options: DENY" and "Content-Security-Policy: frame-ancestors 'self'" [env: SERVER_SECURITY_HEADERS=] [default: false] [possible values: true, false]
+          Enable security headers by default when HTTP/2 feature is activated. Headers included: "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age), "X-Frame-Options: DENY" and "Content-Security-Policy: frame-ancestors 'self'"
+
+          [env: SERVER_SECURITY_HEADERS=]
+          [default: false]
+          [possible values: true, false]
+
   -e, --cache-control-headers[=<CACHE_CONTROL_HEADERS>]
-          Enable cache control headers for incoming requests based on a set of file types. The file type list can be found on `src/control_headers.rs` file [env: SERVER_CACHE_CONTROL_HEADERS=] [default: true] [possible values: true, false]
+          Enable cache control headers for incoming requests based on a set of file types. The file type list can be found on `src/control_headers.rs` file
+
+          [env: SERVER_CACHE_CONTROL_HEADERS=]
+          [default: true]
+          [possible values: true, false]
+
       --basic-auth <BASIC_AUTH>
-          It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function [env: SERVER_BASIC_AUTH=] [default: ]
+          It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function
+
+          [env: SERVER_BASIC_AUTH=]
+          [default: ]
+
   -q, --grace-period <GRACE_PERIOD>
-          Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to shut it down gracefully. The maximum value is 255 seconds [env: SERVER_GRACE_PERIOD=] [default: 0]
+          Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to shut it down gracefully. The maximum value is 255 seconds
+
+          [env: SERVER_GRACE_PERIOD=]
+          [default: 0]
+
   -w, --config-file <CONFIG_FILE>
-          Server TOML configuration file path [env: SERVER_CONFIG_FILE=] [default: ./config.toml]
+          Server TOML configuration file path
+
+          [env: SERVER_CONFIG_FILE=]
+          [default: ./config.toml]
+
       --log-remote-address[=<LOG_REMOTE_ADDRESS>]
-          Log incoming requests information along with its remote address if available using the `info` log level [env: SERVER_LOG_REMOTE_ADDRESS=] [default: false] [possible values: true, false]
+          Log incoming requests information along with its remote address if available using the `info` log level
+
+          [env: SERVER_LOG_REMOTE_ADDRESS=]
+          [default: false]
+          [possible values: true, false]
+
       --redirect-trailing-slash[=<REDIRECT_TRAILING_SLASH>]
-          Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path with a trailing slash suffix if it is missing [env: SERVER_REDIRECT_TRAILING_SLASH=] [default: true] [possible values: true, false]
+          Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path with a trailing slash suffix if it is missing
+
+          [env: SERVER_REDIRECT_TRAILING_SLASH=]
+          [default: true]
+          [possible values: true, false]
+
       --ignore-hidden-files[=<IGNORE_HIDDEN_FILES>]
-          Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing) [env: SERVER_IGNORE_HIDDEN_FILES=] [default: false] [possible values: true, false]
+          Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing)
+
+          [env: SERVER_IGNORE_HIDDEN_FILES=]
+          [default: false]
+          [possible values: true, false]
+
       --health[=<HEALTH>]
-          Add a /health endpoint that doesn't generate any log entry and returns a 200 status code. This is especially useful with Kubernetes liveness and readiness probes [env: SERVER_HEALTH=] [default: false] [possible values: true, false]
+          Add a /health endpoint that doesn't generate any log entry and returns a 200 status code. This is especially useful with Kubernetes liveness and readiness probes
+
+          [env: SERVER_HEALTH=]
+          [default: false]
+          [possible values: true, false]
+
       --maintenance-mode[=<MAINTENANCE_MODE>]
-          Enable the server's maintenance mode functionality [env: SERVER_MAINTENANCE_MODE=] [default: false] [possible values: true, false]
+          Enable the server's maintenance mode functionality
+
+          [env: SERVER_MAINTENANCE_MODE=]
+          [default: false]
+          [possible values: true, false]
+
       --maintenance-mode-status <MAINTENANCE_MODE_STATUS>
-          Provide a custom HTTP status code when entering into maintenance mode. Default 503 [env: SERVER_MAINTENANCE_MODE_STATUS=] [default: 503]
+          Provide a custom HTTP status code when entering into maintenance mode. Default 503
+
+          [env: SERVER_MAINTENANCE_MODE_STATUS=]
+          [default: 503]
+
       --maintenance-mode-file <MAINTENANCE_MODE_FILE>
-          Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed [env: SERVER_MAINTENANCE_MODE_FILE=] [default: ]
+          Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed
+
+          [env: SERVER_MAINTENANCE_MODE_FILE=]
+          [default: ]
+
   -h, --help
-          Print help (see more with '--help')
+          Print help (see a summary with '-h')
+
   -V, --version
           Print version
 ```

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -28,7 +28,7 @@ cache-control-headers = true
 
 #### Auto Compression
 compression = true
-compression_level = "fastest"
+compression_level = "default"
 
 #### Error pages
 # Note: If a relative path is used then it will be resolved under the root directory.

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -28,6 +28,7 @@ cache-control-headers = true
 
 #### Auto Compression
 compression = true
+compression_level = "fastest"
 
 #### Error pages
 # Note: If a relative path is used then it will be resolved under the root directory.
@@ -88,7 +89,7 @@ health = false
 #### Maintenance Mode
 
 maintenance-mode = false
-# maintenance-mode-status = 503 
+# maintenance-mode-status = 503
 # maintenance-mode-file = "./maintenance.html"
 
 ### Windows Only

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -28,7 +28,7 @@ cache-control-headers = true
 
 #### Auto Compression
 compression = true
-compression_level = "default"
+compression-level = "default"
 
 #### Error pages
 # Note: If a relative path is used then it will be resolved under the root directory.

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -78,13 +78,13 @@ Specify an optional CORS list of allowed HTTP headers separated by commas. It re
 Specify an optional CORS list of exposed HTTP headers separated by commas. It requires `SERVER_CORS_ALLOW_ORIGINS` to be used along with. Default `origin, content-type`.
 
 ### SERVER_COMPRESSION
-`Gzip`, `Deflate` or `Brotli` compression on demand determined by the `Accept-Encoding` header and applied to text-based web file types only. See [ad-hoc mime-type list](https://github.com/static-web-server/static-web-server/blob/master/src/compression.rs#L20). Default `true` (enabled).
+`Gzip`, `Deflate`, `Brotli` or `zlib` compression on demand determined by the `Accept-Encoding` header and applied to text-based web file types only. See [ad-hoc mime-type list](https://github.com/static-web-server/static-web-server/blob/master/src/compression.rs#L20). Default `true` (enabled).
 
 ### SERVER_COMPRESSION_LEVEL
 Supported values are `fastest` (fast compression but larger resulting files), `best` (smallest file size but potentially slow) and `default` (algorithm-specific balanced compression level). Default is `default`.
 
 ### SERVER_COMPRESSION_STATIC
-Look up the pre-compressed file variant (`.gz` or `.br`) on disk of a requested file and serves it directly if available. Default `false` (disabled). The compression type is determined by the `Accept-Encoding` header.
+Look up the pre-compressed file variant (`.gz`, `.br` or `.zst`) on disk of a requested file and serves it directly if available. Default `false` (disabled). The compression type is determined by the `Accept-Encoding` header.
 
 ### SERVER_DIRECTORY_LISTING
 Enable directory listing for all requests ending with the slash character (‘/’). Default `false` (disabled).

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -80,6 +80,9 @@ Specify an optional CORS list of exposed HTTP headers separated by commas. It re
 ### SERVER_COMPRESSION
 `Gzip`, `Deflate` or `Brotli` compression on demand determined by the `Accept-Encoding` header and applied to text-based web file types only. See [ad-hoc mime-type list](https://github.com/static-web-server/static-web-server/blob/master/src/compression.rs#L20). Default `true` (enabled).
 
+### SERVER_COMPRESSION_LEVEL
+Supported values are `fastest` (fast compression but larger resulting files), `best` (smallest file size but potentially slow) and `default` (algorithm-specific default compression level setting). Default is `fastest`.
+
 ### SERVER_COMPRESSION_STATIC
 Look up the pre-compressed file variant (`.gz` or `.br`) on disk of a requested file and serves it directly if available. Default `false` (disabled). The compression type is determined by the `Accept-Encoding` header.
 

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -81,7 +81,7 @@ Specify an optional CORS list of exposed HTTP headers separated by commas. It re
 `Gzip`, `Deflate` or `Brotli` compression on demand determined by the `Accept-Encoding` header and applied to text-based web file types only. See [ad-hoc mime-type list](https://github.com/static-web-server/static-web-server/blob/master/src/compression.rs#L20). Default `true` (enabled).
 
 ### SERVER_COMPRESSION_LEVEL
-Supported values are `fastest` (fast compression but larger resulting files), `best` (smallest file size but potentially slow) and `default` (algorithm-specific default compression level setting). Default is `fastest`.
+Supported values are `fastest` (fast compression but larger resulting files), `best` (smallest file size but potentially slow) and `default` (algorithm-specific balanced compression level). Default is `default`.
 
 ### SERVER_COMPRESSION_STATIC
 Look up the pre-compressed file variant (`.gz` or `.br`) on disk of a requested file and serves it directly if available. Default `false` (disabled). The compression type is determined by the `Accept-Encoding` header.

--- a/docs/content/features/compression.md
+++ b/docs/content/features/compression.md
@@ -2,40 +2,7 @@
 
 **`SWS`** provides [`Gzip`](https://datatracker.ietf.org/doc/html/rfc1952), [`Deflate`](https://datatracker.ietf.org/doc/html/rfc1951#section-Abstract), [`Brotli`](https://www.ietf.org/rfc/rfc7932.txt) and [`Zstandard` (zstd)](https://datatracker.ietf.org/doc/html/rfc8878) compression of HTTP responses.
 
-The compression functionality is determined by the [`Accept-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header and is only applied to text-based web file types.
-
-## MIME types compressed
-
-Only this list of common text-based MIME-type files will be compressed either with `Gzip`, `Deflate` or `Brotli` via the `Accept-Encoding` header value.
-
-```txt
-text/html
-text/css
-text/javascript
-text/xml
-text/plain
-text/csv
-text/calendar
-text/markdown
-text/x-yaml
-text/x-toml
-text/x-component
-application/rtf
-application/xhtml+xml
-application/javascript
-application/x-javascript
-application/json
-application/xml
-application/rss+xml
-application/atom+xml
-application/vnd.ms-fontobject
-font/truetype
-font/opentype
-image/svg+xml
-application/wasm
-```
-
-This feature is enabled by default and can be controlled by the boolean `-x, --compression` option or the equivalent [SERVER_COMPRESSION](./../configuration/environment-variables.md#server_compression) env.
+This feature is enabled by default and can be controlled by the boolean `-x, --compression` option or the equivalent [SERVER_COMPRESSION](../configuration/environment-variables.md#server_compression) env.
 
 ```sh
 static-web-server \
@@ -43,3 +10,29 @@ static-web-server \
     --root ./my-public-dir \
     --compression true
 ```
+
+## Choice of compression algorithm
+
+The compression algorithm is determined by the [`Accept-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header and the compression support built into SWS. By default SWS builds with support for `Gzip`, `Deflate`, `Brotli` and `Zstandard` algorithms.
+
+## MIME types compressed
+
+Compression is only applied to files with the MIME types listed below, indicating text and similarly well compressing formats. The asterisk `*` is a placeholder indicating an arbitrary MIME type part.
+
+```txt
+text/*
+*+xml
+*+json
+application/rtf
+application/javascript
+application/json
+application/xml
+font/ttf
+application/font-sfnt
+application/vnd.ms-fontobject
+application/wasm
+```
+
+## Compression level
+
+SWS allows selecting the compression level via `--compression-level` command line option or the equivalent [SERVER_COMPRESSION_LEVEL](../configuration/environment-variables.md#server_compression_level) env. The available values are `fastest`, `best` and `default`. `fastest` will result in the lowest CPU load but also the worst compression factor. `best` will attempt to compress the data as much as possible (not recommended with `Brotli` or `Zstandard` compression, will be very slow). `default` tries to strike a balance, choosing a compression level where compression factor is already fairly good but the CPU load is still low.

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -290,7 +290,7 @@ pub fn zstd(
     body: CompressableBody<Body, hyper::Error>,
     level: CompressionLevel,
 ) -> Response<Body> {
-    const DEFAULT_COMPRESSION_LEVEL: i32 = 4;
+    const DEFAULT_COMPRESSION_LEVEL: i32 = 3;
 
     tracing::trace!("compressing response body on the fly using ZSTD");
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -37,6 +37,7 @@ use crate::{
     handler::RequestHandlerOpts,
     headers_ext::{AcceptEncoding, ContentCoding},
     http_ext::MethodExt,
+    settings::file::CompressionLevel,
     Error, Result,
 };
 
@@ -67,8 +68,9 @@ const AVAILABLE_ENCODINGS: &[ContentCoding] = &[
 ];
 
 /// Initializes dynamic compression.
-pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
+pub fn init(enabled: bool, level: CompressionLevel, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.compression = enabled;
+    handler_opts.compression_level = level.into();
 
     const FORMATS: &[&str] = &[
         #[cfg(any(feature = "compression", feature = "compression-deflate"))]
@@ -81,7 +83,7 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
         "zstd",
     ];
     server_info!(
-        "auto compression: enabled={enabled}, formats={}",
+        "auto compression: enabled={enabled}, formats={}, compression level={level:?}",
         FORMATS.join(",")
     );
 }
@@ -108,7 +110,7 @@ pub(crate) fn post_process(
     );
 
     // Auto compression based on the `Accept-Encoding` header
-    match auto(req.method(), req.headers(), resp) {
+    match auto(req.method(), req.headers(), opts.compression_level, resp) {
         Ok(resp) => Ok(resp),
         Err(err) => {
             tracing::error!("error during body compression: {:?}", err);
@@ -130,6 +132,7 @@ pub(crate) fn post_process(
 pub fn auto(
     method: &Method,
     headers: &HeaderMap<HeaderValue>,
+    level: async_compression::Level,
     resp: Response<Body>,
 ) -> Result<Response<Body>> {
     // Skip compression for HEAD and OPTIONS request methods
@@ -154,25 +157,25 @@ pub fn auto(
         #[cfg(any(feature = "compression", feature = "compression-gzip"))]
         if encoding == ContentCoding::GZIP {
             let (head, body) = resp.into_parts();
-            return Ok(gzip(head, body.into()));
+            return Ok(gzip(head, body.into(), level));
         }
 
         #[cfg(any(feature = "compression", feature = "compression-deflate"))]
         if encoding == ContentCoding::DEFLATE {
             let (head, body) = resp.into_parts();
-            return Ok(deflate(head, body.into()));
+            return Ok(deflate(head, body.into(), level));
         }
 
         #[cfg(any(feature = "compression", feature = "compression-brotli"))]
         if encoding == ContentCoding::BROTLI {
             let (head, body) = resp.into_parts();
-            return Ok(brotli(head, body.into()));
+            return Ok(brotli(head, body.into(), level));
         }
 
         #[cfg(any(feature = "compression", feature = "compression-zstd"))]
         if encoding == ContentCoding::ZSTD {
             let (head, body) = resp.into_parts();
-            return Ok(zstd(head, body.into()));
+            return Ok(zstd(head, body.into(), level));
         }
 
         tracing::trace!("no compression feature matched the preferred encoding, probably not enabled or unsupported");
@@ -200,10 +203,14 @@ fn is_text(mime: Mime) -> bool {
 pub fn gzip(
     mut head: http::response::Parts,
     body: CompressableBody<Body, hyper::Error>,
+    level: async_compression::Level,
 ) -> Response<Body> {
     tracing::trace!("compressing response body on the fly using GZIP");
 
-    let body = Body::wrap_stream(ReaderStream::new(GzipEncoder::new(StreamReader::new(body))));
+    let body = Body::wrap_stream(ReaderStream::new(GzipEncoder::with_quality(
+        StreamReader::new(body),
+        level,
+    )));
     let header = create_encoding_header(head.headers.remove(CONTENT_ENCODING), ContentCoding::GZIP);
     head.headers.remove(CONTENT_LENGTH);
     head.headers.append(CONTENT_ENCODING, header);
@@ -220,12 +227,14 @@ pub fn gzip(
 pub fn deflate(
     mut head: http::response::Parts,
     body: CompressableBody<Body, hyper::Error>,
+    level: async_compression::Level,
 ) -> Response<Body> {
     tracing::trace!("compressing response body on the fly using DEFLATE");
 
-    let body = Body::wrap_stream(ReaderStream::new(DeflateEncoder::new(StreamReader::new(
-        body,
-    ))));
+    let body = Body::wrap_stream(ReaderStream::new(DeflateEncoder::with_quality(
+        StreamReader::new(body),
+        level,
+    )));
     let header = create_encoding_header(
         head.headers.remove(CONTENT_ENCODING),
         ContentCoding::DEFLATE,
@@ -245,12 +254,14 @@ pub fn deflate(
 pub fn brotli(
     mut head: http::response::Parts,
     body: CompressableBody<Body, hyper::Error>,
+    level: async_compression::Level,
 ) -> Response<Body> {
     tracing::trace!("compressing response body on the fly using BROTLI");
 
-    let body = Body::wrap_stream(ReaderStream::new(BrotliEncoder::new(StreamReader::new(
-        body,
-    ))));
+    let body = Body::wrap_stream(ReaderStream::new(BrotliEncoder::with_quality(
+        StreamReader::new(body),
+        level,
+    )));
     let header =
         create_encoding_header(head.headers.remove(CONTENT_ENCODING), ContentCoding::BROTLI);
     head.headers.remove(CONTENT_LENGTH);
@@ -268,10 +279,14 @@ pub fn brotli(
 pub fn zstd(
     mut head: http::response::Parts,
     body: CompressableBody<Body, hyper::Error>,
+    level: async_compression::Level,
 ) -> Response<Body> {
     tracing::trace!("compressing response body on the fly using ZSTD");
 
-    let body = Body::wrap_stream(ReaderStream::new(ZstdEncoder::new(StreamReader::new(body))));
+    let body = Body::wrap_stream(ReaderStream::new(ZstdEncoder::with_quality(
+        StreamReader::new(body),
+        level,
+    )));
     let header = create_encoding_header(head.headers.remove(CONTENT_ENCODING), ContentCoding::ZSTD);
     head.headers.remove(CONTENT_LENGTH);
     head.headers.append(CONTENT_ENCODING, header);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -54,7 +54,7 @@ pub struct RequestHandlerOpts {
         feature = "compression-deflate"
     ))]
     /// Compression level.
-    pub compression_level: async_compression::Level,
+    pub compression_level: crate::settings::CompressionLevel,
     /// Compression static feature.
     pub compression_static: bool,
     /// Directory listing feature.
@@ -124,7 +124,7 @@ impl Default for RequestHandlerOpts {
                 feature = "compression-zstd",
                 feature = "compression-deflate"
             ))]
-            compression_level: async_compression::Level::Fastest,
+            compression_level: crate::settings::CompressionLevel::Default,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
             #[cfg(feature = "directory-listing")]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -46,6 +46,15 @@ pub struct RequestHandlerOpts {
     pub root_dir: PathBuf,
     /// Compression feature.
     pub compression: bool,
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    ))]
+    /// Compression level.
+    pub compression_level: async_compression::Level,
     /// Compression static feature.
     pub compression_static: bool,
     /// Directory listing feature.
@@ -108,6 +117,14 @@ impl Default for RequestHandlerOpts {
             root_dir: PathBuf::from("./public"),
             compression: true,
             compression_static: false,
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-gzip",
+                feature = "compression-brotli",
+                feature = "compression-zstd",
+                feature = "compression-deflate"
+            ))]
+            compression_level: async_compression::Level::Fastest,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
             #[cfg(feature = "directory-listing")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -317,7 +317,11 @@ impl Server {
             feature = "compression-brotli",
             feature = "compression-zstd",
         ))]
-        compression::init(general.compression, &mut handler_opts);
+        compression::init(
+            general.compression,
+            general.compression_level,
+            &mut handler_opts,
+        );
 
         // Cache control headers option
         control_headers::init(general.cache_control_headers, &mut handler_opts);

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -258,6 +258,28 @@ pub struct General {
     )]
     /// Gzip, Deflate, Brotli or Zstd compression on demand determined by the Accept-Encoding header and applied to text-based web file types only.
     pub compression: bool,
+
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))
+    )]
+    #[arg(long, default_value = "fastest", env = "SERVER_COMPRESSION_LEVEL")]
+    /// Compression level to apply for Gzip, Deflate, Brotli or Zstd compression.
+    pub compression_level: super::file::CompressionLevel,
+
     #[cfg(any(
         feature = "compression",
         feature = "compression-gzip",

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -276,9 +276,9 @@ pub struct General {
             feature = "compression-deflate"
         )))
     )]
-    #[arg(long, default_value = "fastest", env = "SERVER_COMPRESSION_LEVEL")]
+    #[arg(long, default_value = "default", env = "SERVER_COMPRESSION_LEVEL")]
     /// Compression level to apply for Gzip, Deflate, Brotli or Zstd compression.
-    pub compression_level: super::file::CompressionLevel,
+    pub compression_level: super::CompressionLevel,
 
     #[cfg(any(
         feature = "compression",

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -66,7 +66,7 @@ impl LogLevel {
 #[serde(rename_all = "kebab-case")]
 /// Compression level settings.
 pub enum CompressionLevel {
-    /// Fastest execution at the expense of larger file sizes (recommended).
+    /// Fastest execution at the expense of larger file sizes.
     Fastest,
     /// Smallest file size but potentially slow.
     Best,
@@ -91,12 +91,14 @@ pub enum CompressionLevel {
         feature = "compression-deflate"
     )))
 )]
-impl From<CompressionLevel> for async_compression::Level {
-    fn from(level: CompressionLevel) -> Self {
-        match level {
-            CompressionLevel::Fastest => Self::Fastest,
-            CompressionLevel::Best => Self::Best,
-            CompressionLevel::Default => Self::Default,
+impl CompressionLevel {
+    /// Converts to a library-specific compression level specification, using
+    /// given numeric level as default.
+    pub fn into_algorithm_level(self, default: i32) -> async_compression::Level {
+        match self {
+            Self::Fastest => async_compression::Level::Fastest,
+            Self::Best => async_compression::Level::Best,
+            Self::Default => async_compression::Level::Precise(default),
         }
     }
 }

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -94,7 +94,7 @@ pub enum CompressionLevel {
 impl CompressionLevel {
     /// Converts to a library-specific compression level specification, using
     /// given numeric level as default.
-    pub fn into_algorithm_level(self, default: i32) -> async_compression::Level {
+    pub(crate) fn into_algorithm_level(self, default: i32) -> async_compression::Level {
         match self {
             Self::Fastest => async_compression::Level::Fastest,
             Self::Best => async_compression::Level::Best,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -45,6 +45,62 @@ impl LogLevel {
     }
 }
 
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    )))
+)]
+#[derive(clap::ValueEnum, Debug, Serialize, Deserialize, Copy, Clone)]
+#[serde(rename_all = "kebab-case")]
+/// Compression level settings.
+pub enum CompressionLevel {
+    /// Fastest execution at the expense of larger file sizes (recommended).
+    Fastest,
+    /// Smallest file size but potentially slow.
+    Best,
+    /// Algorithm-specific default compression level setting.
+    Default,
+}
+
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    )))
+)]
+impl From<CompressionLevel> for async_compression::Level {
+    fn from(level: CompressionLevel) -> Self {
+        match level {
+            CompressionLevel::Fastest => Self::Fastest,
+            CompressionLevel::Best => Self::Best,
+            CompressionLevel::Default => Self::Default,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 /// Represents an HTTP headers map.
@@ -153,6 +209,26 @@ pub struct General {
         )))
     )]
     pub compression: Option<bool>,
+
+    /// Compression level.
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd",
+        feature = "compression-deflate"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        )))
+    )]
+    pub compression_level: Option<CompressionLevel>,
 
     /// Check for a pre-compressed file on disk.
     #[cfg(any(

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -25,6 +25,15 @@ use cli::General;
 
 use self::file::{RedirectsKind, Settings as FileSettings};
 
+#[cfg(any(
+    feature = "compression",
+    feature = "compression-gzip",
+    feature = "compression-brotli",
+    feature = "compression-zstd",
+    feature = "compression-deflate"
+))]
+pub use file::CompressionLevel;
+
 /// The `headers` file options.
 pub struct Headers {
     /// Source pattern glob matcher

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -114,6 +114,14 @@ impl Settings {
             feature = "compression-zstd",
             feature = "compression-deflate"
         ))]
+        let mut compression_level = opts.compression_level;
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-brotli",
+            feature = "compression-zstd",
+            feature = "compression-deflate"
+        ))]
         let mut compression_static = opts.compression_static;
 
         let mut page404 = opts.page404;
@@ -211,6 +219,16 @@ impl Settings {
                 ))]
                 if let Some(v) = general.compression {
                     compression = v
+                }
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
+                if let Some(v) = general.compression_level {
+                    compression_level = v
                 }
                 #[cfg(any(
                     feature = "compression",
@@ -544,6 +562,14 @@ impl Settings {
                     feature = "compression-deflate"
                 ))]
                 compression,
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
+                compression_level,
                 #[cfg(any(
                     feature = "compression",
                     feature = "compression-gzip",

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -63,6 +63,14 @@ pub mod fixtures {
             root_dir: opts.general.root,
             compression,
             compression_static,
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-gzip",
+                feature = "compression-brotli",
+                feature = "compression-zstd",
+                feature = "compression-deflate"
+            ))]
+            compression_level: opts.general.compression_level.into(),
             #[cfg(feature = "directory-listing")]
             dir_listing: opts.general.directory_listing,
             #[cfg(feature = "directory-listing")]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -70,7 +70,7 @@ pub mod fixtures {
                 feature = "compression-zstd",
                 feature = "compression-deflate"
             ))]
-            compression_level: opts.general.compression_level.into(),
+            compression_level: opts.general.compression_level,
             #[cfg(feature = "directory-listing")]
             dir_listing: opts.general.directory_listing,
             #[cfg(feature = "directory-listing")]

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -712,9 +712,13 @@ mod tests {
             {
                 Ok(result) => {
                     let res = result.resp;
-                    let res =
-                        compression::auto(method, &headers, static_web_server::settings::CompressionLevel::Default, res)
-                            .expect("unexpected bytes error during body compression");
+                    let res = compression::auto(
+                        method,
+                        &headers,
+                        static_web_server::settings::CompressionLevel::Default,
+                        res,
+                    )
+                    .expect("unexpected bytes error during body compression");
 
                     let buf = fs::read(root_dir().join("index.html"))
                         .expect("unexpected error during index.html reading");

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -713,7 +713,7 @@ mod tests {
                 Ok(result) => {
                     let res = result.resp;
                     let res =
-                        compression::auto(method, &headers, async_compression::Level::Fastest, res)
+                        compression::auto(method, &headers, static_web_server::settings::CompressionLevel::Default, res)
                             .expect("unexpected bytes error during body compression");
 
                     let buf = fs::read(root_dir().join("index.html"))

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -712,8 +712,9 @@ mod tests {
             {
                 Ok(result) => {
                     let res = result.resp;
-                    let res = compression::auto(method, &headers, res)
-                        .expect("unexpected bytes error during body compression");
+                    let res =
+                        compression::auto(method, &headers, async_compression::Level::Fastest, res)
+                            .expect("unexpected bytes error during body compression");
 
                     let buf = fs::read(root_dir().join("index.html"))
                         .expect("unexpected error during index.html reading");


### PR DESCRIPTION
## Description
This introduces a new `--compression-level=fastest|best|default` setting with `default` being the default. While `default` is meant to be algorithm-specific, currently level 4 seems to be the perfect sweet spot for all supported algorithms (see benchmarking results below).

This increases the data size somewhat: the 144 KiB `large.txt` file in our tests used to compress into 17.86 KiB with gzip (level 6), new default is 21.90 KiB. Brotli used to produce 14.00 KiB, now it is 21.51 KiB. It also improves the performance significantly however, especially for Brotli that for some reason goes with “best but horribly slow compression” as default.

## Related Issue
#380

## How Has This Been Tested?
Functional testing on Linux looks good.