### PR TITLE
Add in-memory files cache to the Cargo `experimental` feature list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,9 @@ directory-listing = ["chrono", "maud"]
 basic-auth = ["bcrypt"]
 # Fallback Page
 fallback-page = []
-# Experimental features
+# Experimental features (requires: `RUSTFLAGS="--cfg tokio_unstable"`)
 # --experimental-metrics
-experimental = ["tokio-metrics-collector", "prometheus"]
+experimental = ["tokio-metrics-collector", "prometheus", "compact_str", "mini-moka"]
 
 [dependencies]
 aho-corasick = "1.1"
@@ -68,7 +68,7 @@ bytes = "1.7"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_allgen = "0.2.0"
-compact_str = "0.8"
+compact_str = { version = "0.8.0", optional = true }
 form_urlencoded = "1.2"
 futures-util = { version = "0.3", default-features = false }
 globset = { version = "0.4", features = ["serde1"] }
@@ -80,7 +80,7 @@ lazy_static = "1.5"
 listenfd = "1.0"
 maud = { version = "0.26", optional = true }
 mime_guess = "2.0"
-mini-moka = "0.10.3"
+mini-moka = { version = "0.10.3", optional = true }
 percent-encoding = "2.3"
 pin-project = "1.1"
 regex = "1.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,7 @@ pub(crate) mod http_ext;
 pub mod https_redirect;
 pub(crate) mod log_addr;
 pub mod maintenance_mode;
+#[cfg(feature = "experimental")]
 pub(crate) mod mem_cache;
 #[cfg(all(unix, feature = "experimental"))]
 pub(crate) mod metrics;

--- a/src/server.rs
+++ b/src/server.rs
@@ -44,9 +44,11 @@ use crate::{compression, compression_static};
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;
 
+#[cfg(feature = "experimental")]
+use crate::mem_cache;
+
 use crate::{
-    control_headers, cors, health, helpers, log_addr, maintenance_mode, mem_cache,
-    security_headers, Settings,
+    control_headers, cors, health, helpers, log_addr, maintenance_mode, security_headers, Settings,
 };
 use crate::{service::RouterService, Context, Result};
 
@@ -341,6 +343,7 @@ impl Server {
         security_headers::init(general.security_headers, &mut handler_opts);
 
         // In-Memory cache option
+        #[cfg(feature = "experimental")]
         mem_cache::cache::init(&mut handler_opts)?;
 
         // Create a service router for Hyper

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -160,6 +160,7 @@ pub struct VirtualHosts {
     pub root: Option<PathBuf>,
 }
 
+#[cfg(feature = "experimental")]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 /// Represents the in-memory file cache feature.
@@ -186,6 +187,7 @@ pub struct Advanced {
     pub redirects: Option<Vec<Redirects>>,
     /// Name-based virtual hosting
     pub virtual_hosts: Option<Vec<VirtualHosts>>,
+    #[cfg(feature = "experimental")]
     /// In-memory cache feature (experimental).
     pub memory_cache: Option<MemoryCache>,
 }
@@ -379,6 +381,7 @@ pub struct General {
     /// Custom maintenance mode HTML file.
     pub maintenance_mode_file: Option<PathBuf>,
 
+    #[cfg(feature = "experimental")]
     /// In-memory files cache feature.
     pub memory_cache: Option<bool>,
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -24,7 +24,10 @@ pub use cli::Commands;
 
 use cli::General;
 
-use self::file::{MemoryCache, RedirectsKind, Settings as FileSettings};
+#[cfg(feature = "experimental")]
+use self::file::MemoryCache;
+
+use self::file::{RedirectsKind, Settings as FileSettings};
 
 #[cfg(any(
     feature = "compression",
@@ -84,6 +87,7 @@ pub struct Advanced {
     pub redirects: Option<Vec<Redirects>>,
     /// Name-based virtual hosting
     pub virtual_hosts: Option<Vec<VirtualHosts>>,
+    #[cfg(feature = "experimental")]
     /// In-memory cache feature (experimental).
     pub memory_cache: Option<MemoryCache>,
 }
@@ -570,6 +574,7 @@ impl Settings {
                     rewrites: rewrites_entries,
                     redirects: redirects_entries,
                     virtual_hosts: vhosts_entries,
+                    #[cfg(feature = "experimental")]
                     memory_cache: advanced.memory_cache,
                 });
             }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -104,6 +104,7 @@ pub mod fixtures {
             maintenance_mode: general.maintenance_mode,
             maintenance_mode_status: general.maintenance_mode_status,
             maintenance_mode_file: general.maintenance_mode_file,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             advanced_opts: advanced,
         };

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -44,6 +44,7 @@ mod tests {
             base_path: &public_dir(),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -115,6 +116,7 @@ mod tests {
             base_path: &public_dir(),
             uri_path: "404.html",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -183,6 +185,7 @@ mod tests {
             base_path: &public_dir().join("assets/"),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -249,6 +252,7 @@ mod tests {
             base_path: &base_path,
             uri_path: "/",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             dir_listing: true,
             dir_listing_order: 6,
@@ -282,6 +286,7 @@ mod tests {
             base_path: &public_dir(),
             uri_path: "main.js",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -43,6 +43,7 @@ mod tests {
                 base_path: &root_dir("docker/public/"),
                 uri_path: "/assets",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -77,6 +78,7 @@ mod tests {
                 base_path: &root_dir("docs/"),
                 uri_path: "/content/",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -121,6 +123,7 @@ mod tests {
                 base_path: &root_dir("docs/"),
                 uri_path: "/content",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -165,6 +168,7 @@ mod tests {
                 base_path: &root_dir("docs/"),
                 uri_path: "/README.md",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -199,6 +203,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public/"),
                 uri_path: "/",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -254,6 +259,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public/"),
                 uri_path: "/",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -327,6 +333,7 @@ mod tests {
                 base_path: &root_dir(&empty_dir),
                 uri_path: "/",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -373,6 +380,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public"),
                 uri_path: "/",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -47,6 +47,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -92,6 +93,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "index.html",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -138,6 +140,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "xyz.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -171,6 +174,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -206,6 +210,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -240,6 +245,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
+            #[cfg(feature = "experimental")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -279,6 +285,7 @@ mod tests {
                     base_path: &root_dir(),
                     uri_path: uri,
                     uri_query: None,
+                    #[cfg(feature = "experimental")]
                     memory_cache: None,
                     #[cfg(feature = "directory-listing")]
                     dir_listing: false,
@@ -333,6 +340,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "/index%2ehtml",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -369,6 +377,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "/%2E%2e.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -407,6 +416,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -446,6 +456,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -488,6 +499,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -528,6 +540,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -566,6 +579,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -603,6 +617,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -644,6 +659,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -728,6 +744,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -800,6 +817,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -851,6 +869,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -902,6 +921,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -954,6 +974,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -998,6 +1019,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1052,6 +1074,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1103,6 +1126,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1154,6 +1178,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1208,6 +1233,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1252,6 +1278,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1295,6 +1322,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1353,6 +1381,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.html",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1403,6 +1432,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: ".dotfile",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1444,6 +1474,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: "/",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1487,6 +1518,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: "/symlink",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1520,6 +1552,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: "/symlink/spécial file.txt~",
                 uri_query: None,
+                #[cfg(feature = "experimental")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR complements what is done in #328 by adding the _in-memory files cache_ to the Cargo `experimental` feature.

**Note:** when using SWS as a library the `experimental` Cargo feature will require `RUSTFLAGS="--cfg tokio_unstable"` to be passed due to the SWS `experimental-metrics` feature. 

Also, be aware that **this experimental feature could be subject to change in future releases**.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
