### PR TITLE
Move remote and real IP addresses logging to its own module

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -17,11 +17,10 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     server_info!("health endpoint: enabled={enabled}");
 }
 
-/// Handles health requests
+/// Handles health requests.
 pub fn pre_process<T>(
     opts: &RequestHandlerOpts,
     req: &Request<T>,
-    remote_addr_str: &str,
 ) -> Option<Result<Response<Body>, Error>> {
     if !opts.health {
         return None;
@@ -36,13 +35,6 @@ pub fn pre_process<T>(
     if !method.is_get() && !method.is_head() {
         return None;
     }
-
-    tracing::debug!(
-        "incoming request: method={} uri={}{}",
-        method,
-        uri,
-        remote_addr_str,
-    );
 
     let body = if method.is_get() {
         Body::from("OK")
@@ -77,7 +69,6 @@ mod tests {
                 ..Default::default()
             },
             &make_request("GET", "/health"),
-            ""
         )
         .is_none());
     }
@@ -90,7 +81,6 @@ mod tests {
                 ..Default::default()
             },
             &make_request("GET", "/health2"),
-            ""
         )
         .is_none());
     }
@@ -103,7 +93,6 @@ mod tests {
                 ..Default::default()
             },
             &make_request("POST", "/health"),
-            ""
         )
         .is_none());
     }
@@ -116,7 +105,6 @@ mod tests {
                 ..Default::default()
             },
             &make_request("GET", "/health"),
-            ""
         )
         .is_some());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ pub(crate) mod http_ext;
 #[cfg(feature = "http2")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
 pub mod https_redirect;
+pub(crate) mod log_addr;
 pub mod maintenance_mode;
 #[cfg(all(unix, feature = "experimental"))]
 pub(crate) mod metrics;

--- a/src/log_addr.rs
+++ b/src/log_addr.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// This file is part of Static Web Server.
+// See https://static-web-server.net/ for more information
+// Copyright (C) 2019-present Jose Quintana <joseluisq.net>
+
+//! A module to log remote and real IP addresses.
+//!
+
+use hyper::Request;
+use std::net::{IpAddr, SocketAddr};
+
+use crate::handler::RequestHandlerOpts;
+
+/// Initializes the log address module.
+pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
+    handler_opts.log_remote_address = enabled;
+    server_info!("log requests with remote and real IP addresses: enabled={enabled}");
+}
+
+/// It logs remote and real IP addresses if available.
+pub(crate) fn pre_process<T>(
+    opts: &RequestHandlerOpts,
+    req: &Request<T>,
+    remote_addr: Option<SocketAddr>,
+) {
+    let remote_addrs = if opts.log_remote_address {
+        // Add a Remote IP if available
+        let remote_addr = remote_addr.map_or("".to_owned(), |ip| format!(" remote_addr={ip}"));
+
+        // Add also a Real Remote IP if available
+        let real_remote_addr = req
+            .headers()
+            .get("X-Forwarded-For")
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.split(',').next())
+            .and_then(|s| s.trim().parse::<IpAddr>().ok())
+            .map_or("".to_owned(), |ip| format!(" real_remote_ip={ip}"));
+
+        [remote_addr, real_remote_addr].concat()
+    } else {
+        String::new()
+    };
+
+    // Log incoming requests in debug mode only if the health option is enabled
+    if opts.health {
+        tracing::debug!(
+            "incoming request: method={} uri={}{remote_addrs}",
+            req.method(),
+            req.uri(),
+        );
+        return;
+    }
+
+    tracing::info!(
+        "incoming request: method={} uri={}{remote_addrs}",
+        req.method(),
+        req.uri(),
+    );
+}

--- a/src/log_addr.rs
+++ b/src/log_addr.rs
@@ -9,7 +9,7 @@
 use hyper::Request;
 use std::net::{IpAddr, SocketAddr};
 
-use crate::handler::RequestHandlerOpts;
+use crate::{handler::RequestHandlerOpts, health};
 
 /// Initializes the log address module.
 pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
@@ -42,7 +42,7 @@ pub(crate) fn pre_process<T>(
     };
 
     // Log incoming requests in debug mode only if the health option is enabled
-    if opts.health {
+    if opts.health && health::is_health_endpoint(req) {
         tracing::debug!(
             "incoming request: method={} uri={}{remote_addrs}",
             req.method(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,9 @@ use crate::{compression, compression_static};
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;
 
-use crate::{control_headers, cors, health, helpers, maintenance_mode, security_headers, Settings};
+use crate::{
+    control_headers, cors, health, helpers, log_addr, maintenance_mode, security_headers, Settings,
+};
 use crate::{service::RouterService, Context, Result};
 
 /// Define a multi-threaded HTTP or HTTP/2 web server.
@@ -218,7 +220,6 @@ impl Server {
 
         // Log remote address option
         let log_remote_address = general.log_remote_address;
-        server_info!("log remote address: enabled={}", log_remote_address);
 
         // Log redirect trailing slash option
         let redirect_trailing_slash = general.redirect_trailing_slash;
@@ -274,6 +275,9 @@ impl Server {
 
         // Health endpoint option
         health::init(general.health, &mut handler_opts);
+
+        // Log request option
+        log_addr::init(general.log_remote_address, &mut handler_opts);
 
         // Metrics endpoint option (experimental)
         #[cfg(all(unix, feature = "experimental"))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -276,7 +276,7 @@ impl Server {
         // Health endpoint option
         health::init(general.health, &mut handler_opts);
 
-        // Log request option
+        // Log remote address option
         log_addr::init(general.log_remote_address, &mut handler_opts);
 
         // Metrics endpoint option (experimental)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR delegates the logic of logging remote and real IP addresses to a new `src/log_addr.rs` module as part of logging the incoming request.

It additionally makes sure to check for allowed HTTP methods before running modules `pre_process` functions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
