### PR TITLE
Fix jemalloc unsupported system page size error in Linux ARM64 musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,6 @@ jobs:
           os: ubuntu-22.04
           rust: stable
           target: aarch64-unknown-linux-musl
-          # jemalloc 64KB (16) pagesize by default
-          # See: https://github.com/jemalloc/jemalloc/issues/467
-          jemalloc_sys_with_lg_page: 16
         - build: linux-gnu
           os: ubuntu-22.04
           rust: stable
@@ -211,11 +208,6 @@ jobs:
       run: |
         # ring crate: add Visual Studio Build Tools "VS 2022 C++ ARM64 build tools" and "clang" components
         $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin"
-
-    - name: Setup Linux ARM64 MUSL
-      if: ${{ contains(matrix.build, 'linux-musl-arm64') }}
-      run: |
-        echo "JEMALLOC_SYS_WITH_LG_PAGE=${{ matrix.jemalloc_sys_with_lg_page }}" >> $GITHUB_ENV
 
     - name: Show command used for Cargo
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ strip = true
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-# workaround for https://github.com/cross-rs/cross/issues/1345
+# Cross: workaround for https://github.com/cross-rs/cross/issues/1345
 [package.metadata.cross.target.x86_64-unknown-netbsd]
 pre-build = [
     "mkdir -p /tmp/netbsd",
@@ -136,3 +136,10 @@ pre-build = [
     "rm base.tar.xz",
     "rm -rf /tmp/netbsd",
 ]
+
+# Cross: Linux ARM64 Musl only
+[package.metadata.cross.target.aarch64-unknown-linux-musl.env]
+# workaround for jemalloc on ARM64 (musl) by using 64KB pagesize by default (max value)
+# - https://github.com/static-web-server/static-web-server/issues/440
+# - https://github.com/jemalloc/jemalloc/issues/467
+passthrough = ["JEMALLOC_SYS_WITH_LG_PAGE=16"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It supersedes the previous work on https://github.com/static-web-server/static-web-server/pull/443 by correctly setting the default `64KB` page size for Jemalloc at the build config level (cross) that should be applied to development and production `aarch64-unknown-linux-musl` builds.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It supersedes #443 and fixes #440 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
