### PR TITLE
Fixed clippy warning

### DIFF
--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -579,8 +579,6 @@ fn format_file_size(size: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::u64::MAX;
-
     use super::format_file_size;
 
     #[test]
@@ -621,7 +619,7 @@ mod tests {
 
     #[test]
     fn handle_large() {
-        let size = MAX;
+        let size = u64::MAX;
         assert_eq!("16384.00 PiB", format_file_size(size))
     }
 }


### PR DESCRIPTION
## Description
This fixes a clippy warning caused by test code added in #376:

```
error: importing a legacy numeric constant
   --> src/directory_listing.rs:582:9
    |
582 |     use std::u64::MAX;
    |         ^^^^^^^^^^^^^
    |
    = help: remove this import and use the associated constant `u64::MAX` from the primitive type instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
note: the lint level is defined here
   --> src/lib.rs:99:9
    |
99  | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(clippy::legacy_numeric_constants)]` implied by `#[deny(warnings)]`

error: usage of a legacy numeric constant
   --> src/directory_listing.rs:624:20
    |
624 |         let size = MAX;
    |                    ^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
help: use the associated constant instead
    |
624 |         let size = u64::MAX;
    |                    ~~~~~~~~
```