### PR TITLE
Remove redundant `async` function signatures

### DIFF
--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -54,9 +54,9 @@ pub(crate) fn post_process<T>(
 }
 
 /// Search for the pre-compressed variant of the given file path.
-pub async fn precompressed_variant<'a>(
+pub fn precompressed_variant(
     file_path: &Path,
-    headers: &'a HeaderMap<HeaderValue>,
+    headers: &HeaderMap<HeaderValue>,
 ) -> Option<CompressedFileVariant> {
     tracing::trace!(
         "preparing pre-compressed file variant path of {}",

--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -88,8 +88,8 @@ mod tests {
         MAX_AGE_ONE_DAY, MAX_AGE_ONE_HOUR, MAX_AGE_ONE_YEAR,
     };
 
-    #[tokio::test]
-    async fn headers_one_hour() {
+    #[test]
+    fn headers_one_hour() {
         let mut resp = Response::new(Body::empty());
         *resp.status_mut() = StatusCode::OK;
 
@@ -105,8 +105,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn headers_one_day_default() {
+    #[test]
+    fn headers_one_day_default() {
         let mut resp = Response::new(Body::empty());
         *resp.status_mut() = StatusCode::OK;
 
@@ -120,8 +120,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn headers_one_year() {
+    #[test]
+    fn headers_one_year() {
         let mut resp = Response::new(Body::empty());
         *resp.status_mut() = StatusCode::OK;
 

--- a/src/https_redirect.rs
+++ b/src/https_redirect.rs
@@ -23,7 +23,7 @@ pub struct RedirectOpts {
 }
 
 /// It redirects all requests from HTTP to HTTPS.
-pub async fn redirect_to_https<T>(
+pub fn redirect_to_https<T>(
     req: &Request<T>,
     opts: Arc<RedirectOpts>,
 ) -> Result<Response<Body>, StatusCode> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -20,7 +20,7 @@ use crate::fs::stream::{optimal_buf_size, FileStream};
 
 /// It converts a file object into a corresponding HTTP response or
 /// returns an error holding an HTTP status code otherwise.
-pub(crate) async fn response_body(
+pub(crate) fn response_body(
     mut file: File,
     path: &PathBuf,
     meta: &Metadata,

--- a/src/server.rs
+++ b/src/server.rs
@@ -507,9 +507,7 @@ impl Server {
                                 async move {
                                     let uri = req.uri();
                                     let method = req.method();
-                                    match https_redirect::redirect_to_https(&req, redirect_opts)
-                                        .await
-                                    {
+                                    match https_redirect::redirect_to_https(&req, redirect_opts) {
                                         Ok(resp) => Ok(resp),
                                         Err(status) => error_page::error_response(
                                             uri, method, &status, &page404, &page50x,

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -9,8 +9,8 @@ mod tests {
     use http::Method;
     use static_web_server::cors;
 
-    #[tokio::test]
-    async fn allow_methods() {
+    #[test]
+    fn allow_methods() {
         let cors = cors::new("*", "", "").unwrap();
         let headers = HeaderMap::new();
         let methods = &[Method::GET, Method::HEAD, Method::OPTIONS];
@@ -48,8 +48,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn origin_allowed() {
+    #[test]
+    fn origin_allowed() {
         let cors = cors::new("*", "", "").unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("origin", "https://localhost".parse().unwrap());
@@ -65,8 +65,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn origin_not_allowed() {
+    #[test]
+    fn origin_not_allowed() {
         let cors = cors::new("https://localhost.rs", "", "").unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("origin", "https://localhost".parse().unwrap());
@@ -78,8 +78,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn method_allowed() {
+    #[test]
+    fn method_allowed() {
         let cors = cors::new("*", "", "").unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("origin", "https://localhost".parse().unwrap());
@@ -90,8 +90,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn method_disallowed() {
+    #[test]
+    fn method_disallowed() {
         let cors = cors::new("*", "", "").unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("origin", "https://localhost".parse().unwrap());
@@ -108,8 +108,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn headers_allowed() {
+    #[test]
+    fn headers_allowed() {
         let cors = cors::new("*", "", "").unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("origin", "https://localhost".parse().unwrap());
@@ -125,8 +125,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn headers_invalid() {
+    #[test]
+    fn headers_invalid() {
         let cors = cors::new("*", "", "").unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("origin", "https://localhost".parse().unwrap());

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -8,8 +8,8 @@ mod tests {
     use static_web_server::settings::file::Settings;
     use std::path::{Path, PathBuf};
 
-    #[tokio::test]
-    async fn toml_file_parsing() {
+    #[test]
+    fn toml_file_parsing() {
         let config_path = Path::new("tests/toml/config.toml");
         let settings = Settings::read(config_path).unwrap();
         let root = settings.general.unwrap().root.unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->
This PR improves the code signature of some `async` functions and makes them `sync` to communicate better the function's intention.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
