### PR TITLE
Fix regression when using CLI boolean flags without explicit values

### DIFF
--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -155,7 +155,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_HTTP2_TLS",
     )]
@@ -181,7 +181,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         requires_if("true", "http2"),
         env = "SERVER_HTTPS_REDIRECT"
@@ -252,7 +252,7 @@ pub struct General {
         default_value = "true",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_COMPRESSION",
     )]
@@ -302,7 +302,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_COMPRESSION_STATIC",
     )]
@@ -318,7 +318,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_DIRECTORY_LISTING",
     )]
@@ -355,7 +355,7 @@ pub struct General {
         default_value_if("http2", "true", Some("true")),
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_SECURITY_HEADERS",
     )]
@@ -376,7 +376,7 @@ pub struct General {
         default_value = "true",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_CACHE_CONTROL_HEADERS",
     )]
@@ -407,7 +407,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_LOG_REMOTE_ADDRESS",
     )]
@@ -419,7 +419,7 @@ pub struct General {
         default_value = "true",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_REDIRECT_TRAILING_SLASH",
     )]
@@ -431,7 +431,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_IGNORE_HIDDEN_FILES",
     )]
@@ -443,7 +443,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_DISABLE_SYMLINKS",
     )]
@@ -455,7 +455,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_HEALTH",
     )]
@@ -469,7 +469,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_EXPERIMENTAL_METRICS",
     )]
@@ -481,7 +481,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_MAINTENANCE_MODE"
     )]
@@ -518,7 +518,7 @@ pub struct General {
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
-        require_equals(true),
+        require_equals(false),
         action = clap::ArgAction::Set,
         env = "SERVER_WINDOWS_SERVICE",
     )]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->
This PR fixes a regression when using CLI boolean flags without explicit values. 

Boolean flags like `--directory-listing`, `--compression-static`, etc will work properly in three variants.

For example:

```sh
--directory-listing
--directory-listing true
--directory-listing=true
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It fixes #467

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Supersedes https://github.com/static-web-server/static-web-server/pull/215 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
