### PR TITLE
Re-enable Windows 7, 8, 8.1 builds support previously dropped in v2.31.0

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -145,11 +145,11 @@ jobs:
             target: aarch64-apple-darwin
           - build: windows-msvc
             os: windows-2022
-            rust: stable
+            rust: 1.77.2
             target: x86_64-pc-windows-msvc
           - build: windows-msvc-i686
             os: windows-2022
-            rust: stable
+            rust: 1.77.2
             target: i686-pc-windows-msvc
           - build: windows-msvc-arm64
             os: windows-2022
@@ -157,7 +157,8 @@ jobs:
             target: aarch64-pc-windows-msvc
           - build: windows-pc-gnu
             os: windows-2022
-            rust: stable-x86_64-gnu
+            rust: 1.77.2
+            target: x86_64-pc-windows-gnu
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,11 +143,11 @@ jobs:
           target: aarch64-apple-darwin
         - build: windows-msvc
           os: windows-2022
-          rust: stable
+          rust: 1.77.2
           target: x86_64-pc-windows-msvc
         - build: windows-msvc-i686
           os: windows-2022
-          rust: stable
+          rust: 1.77.2
           target: i686-pc-windows-msvc
         - build: windows-msvc-arm64
           os: windows-2022
@@ -155,7 +155,7 @@ jobs:
           target: aarch64-pc-windows-msvc
         - build: windows-pc-gnu
           os: windows-2022
-          rust: stable-x86_64-gnu
+          rust: 1.77.2
           target: x86_64-pc-windows-gnu
 
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds again support for the legacy Windows 7, 8, 8.1 previously removed in SWS `v2.31.0` due to [Rust also dropped support in 1.78.0](https://blog.rust-lang.org/2024/02/26/Windows-7.html).

Now, we pin Rust to `1.77.2` for the following Windows targets:

- `x86_64-pc-windows-msvc`
- `i686-pc-windows-msvc`
- `x86_64-pc-windows-gnu`

`aarch64-pc-windows-msvc` (a.k.a. Windows ARM64) will continue using the latest stable Rust available.

**Notes**

[Microsoft stopped support for Windows 7 in 2020](https://learn.microsoft.com/en-us/lifecycle/products/windows-7) (2023 for extended users).
But at the moment, we don't know how long we will keep supporting this unmaintained platform.
However, keep in mind that we could reconsider bumping up the MSRV in future SWS versions when convenient, advising users accordingly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/orgs/static-web-server/discussions/445#discussioncomment-9495097

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
