### PR TITLE
Fix duplicate `Vary` response headers for `compression` and `compression-static` features

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -98,13 +98,8 @@ pub(crate) fn post_process<T>(
         return Ok(resp);
     }
 
-    let is_precompressed = resp.headers().get(CONTENT_ENCODING).is_some();
-    if is_precompressed {
-        return Ok(resp);
-    }
-
     // Compression content encoding varies so use a `Vary` header
-    resp.headers_mut().append(
+    resp.headers_mut().insert(
         hyper::header::VARY,
         HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
     );
@@ -216,7 +211,7 @@ pub fn gzip(
     )));
     let header = create_encoding_header(head.headers.remove(CONTENT_ENCODING), ContentCoding::GZIP);
     head.headers.remove(CONTENT_LENGTH);
-    head.headers.append(CONTENT_ENCODING, header);
+    head.headers.insert(CONTENT_ENCODING, header);
     Response::from_parts(head, body)
 }
 
@@ -246,7 +241,7 @@ pub fn deflate(
         ContentCoding::DEFLATE,
     );
     head.headers.remove(CONTENT_LENGTH);
-    head.headers.append(CONTENT_ENCODING, header);
+    head.headers.insert(CONTENT_ENCODING, header);
     Response::from_parts(head, body)
 }
 
@@ -274,7 +269,7 @@ pub fn brotli(
     let header =
         create_encoding_header(head.headers.remove(CONTENT_ENCODING), ContentCoding::BROTLI);
     head.headers.remove(CONTENT_LENGTH);
-    head.headers.append(CONTENT_ENCODING, header);
+    head.headers.insert(CONTENT_ENCODING, header);
     Response::from_parts(head, body)
 }
 
@@ -301,7 +296,7 @@ pub fn zstd(
     )));
     let header = create_encoding_header(head.headers.remove(CONTENT_ENCODING), ContentCoding::ZSTD);
     head.headers.remove(CONTENT_LENGTH);
-    head.headers.append(CONTENT_ENCODING, header);
+    head.headers.insert(CONTENT_ENCODING, header);
     Response::from_parts(head, body)
 }
 

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -45,7 +45,7 @@ pub(crate) fn post_process<T>(
     }
 
     // Compression content encoding varies so use a `Vary` header
-    resp.headers_mut().append(
+    resp.headers_mut().insert(
         hyper::header::VARY,
         HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
     );

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -324,11 +324,12 @@ mod tests {
     use std::net::SocketAddr;
 
     use crate::http_ext::MethodExt;
-    use crate::testing::fixtures::{fixture_req_handler, REMOTE_ADDR};
+    use crate::testing::fixtures::{fixture_req_handler, fixture_settings, REMOTE_ADDR};
 
     #[tokio::test]
     async fn check_allowed_methods() {
-        let req_handler = fixture_req_handler("toml/handler.toml");
+        let settings = fixture_settings("toml/handler.toml");
+        let req_handler = fixture_req_handler(settings.general, settings.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let methods = [

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -13,19 +13,24 @@ pub mod fixtures {
 
     use crate::{
         handler::{RequestHandler, RequestHandlerOpts},
+        settings::cli::General,
+        settings::Advanced,
         Settings,
     };
 
     /// Testing Remote address
     pub const REMOTE_ADDR: &str = "127.0.0.1:1234";
 
-    /// Create a `RequestHandler` from a custom TOML config file (fixture).
-    pub fn fixture_req_handler(fixture_toml: &str) -> RequestHandler {
+    /// Load the fixture TOML settings and return it.
+    pub fn fixture_settings(fixture_toml: &str) -> Settings {
         // Replace default config file and load the fixture TOML settings
         let f = PathBuf::from("tests/fixtures").join(fixture_toml);
         std::env::set_var("SERVER_CONFIG_FILE", f);
-        let opts = Settings::get(false).unwrap();
+        Settings::get(false).unwrap()
+    }
 
+    /// Create a `RequestHandler` from a custom TOML config file (fixture).
+    pub fn fixture_req_handler(general: General, advanced: Option<Advanced>) -> RequestHandler {
         #[cfg(not(any(
             feature = "compression",
             feature = "compression-gzip",
@@ -49,7 +54,7 @@ pub mod fixtures {
             feature = "compression-zstd",
             feature = "compression-deflate"
         ))]
-        let compression = opts.general.compression;
+        let compression = general.compression;
         #[cfg(any(
             feature = "compression",
             feature = "compression-gzip",
@@ -57,10 +62,10 @@ pub mod fixtures {
             feature = "compression-zstd",
             feature = "compression-deflate"
         ))]
-        let compression_static = opts.general.compression_static;
+        let compression_static = general.compression_static;
 
         let req_handler_opts = RequestHandlerOpts {
-            root_dir: opts.general.root,
+            root_dir: general.root,
             compression,
             compression_static,
             #[cfg(any(
@@ -70,35 +75,35 @@ pub mod fixtures {
                 feature = "compression-zstd",
                 feature = "compression-deflate"
             ))]
-            compression_level: opts.general.compression_level,
+            compression_level: general.compression_level,
             #[cfg(feature = "directory-listing")]
-            dir_listing: opts.general.directory_listing,
+            dir_listing: general.directory_listing,
             #[cfg(feature = "directory-listing")]
-            dir_listing_order: opts.general.directory_listing_order,
+            dir_listing_order: general.directory_listing_order,
             #[cfg(feature = "directory-listing")]
-            dir_listing_format: opts.general.directory_listing_format,
+            dir_listing_format: general.directory_listing_format,
             // TODO: add support or `cors` when required
             cors: None,
-            security_headers: opts.general.security_headers,
-            cache_control_headers: opts.general.cache_control_headers,
-            page404: opts.general.page404,
-            page50x: opts.general.page50x,
+            security_headers: general.security_headers,
+            cache_control_headers: general.cache_control_headers,
+            page404: general.page404,
+            page50x: general.page50x,
             // TODO: add support or `page_fallback` when required
             #[cfg(feature = "fallback-page")]
             page_fallback: vec![],
             #[cfg(feature = "basic-auth")]
-            basic_auth: opts.general.basic_auth,
-            log_remote_address: opts.general.log_remote_address,
-            redirect_trailing_slash: opts.general.redirect_trailing_slash,
-            ignore_hidden_files: opts.general.ignore_hidden_files,
-            index_files: vec![opts.general.index_files],
-            health: opts.general.health,
+            basic_auth: general.basic_auth,
+            log_remote_address: general.log_remote_address,
+            redirect_trailing_slash: general.redirect_trailing_slash,
+            ignore_hidden_files: general.ignore_hidden_files,
+            index_files: vec![general.index_files],
+            health: general.health,
             #[cfg(all(unix, feature = "experimental"))]
-            experimental_metrics: opts.general.experimental_metrics,
-            maintenance_mode: opts.general.maintenance_mode,
-            maintenance_mode_status: opts.general.maintenance_mode_status,
-            maintenance_mode_file: opts.general.maintenance_mode_file,
-            advanced_opts: opts.advanced,
+            experimental_metrics: general.experimental_metrics,
+            maintenance_mode: general.maintenance_mode,
+            maintenance_mode_status: general.maintenance_mode_status,
+            maintenance_mode_file: general.maintenance_mode_file,
+            advanced_opts: advanced,
         };
 
         RequestHandler {

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -1,0 +1,64 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(dead_code)]
+
+pub mod tests {
+    use headers::HeaderValue;
+    use hyper::Request;
+    use std::net::SocketAddr;
+
+    use static_web_server::{
+        settings::cli::General,
+        testing::fixtures::{fixture_req_handler, fixture_settings, REMOTE_ADDR},
+    };
+
+    #[tokio::test]
+    async fn compression_file() {
+        let opts = fixture_settings("toml/handler.toml");
+        let general = General {
+            compression: true,
+            compression_static: true,
+            ..opts.general
+        };
+        let req_handler = fixture_req_handler(general, opts.advanced);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/index.html".parse().unwrap();
+        req.headers_mut().insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br".parse().unwrap(),
+        );
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 200);
+                assert_eq!(
+                    res.headers().get("content-type"),
+                    Some(&HeaderValue::from_static("text/html"))
+                );
+                assert_eq!(
+                    res.headers().get("vary"),
+                    Some(&HeaderValue::from_static("accept-encoding"))
+                );
+                assert_eq!(
+                    res.headers().get("content-encoding"),
+                    Some(&HeaderValue::from_static("gzip"))
+                );
+                assert_eq!(
+                    res.headers().get("cache-control"),
+                    Some(&HeaderValue::from_static("public, max-age=86400"))
+                );
+                assert_eq!(
+                    res.headers().get("server"),
+                    Some(&HeaderValue::from_static("Static Web Server"))
+                );
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
+}

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -316,7 +316,7 @@ mod tests {
         assert!(!headers["last-modified"].is_empty());
         assert_eq!(
             &headers["content-type"], "application/javascript",
-            "content-type is not html"
+            "content-type is not javascript"
         );
 
         let body = hyper::body::to_bytes(res.body_mut())

--- a/tests/experimental_metrics.rs
+++ b/tests/experimental_metrics.rs
@@ -8,11 +8,14 @@ pub mod tests {
     use hyper::Request;
     use std::net::SocketAddr;
 
-    use static_web_server::testing::fixtures::{fixture_req_handler, REMOTE_ADDR};
+    use static_web_server::testing::fixtures::{
+        fixture_req_handler, fixture_settings, REMOTE_ADDR,
+    };
 
     #[tokio::test]
     async fn experimental_metrics_enabled() {
-        let req_handler = fixture_req_handler("toml/experimental_metrics.toml");
+        let opts = fixture_settings("toml/experimental_metrics.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -8,11 +8,14 @@ pub mod tests {
     use hyper::Request;
     use std::net::SocketAddr;
 
-    use static_web_server::testing::fixtures::{fixture_req_handler, REMOTE_ADDR};
+    use static_web_server::testing::fixtures::{
+        fixture_req_handler, fixture_settings, REMOTE_ADDR,
+    };
 
     #[tokio::test]
     async fn custom_headers_apply_for_dir() {
-        let req_handler = fixture_req_handler("toml/handler.toml");
+        let opts = fixture_settings("toml/handler.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -27,6 +30,10 @@ pub mod tests {
                     Some(&HeaderValue::from_static("text/html"))
                 );
                 assert_eq!(
+                    res.headers().get("vary"),
+                    Some(&HeaderValue::from_static("accept-encoding"))
+                );
+                assert_eq!(
                     res.headers().get("server"),
                     Some(&HeaderValue::from_static("Static Web Server"))
                 );
@@ -39,7 +46,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn custom_headers_apply_for_file() {
-        let req_handler = fixture_req_handler("toml/handler.toml");
+        let opts = fixture_settings("toml/handler.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -52,6 +60,14 @@ pub mod tests {
                 assert_eq!(
                     res.headers().get("content-type"),
                     Some(&HeaderValue::from_static("text/html"))
+                );
+                assert_eq!(
+                    res.headers().get("vary"),
+                    Some(&HeaderValue::from_static("accept-encoding"))
+                );
+                assert_eq!(
+                    res.headers().get("cache-control"),
+                    Some(&HeaderValue::from_static("public, max-age=86400"))
                 );
                 assert_eq!(
                     res.headers().get("server"),

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -7,11 +7,14 @@ pub mod tests {
     use hyper::Request;
     use std::net::SocketAddr;
 
-    use static_web_server::testing::fixtures::{fixture_req_handler, REMOTE_ADDR};
+    use static_web_server::testing::fixtures::{
+        fixture_req_handler, fixture_settings, REMOTE_ADDR,
+    };
 
     #[tokio::test]
     async fn redirects_skipped() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -30,7 +33,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_host() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -49,7 +53,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_glob_groups_1() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -71,7 +76,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_glob_groups_2() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -93,7 +99,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_glob_groups_3() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -115,7 +122,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_glob_groups_4() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -137,7 +145,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_glob_groups_5() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -159,7 +168,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_glob_groups_6() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -181,7 +191,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn redirects_glob_groups_generic_1() {
-        let req_handler = fixture_req_handler("toml/redirects.toml");
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();

--- a/tests/rewrites.rs
+++ b/tests/rewrites.rs
@@ -7,11 +7,14 @@ pub mod tests {
     use hyper::Request;
     use std::net::SocketAddr;
 
-    use static_web_server::testing::fixtures::{fixture_req_handler, REMOTE_ADDR};
+    use static_web_server::testing::fixtures::{
+        fixture_req_handler, fixture_settings, REMOTE_ADDR,
+    };
 
     #[tokio::test]
     async fn rewrites_skipped() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -30,7 +33,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn rewrites_glob_groups_1() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -55,7 +59,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn rewrites_glob_groups_2() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -80,7 +85,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn rewrites_glob_groups_3() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -105,7 +111,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn rewrites_glob_groups_4() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -130,7 +137,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn rewrites_glob_groups_5() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -149,7 +157,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn rewrites_glob_groups_6() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -171,7 +180,8 @@ pub mod tests {
 
     #[tokio::test]
     async fn rewrites_glob_groups_generic_1() {
-        let req_handler = fixture_req_handler("toml/rewrites.toml");
+        let opts = fixture_settings("toml/rewrites.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->
This PR prevents duplicate `Vary` headers in responses when enabling `compression` and `compression-static`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
