### PR TITLE
Log virtual-hosts information per request

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -235,7 +235,7 @@ impl RequestHandler {
             if let Some(advanced) = &self.opts.advanced_opts {
                 // If the "Host" header matches any virtual_host, change the root directory
                 if let Some(root) =
-                    virtual_hosts::get_real_root(req.headers(), advanced.virtual_hosts.as_deref())
+                    virtual_hosts::get_real_root(req, advanced.virtual_hosts.as_deref())
                 {
                     base_path = root;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ pub mod static_files;
 #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
 pub mod tls;
 pub mod transport;
-pub mod virtual_hosts;
+pub(crate) mod virtual_hosts;
 #[cfg(windows)]
 #[cfg_attr(docsrs, doc(cfg(windows)))]
 pub mod winservice;

--- a/src/virtual_hosts.rs
+++ b/src/virtual_hosts.rs
@@ -6,21 +6,28 @@
 //! Module that allows to determine a virtual hostname.
 //!
 
-use headers::HeaderMap;
 use hyper::header::HOST;
+use hyper::Request;
 use std::path::PathBuf;
 
 use crate::settings::VirtualHosts;
 
 /// It returns different root directory if the "Host" header matches a virtual hostname.
-pub fn get_real_root<'a>(
-    headers: &HeaderMap,
+pub(crate) fn get_real_root<'a, T>(
+    req: &mut Request<T>,
     vhosts_opts: Option<&'a [VirtualHosts]>,
 ) -> Option<&'a PathBuf> {
     if let Some(vhosts) = vhosts_opts {
-        if let Ok(host_str) = headers.get(HOST)?.to_str() {
+        if let Ok(host_str) = req.headers().get(HOST)?.to_str() {
             for vhost in vhosts {
                 if vhost.host == host_str {
+                    tracing::info!(
+                        "virtual host matched: vhost={} vhost_root={} method={} uri={}",
+                        vhost.host,
+                        vhost.root.display(),
+                        req.method(),
+                        req.uri(),
+                    );
                     return Some(&vhost.root);
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR logs relevant virtual-hosts information like `host` and `root` per incoming request.

**Log entry example:**

```log
2024-05-12T22:21:31.840432Z  INFO static_web_server::log_addr: incoming request: method=GET uri=/ remote_addr=[::1]:62623
2024-05-12T22:21:48.074323Z  INFO static_web_server::log_addr: incoming request: method=GET uri=/ remote_addr=[::1]:62625
2024-05-12T22:21:48.074394Z  INFO static_web_server::virtual_hosts: virtual host matched: vhost=example.com vhost_root=docker method=GET uri=/
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #322

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
