### PR TITLE
update installer.sh to support overriding default variables

### DIFF
--- a/docs/content/download-and-install.md
+++ b/docs/content/download-and-install.md
@@ -27,6 +27,20 @@ curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | sh
 
 `static-web-server` should be installed under the `/usr/local/bin` directory.
 
+You can install a specific version of SWS to a custom location by setting environment variables:
+
+```sh
+export SWS_INSTALL_DIR="~/.local/bin"
+export SWS_INSTALL_VERSION="2.31.0" # full list at https://github.com/static-web-server/static-web-server/tags
+curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | sh
+```
+
+Make sure you set the environment variables for the piped process (`sh` in our case), not the piping process(`curl`). If you don't want to `export` the variable, use:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | SWS_INSTALL_DIR="~/.local/bin" sh
+```
+
 ### Arch Linux
 
 Via [Yay](https://github.com/Jguer/yay) or your favorite AUR Helper.

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -23,10 +23,10 @@ fi
 set -u
 
 # SWS latest version
-version="2.31.1"
+version=${SWS_INSTALL_VERSION:-"2.31.1"}
 
 # Default directory where SWS will be installed
-local_bin="/usr/local/bin"
+local_bin=${SWS_INSTALL_DIR:-"/usr/local/bin"}
 
 main() {
     need_cmd uname


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

adds two optional environment variables controlling the installation script:

```sh
export SWS_INSTALL_DIR="~/.local/bin"
export SWS_INSTALL_VERSION="2.31.0"
curl --proto '=https' --tlsv1.2 -sSfL https://get.static-web-server.net | sh
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

when installing with get.static-web-server.net, I would like to be able to pin the install version and specify an installation directory (so I can use it in packaging scripts)
