### PR TITLE
Display file size for empty files as "0 B", not as "-"

### DIFF
--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -468,10 +468,7 @@ fn html_auto_index<'a>(
                                 }))
                             }
                             td align="right" {
-                                (match entry.size.unwrap_or(0) {
-                                    0 => "-".to_owned(),
-                                    size => format_file_size(size),
-                                })
+                                (entry.size.map(format_file_size).unwrap_or("-".into()))
                             }
                         }
                     }


### PR DESCRIPTION
## Description
This is something I originally implemented in #367 but reverted when I suspected a performance regression.

We use `"-"` in directory listings to indicate that a value is unavailable. However, for empty files that isn’t the case. We know the size, so we shouldn’t list it as `"-"` but as `"0 B"`, the former being typically reserved for directories.

## How Has This Been Tested?
Functional testing on Linux looks fine.