### PR TITLE
Fixed compile errors if only deflate compression is enabled

### DIFF
--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -67,7 +67,11 @@ pub async fn precompressed_variant<'a>(
     // Determine preferred-encoding extension if available
     let comp_ext = match compression::get_preferred_encoding(headers) {
         // https://zlib.net/zlib_faq.html#faq39
-        #[cfg(any(feature = "compression", feature = "compression-gzip", feature = "compression-deflate"))]
+        #[cfg(any(
+            feature = "compression",
+            feature = "compression-gzip",
+            feature = "compression-deflate"
+        ))]
         Some(ContentCoding::GZIP | ContentCoding::DEFLATE) => "gz",
         // https://peazip.github.io/brotli-compressed-file-format.html
         #[cfg(any(feature = "compression", feature = "compression-brotli"))]

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -67,7 +67,7 @@ pub async fn precompressed_variant<'a>(
     // Determine preferred-encoding extension if available
     let comp_ext = match compression::get_preferred_encoding(headers) {
         // https://zlib.net/zlib_faq.html#faq39
-        #[cfg(any(feature = "compression", feature = "compression-gzip"))]
+        #[cfg(any(feature = "compression", feature = "compression-gzip", feature = "compression-deflate"))]
         Some(ContentCoding::GZIP | ContentCoding::DEFLATE) => "gz",
         // https://peazip.github.io/brotli-compressed-file-format.html
         #[cfg(any(feature = "compression", feature = "compression-brotli"))]


### PR DESCRIPTION
## Description
Compiling with `--no-default-features --features=compression-deflate` currently produces errors:

```
error: unused import: `headers_ext::ContentCoding`
  --> src/compression_static.rs:18:47
   |
18 |     compression, handler::RequestHandlerOpts, headers_ext::ContentCoding,
   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:99:9
   |
99 | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`

error: unreachable statement
  --> src/compression_static.rs:86:5
   |
68 |       let comp_ext = match compression::get_preferred_encoding(headers) {
   |  ____________________-
69 | |         // https://zlib.net/zlib_faq.html#faq39
70 | |         #[cfg(any(feature = "compression", feature = "compression-gzip"))]
71 | |         Some(ContentCoding::GZIP | ContentCoding::DEFLATE) => "gz",
...  |
83 | |         }
84 | |     };
   | |_____- any code following this `match` expression is unreachable, as all arms diverge
85 |
86 | /     let comp_name = match file_path.file_name().and_then(OsStr::to_str) {
87 | |         Some(v) => v,
88 | |         None => {
89 | |             tracing::trace!("file name was not determined for the current path, skipping");
90 | |             return None;
91 | |         }
92 | |     };
   | |______^ unreachable statement
   |
   = note: `#[deny(unreachable_code)]` implied by `#[deny(warnings)]`

error: unused variable: `comp_ext`
  --> src/compression_static.rs:68:9
   |
68 |     let comp_ext = match compression::get_preferred_encoding(headers) {
   |         ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_comp_ext`
   |
   = note: `#[deny(unused_variables)]` implied by `#[deny(warnings)]`
```

This change fixes the bug.