### PR TITLE
Fix unsupported system page size when using Linux aarch64 (ARM64) musl binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,9 @@ jobs:
           os: ubuntu-22.04
           rust: stable
           target: aarch64-unknown-linux-musl
+          # jemalloc 64KB (16) pagesize by default
+          # See: https://github.com/jemalloc/jemalloc/issues/467
+          jemalloc_sys_with_lg_page: 16
         - build: linux-gnu
           os: ubuntu-22.04
           rust: stable
@@ -208,6 +211,11 @@ jobs:
       run: |
         # ring crate: add Visual Studio Build Tools "VS 2022 C++ ARM64 build tools" and "clang" components
         $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin"
+
+    - name: Setup Linux ARM64 MUSL
+      if: ${{ contains(matrix.build, 'linux-musl-arm64') }}
+      run: |
+        echo "JEMALLOC_SYS_WITH_LG_PAGE=${{ matrix.jemalloc_sys_with_lg_page }}" >> $GITHUB_ENV
 
     - name: Show command used for Cargo
       run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->
This PR fixes an issue when using the `aarch64-unknown-linux-musl` binary (Jemalloc) in Debian Linux systems with page sizes bigger than `4K` like Linux aarch64 (E.g. **Raspberry Pi 5** uses `16K` pages).

Jemalloc by default builds with the host page size so we set it up to use the maximum supported page size of `64KB` on aarch64 when building SWS. `jemalloc` will handle systems with smaller page sizes too. See jemalloc/jemalloc#769

Until Jemalloc can have a better default someday. https://github.com/jemalloc/jemalloc/issues/467#issuecomment-2054282344

**Error:**

```sh
<jemalloc>: Unsupported system page size
<jemalloc>: Unsupported system page size
memory allocation of 5 bytes failed
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #440

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
