### PR TITLE
Support for generating man pages and completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "carapace_spec_clap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1b382d0ea2f304c9dba34f746284c7b6d231db48eae53b36d1e6eda1aba402"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "indexmap",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +355,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_allgen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b31337b55b534905114db35586730324e5dab9a01af7cf440db39723caeab4"
+dependencies = [
+ "carapace_spec_clap",
+ "clap",
+ "clap_complete",
+ "clap_complete_fig",
+ "clap_complete_nushell",
+ "clap_mangen",
+ "thiserror",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +379,35 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "205d5ef6d485fa47606b98b0ddc4ead26eb850aaa86abfb562a94fb3280ecba0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d494102c8ff3951810c72baf96910b980fb065ca5d3101243e6a8dc19747c86b"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe32110e006bccf720f8c9af3fee1ba7db290c724eab61544e1d3295be3a40e"
+dependencies = [
+ "clap",
+ "clap_complete",
 ]
 
 [[package]]
@@ -370,6 +427,16 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17415fd4dfbea46e3274fcd8d368284519b358654772afb700dc2e8d2b24eeb"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -836,6 +903,7 @@ checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1287,6 +1355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1519,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1653,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "clap_allgen",
  "compact_str",
  "form_urlencoded",
  "futures-util",
@@ -2004,6 +2092,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ bcrypt = { version = "0.15", optional = true }
 bytes = "1.6"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_allgen = "0.2.0"
 compact_str = "0.8"
 form_urlencoded = "1.2"
 futures-util = { version = "0.3", default-features = false }

--- a/docs/content/features/man-pages-completions.md
+++ b/docs/content/features/man-pages-completions.md
@@ -1,0 +1,16 @@
+# Generated CLI documentation
+**`SWS`** is capable of generating documentation for its command line interface in the form of man pages and shell completions.
+
+You can generate completions for these shells and completion engines using `static-web-server generate --completions <output_path>`:
+- bash
+- carapace
+- elvish
+- fig
+- fish
+- nushell
+- powershell
+- zsh
+
+You can generate man pages using `static-web-server generate --man-pages <output_path>`.
+
+Finally, if you want both to be generated, you can just use `static-web-server generate <output_path>` without specifying `--completions` or `--man-pages`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -166,6 +166,7 @@ nav:
     - 'Multiple Index Files': 'features/multiple-index-files.md'
     - 'Maintenance Mode': 'features/maintenance-mode.md'
     - 'WebAssembly': 'features/webassembly.md'
+    - 'Man Pages and Shell Completions': 'features/man-pages-completions.md'
   - 'Platforms & Architectures': 'platforms-architectures.md'
   - 'Migrating from v1 to v2': 'migration.md'
   - 'Changelog v2 (stable)': 'https://github.com/static-web-server/static-web-server/blob/master/CHANGELOG.md'

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -25,6 +25,8 @@ fn main() -> Result {
     }
 
     if let Some(commands) = opts.general.commands {
+        use static_web_server::server_info;
+
         match commands {
             #[cfg(windows)]
             Commands::Install {} => {
@@ -43,13 +45,13 @@ fn main() -> Result {
                     let mut comp_dir = out_dir.clone();
                     comp_dir.push("completions");
                     clap_allgen::render_shell_completions::<General>(&comp_dir)?;
-                    tracing::info!("Wrote completions to {}", comp_dir.to_string_lossy());
+                    server_info!("wrote completions to {}", comp_dir.to_string_lossy());
                 }
                 if man_pages || !completions {
                     let mut man_dir = out_dir.clone();
                     man_dir.push("man");
                     clap_allgen::render_manpages::<General>(&man_dir)?;
-                    tracing::info!("Wrote man pages to {}", man_dir.to_string_lossy());
+                    server_info!("wrote man pages to {}", man_dir.to_string_lossy());
                 }
                 return Ok(());
             }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -12,7 +12,10 @@
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-use static_web_server::{Result, Settings};
+use static_web_server::{
+    settings::{cli::General, Commands},
+    Result, Settings,
+};
 
 fn main() -> Result {
     let opts = Settings::get(true)?;
@@ -21,23 +24,41 @@ fn main() -> Result {
         return static_web_server::settings::cli_output::display_version();
     }
 
-    #[cfg(windows)]
-    {
-        use static_web_server::settings::Commands;
-        use static_web_server::winservice;
-
-        if let Some(commands) = opts.general.commands {
-            match commands {
-                Commands::Install {} => {
-                    return winservice::install_service(&opts.general.config_file);
-                }
-                Commands::Uninstall {} => {
-                    return winservice::uninstall_service();
-                }
+    if let Some(commands) = opts.general.commands {
+        match commands {
+            #[cfg(windows)]
+            Commands::Install {} => {
+                return winservice::install_service(&opts.general.config_file);
             }
-        } else if opts.general.windows_service {
-            return winservice::run_server_as_service();
+            #[cfg(windows)]
+            Commands::Uninstall {} => {
+                return winservice::uninstall_service();
+            }
+            Commands::Generate {
+                completions,
+                man_pages,
+                out_dir,
+            } => {
+                if completions || !man_pages {
+                    let mut comp_dir = out_dir.clone();
+                    comp_dir.push("completions");
+                    clap_allgen::render_shell_completions::<General>(&comp_dir)?;
+                    tracing::info!("Wrote completions to {}", comp_dir.to_string_lossy());
+                }
+                if man_pages || !completions {
+                    let mut man_dir = out_dir.clone();
+                    man_dir.push("man");
+                    clap_allgen::render_manpages::<General>(&man_dir)?;
+                    tracing::info!("Wrote man pages to {}", man_dir.to_string_lossy());
+                }
+                return Ok(());
+            }
         }
+    }
+
+    #[cfg(windows)]
+    if opts.general.windows_service {
+        return winservice::run_server_as_service();
     }
 
     // Run the server by default

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -28,11 +28,11 @@ fn main() -> Result {
         match commands {
             #[cfg(windows)]
             Commands::Install {} => {
-                return winservice::install_service(&opts.general.config_file);
+                return static_web_server::winservice::install_service(&opts.general.config_file);
             }
             #[cfg(windows)]
             Commands::Uninstall {} => {
-                return winservice::uninstall_service();
+                return static_web_server::winservice::uninstall_service();
             }
             Commands::Generate {
                 completions,
@@ -58,7 +58,7 @@ fn main() -> Result {
 
     #[cfg(windows)]
     if opts.general.windows_service {
-        return winservice::run_server_as_service();
+        return static_web_server::winservice::run_server_as_service();
     }
 
     // Run the server by default

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -525,10 +525,9 @@ pub struct General {
     /// Tell the web server to run in a Windows Service context. Note that the `install` subcommand will enable this option automatically.
     pub windows_service: bool,
 
-    // Windows commands
-    #[cfg(windows)]
+    // Subcommands
     #[command(subcommand)]
-    /// Subcommands to install or uninstall the SWS Windows Service.
+    /// Subcommands for additional maintenance tasks, like installing and uninstalling the SWS Windows Service and generation of completions and man pages
     pub commands: Option<Commands>,
 
     #[arg(
@@ -542,17 +541,31 @@ pub struct General {
     pub version: bool,
 }
 
-#[cfg(windows)]
 #[derive(Debug, clap::Subcommand)]
-/// Subcommands to install or uninstall the SWS Windows Service.
+/// Subcommands for additional maintenance tasks, like installing and uninstalling the SWS Windows Service and generation of completions and man pages
 pub enum Commands {
     /// Install a Windows Service for the web server.
+    #[cfg(windows)]
     #[command(name = "install")]
     Install {},
 
     /// Uninstall the current Windows Service.
+    #[cfg(windows)]
     #[command(name = "uninstall")]
     Uninstall {},
+
+    /// Generate man pages and shell completions
+    #[command(name = "generate")]
+    Generate {
+        /// Generate shell completions
+        #[arg(long)]
+        completions: bool,
+        /// Generate man pages
+        #[arg(long)]
+        man_pages: bool,
+        /// Path to write generated artifacts to
+        out_dir: PathBuf,
+    },
 }
 
 fn value_parser_pathbuf(s: &str) -> Result<PathBuf, String> {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -20,7 +20,6 @@ pub mod cli;
 pub mod cli_output;
 pub mod file;
 
-#[cfg(windows)]
 pub use cli::Commands;
 
 use cli::General;
@@ -661,7 +660,6 @@ impl Settings {
                 // Windows-only options and commands
                 #[cfg(windows)]
                 windows_service,
-                #[cfg(windows)]
                 commands: opts.commands,
             },
             advanced: settings_advanced,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a way to generate completions and man pages so that distro packagers can ship them.

Instead of doing it based on an env var, which others are doing in f.ex. https://codeberg.org/openpgp-card/openpgp-card-tools/src/branch/main/src/oct.rs#L34-L56, it would also be possible to add a subcommand or a special command line flag, like other are doing in f.ex. https://github.com/orhun/git-cliff/blob/v2.4.0/git-cliff/src/bin/mangen.rs

## Related Issue
I have not opened an issue about this. The change is fairly trivial though. If I really need to open an issue, I can do that, but I don't really see the purpose of it.

## Motivation and Context
I have written this patch while packaging static-web-server for Chimera Linux, and it was (rightfully) pointed out that this patch should go upstream: https://github.com/chimera-linux/cports/pull/2818#pullrequestreview-2273742092.

## How Has This Been Tested?
A slightly different version of this patch has been tested in the cports PR linked above.

## Screenshots (if appropriate):
### Shell Completions
#### Fish
![image](https://github.com/user-attachments/assets/d27547c9-37fc-4356-89da-58d7d63a9595)
#### Nushell
![image](https://github.com/user-attachments/assets/7c6ce374-2a40-4c2e-9aea-a2fae5d6831f)
### Man page
![image](https://github.com/user-attachments/assets/f95887a9-fe63-4ae0-b789-4241d8d1dac4)

