### PR TITLE
Improve typos configuration

### DIFF
--- a/.github/workflows/config/typos.toml
+++ b/.github/workflows/config/typos.toml
@@ -1,7 +1,19 @@
+[files]
+extend-exclude = [
+    ".git/",
+]
+ignore-hidden = false
+
+[default]
+extend-ignore-re = [
+    "\\[[0-9a-f]{7}\\]",
+    "commit/[0-9a-f]{7}",
+    "\\{a,ba,da,k,z\\}sh",
+]
+
 [default.extend-words]
-Compressable = "Compressable"
-ba = "ba"
-caf = "caf"
-flate = "flate"
-Ody = "Ody"
-prefered = "prefered"
+compressable = "compressable"
+
+[default.extend-identifiers]
+flate2 = "flate2"
+OdyX = "OdyX"

--- a/.github/workflows/config/typos.toml
+++ b/.github/workflows/config/typos.toml
@@ -9,6 +9,7 @@ extend-ignore-re = [
     "\\[[0-9a-f]{7}\\]",
     "commit/[0-9a-f]{7}",
     "\\{a,ba,da,k,z\\}sh",
+    "\\[@[a-zA-Z0-9\\-]+\\]",
 ]
 
 [default.extend-words]

--- a/.github/workflows/config/typos.toml
+++ b/.github/workflows/config/typos.toml
@@ -16,4 +16,3 @@ compressable = "compressable"
 
 [default.extend-identifiers]
 flate2 = "flate2"
-OdyX = "OdyX"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ __Fixes__
 __Features__
 
 - [012ef11](https://github.com/static-web-server/static-web-server/commit/012ef11) Crate: Display platforms-specific documentation on docs.rs.
-- [a197f20](https://github.com/static-web-server/static-web-server/commit/a197f20) CI: Load testing benchmarks comparison for each commit via Github Actions. PR [#355](https://github.com/static-web-server/static-web-server/pull/355) by [@palant](https://github.com/palant).
+- [a197f20](https://github.com/static-web-server/static-web-server/commit/a197f20) CI: Load testing benchmarks comparison for each commit via GitHub Actions. PR [#355](https://github.com/static-web-server/static-web-server/pull/355) by [@palant](https://github.com/palant).
 
 __Refactorings__
 
@@ -660,7 +660,7 @@ __Docs__
 
 **Advice about the new organization change**
 
-Certainly, there is no impact if you still rely on previous Github release links (E.g pre-compiled binaries) because they are always redirected permanently.<br>
+Certainly, there is no impact if you still rely on previous GitHub release links (E.g pre-compiled binaries) because they are always redirected permanently.<br>
 However, since we moved to a [new organization](https://github.com/static-web-server/static-web-server), we highly encourage you to update your links using the new GitHub release address of the `static-web-server` organization.
 
 ## v2.13.1 - 2022-10-17
@@ -1269,7 +1269,7 @@ __Refactorings__
 
 __Codebase__
 
-- [7265f6b](https://github.com/static-web-server/static-web-server/commit/7265f6b) Github Actions as new CI.
+- [7265f6b](https://github.com/static-web-server/static-web-server/commit/7265f6b) GitHub Actions as new CI.
 - [c63b549](https://github.com/static-web-server/static-web-server/commit/c63b549) Remove Travis CI.
 - [65250c0](https://github.com/static-web-server/static-web-server/commit/65250c0) Minor simplications on server module.
 - [b94fe72](https://github.com/static-web-server/static-web-server/commit/b94fe72) Update core modules structure.


### PR DESCRIPTION
## Description

Make typos config more strict preventing future ignore of actual typos. Put everything in its place.

You could check hidden files by removing `.` from the command line.
https://github.com/static-web-server/static-web-server/blob/9afff97acd15320bbd8b7c426d42a3fd369992c3/Makefile#L301