### PR TITLE
Drop custom conversion between SystemTime and DateTime

### DIFF
--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -278,7 +278,7 @@ fn read_dir_entries(
             uri.push('/');
         }
 
-        let mtime = meta.modified().ok().map(|mtime| mtime.into());
+        let mtime = meta.modified().ok().map(DateTime::<Local>::from);
 
         file_entries.push(FileEntry {
             name,


### PR DESCRIPTION
## Description
The chrono crate implements conversion from `SystemTime` to `DateTime`, a custom implementation which does mostly the same thing (minus handling timestamps before the Unix epoch) is unnecessary.

## How Has This Been Tested?
Functional testing on Linux is fine.