### PR TITLE
Fix wrong `Content-Encoding` when enabling both compression and compression-static features

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -98,6 +98,11 @@ pub(crate) fn post_process<T>(
         return Ok(resp);
     }
 
+    let is_precompressed = resp.headers().get(CONTENT_ENCODING).is_some();
+    if is_precompressed {
+        return Ok(resp);
+    }
+
     // Compression content encoding varies so use a `Vary` header
     resp.headers_mut().insert(
         hyper::header::VARY,

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -16,7 +16,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn compression_file() {
-        let opts = fixture_settings("toml/handler.toml");
+        let opts = fixture_settings("toml/handler_fixtures.toml");
         let general = General {
             compression: true,
             compression_static: true,

--- a/tests/fixtures/toml/handler_fixtures.toml
+++ b/tests/fixtures/toml/handler_fixtures.toml
@@ -1,0 +1,9 @@
+[general]
+
+root = "tests/fixtures/public"
+
+[advanced]
+
+[[advanced.headers]]
+source = "**/*.{html,htm}"
+headers = { Server = "Static Web Server" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR fixes a wrong `Content-Encoding` header value in the response when `compression` and `compression-static` features are enabled (either via CLI or a config file) due to SWS compression (dynamic) module performing the post-processing even if a pre-compressed file was found. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It fixes #470

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

```sh
static-web-server -p 8787 -d docker/public/ --compression --compression-static
```

**Before**

```sh
curl -sD - -o /dev/null -H "Accept-Encoding: gzip, zstd, br" http://localhost:8787/assets/main.css
# HTTP/1.1 200 OK
# last-modified: Mon, 12 Aug 2024 22:56:47 GMT
# content-type: text/css
# accept-ranges: bytes
# vary: accept-encoding
# content-encoding: gzip, gzip
# cache-control: public, max-age=31536000
# transfer-encoding: chunked
# date: Mon, 12 Aug 2024 23:16:59 GMT
```

**After**

```sh
curl -sD - -o /dev/null -H "Accept-Encoding: gzip, zstd, br" http://localhost:8787/assets/main.css
# HTTP/1.1 200 OK
# last-modified: Mon, 12 Aug 2024 22:56:47 GMT
# content-type: text/css
# accept-ranges: bytes
# content-encoding: gzip
# vary: accept-encoding
# cache-control: public, max-age=31536000
# transfer-encoding: chunked
# date: Mon, 12 Aug 2024 23:18:14 GMT
```

## Screenshots (if appropriate):
