### PR TITLE
Fix test execution issues when running cargo tests passing non-SWS arguments

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -100,7 +100,21 @@ impl Settings {
     /// It also takes care to initialize the logging system with its level
     /// once the `general` settings are determined.
     pub fn get(log_init: bool) -> Result<Settings> {
-        let opts = General::parse();
+        Self::read(log_init, true)
+    }
+
+    /// Reads CLI/Env and config file options returning the server settings
+    /// without parsing arguments useful for testing.
+    pub fn get_unparsed(log_init: bool) -> Result<Settings> {
+        Self::read(log_init, false)
+    }
+
+    fn read(log_init: bool, parse_args: bool) -> Result<Settings> {
+        let opts = if parse_args {
+            General::parse()
+        } else {
+            General::parse_from([""])
+        };
 
         // Define the general CLI/file options
         let version = opts.version;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -26,7 +26,7 @@ pub mod fixtures {
         // Replace default config file and load the fixture TOML settings
         let f = PathBuf::from("tests/fixtures").join(fixture_toml);
         std::env::set_var("SERVER_CONFIG_FILE", f);
-        Settings::get(false).unwrap()
+        Settings::get_unparsed(false).unwrap()
     }
 
     /// Create a `RequestHandler` from a custom TOML config file (fixture).

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
+#[cfg(test)]
 pub mod tests {
     use headers::HeaderValue;
     use hyper::Request;

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
+#[cfg(test)]
 pub mod tests {
     use headers::HeaderValue;
     use hyper::Request;

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
+#[cfg(test)]
 pub mod tests {
     use hyper::Request;
     use std::net::SocketAddr;

--- a/tests/rewrites.rs
+++ b/tests/rewrites.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
+#[cfg(test)]
 pub mod tests {
     use hyper::Request;
     use std::net::SocketAddr;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR fixes an issue when running tests via Cargo with additional non-SWS arguments.
This was because SWS tried to parse CLI arguments in a test context.

Now, SWS won't parse arguments by default when running tests. So the following command will work as expected (run all tests):

```sh
cargo test -- --test-threads 1 --nocapture
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It fixes #465 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
