### PR TITLE
Improve X-Forwarded-For handling

### DIFF
--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -85,6 +85,10 @@ Options:
           Server TOML configuration file path [env: SERVER_CONFIG_FILE=] [default: ./config.toml]
       --log-remote-address [<LOG_REMOTE_ADDRESS>]
           Log incoming requests information along with its remote address if available using the `info` log level [env: SERVER_LOG_REMOTE_ADDRESS=] [default: false] [possible values: true, false]
+      --log-forwarded-for [<LOG_FORWARDED_FOR>]
+          Log real IP from X-Forwarded-For header [env: SERVER_LOG_FORWARDED_FOR] [default: false] [possible values: true, false]
+      --trusted-proxies <TRUSTED_PROXIES>
+          A comma separated list of IP addresses to accept the X-Forwarded-For header from. Empty means trust all IPs [env: SERVER_TRUSTED_PROXIES] [default: ""]
       --redirect-trailing-slash [<REDIRECT_TRAILING_SLASH>]
           Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path with a trailing slash suffix if it is missing [env: SERVER_REDIRECT_TRAILING_SLASH=] [default: true] [possible values: true, false]
       --ignore-hidden-files [<IGNORE_HIDDEN_FILES>]

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -75,6 +75,12 @@ grace-period = 0
 #### Log request Remote Address if available
 log-remote-address = false
 
+#### Log real IP from X-Forwarded-For header if available
+log-forwarded-for = false
+
+#### IPs to accept the X-Forwarded-For header from. Empty means all
+trusted-proxies = []
+
 #### Redirect to trailing slash in the requested directory uri
 redirect-trailing-slash = true
 

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -30,6 +30,12 @@ Specify a logging level in lowercase. Possible values are `error`, `warn`, `info
 ### SERVER_LOG_REMOTE_ADDRESS
 Log incoming request information along with its Remote Address (IP) if available using the `info` log level. Default `false`.
 
+### SERVER_LOG_FORWARDED_FOR
+Log real IP from X-Forwarded-For header if available using the `info` log level. Default `false`
+
+### SERVER_TRUSTED_PROXIES
+A comma separated list of IP addresses to accept the X-Forwarded-For header from. An empty string means trust all IPs. Default `""`
+
 ### SERVER_ERROR_PAGE_404
 HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message.
 If a relative path is used then it will be resolved under the root directory. Default `./404.html`.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -7,7 +7,12 @@
 //!
 
 use hyper::{Body, Request, Response, StatusCode};
-use std::{future::Future, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    future::Future,
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+    sync::Arc,
+};
 
 #[cfg(any(
     feature = "compression",
@@ -97,6 +102,10 @@ pub struct RequestHandlerOpts {
     pub index_files: Vec<String>,
     /// Log remote address feature.
     pub log_remote_address: bool,
+    /// Log the X-Forwarded-For header.
+    pub log_forwarded_for: bool,
+    /// Trusted IPs for remote addresses.
+    pub trusted_proxies: Vec<IpAddr>,
     /// Redirect trailing slash feature.
     pub redirect_trailing_slash: bool,
     /// Ignore hidden files feature.
@@ -152,6 +161,8 @@ impl Default for RequestHandlerOpts {
             basic_auth: String::new(),
             index_files: vec!["index.html".into()],
             log_remote_address: false,
+            log_forwarded_for: false,
+            trusted_proxies: Vec::new(),
             redirect_trailing_slash: true,
             ignore_hidden_files: false,
             disable_symlinks: false,

--- a/src/server.rs
+++ b/src/server.rs
@@ -225,6 +225,12 @@ impl Server {
         // Log remote address option
         let log_remote_address = general.log_remote_address;
 
+        // Log the X-Forwarded-For header.
+        let log_forwarded_for = general.log_forwarded_for;
+
+        // Trusted IPs for remote addresses.
+        let trusted_proxies = general.trusted_proxies;
+
         // Log redirect trailing slash option
         let redirect_trailing_slash = general.redirect_trailing_slash;
         server_info!(
@@ -261,6 +267,8 @@ impl Server {
             page404: page404.clone(),
             page50x: page50x.clone(),
             log_remote_address,
+            log_forwarded_for,
+            trusted_proxies,
             redirect_trailing_slash,
             ignore_hidden_files,
             disable_symlinks,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -7,7 +7,7 @@
 
 use clap::Parser;
 use hyper::StatusCode;
-use std::path::PathBuf;
+use std::{net::IpAddr, path::PathBuf};
 
 #[cfg(feature = "directory-listing")]
 use crate::directory_listing::DirListFmt;
@@ -413,6 +413,28 @@ pub struct General {
     )]
     /// Log incoming requests information along with its remote address if available using the `info` log level.
     pub log_remote_address: bool,
+
+    #[arg(
+        long,
+        default_value = "false",
+        default_missing_value("true"),
+        num_args(0..=1),
+        require_equals(false),
+        action = clap::ArgAction::Set,
+        env = "SERVER_LOG_FORWARDED_FOR",
+    )]
+    /// Log the X-Forwarded-For header for remote IP information
+    pub log_forwarded_for: bool,
+
+    #[arg(
+        long,
+        require_equals(false),
+        value_delimiter(','),
+        action = clap::ArgAction::Set,
+        env = "SERVER_TRUSTED_PROXIES",
+    )]
+    /// List of IPs to use X-Forwarded-For from. The default is to trust all
+    pub trusted_proxies: Vec<IpAddr>,
 
     #[arg(
         long,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -8,6 +8,7 @@
 use headers::HeaderMap;
 use serde::Deserialize;
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::net::IpAddr;
 use std::path::Path;
 use std::{collections::BTreeSet, path::PathBuf};
 
@@ -355,6 +356,12 @@ pub struct General {
 
     /// Log remote address feature.
     pub log_remote_address: Option<bool>,
+
+    /// Log the X-Forwarded-For header.
+    pub log_forwarded_for: Option<bool>,
+
+    /// Trusted IPs for remote addresses.
+    pub trusted_proxies: Option<Vec<IpAddr>>,
 
     /// Redirect trailing slash feature.
     pub redirect_trailing_slash: Option<bool>,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -197,6 +197,8 @@ impl Settings {
         let mut page_fallback = opts.page_fallback;
 
         let mut log_remote_address = opts.log_remote_address;
+        let mut log_forwarded_for = opts.log_forwarded_for;
+        let mut trusted_proxies = opts.trusted_proxies;
         let mut redirect_trailing_slash = opts.redirect_trailing_slash;
         let mut ignore_hidden_files = opts.ignore_hidden_files;
         let mut disable_symlinks = opts.disable_symlinks;
@@ -362,6 +364,12 @@ impl Settings {
                 }
                 if let Some(v) = general.log_remote_address {
                     log_remote_address = v
+                }
+                if let Some(v) = general.log_forwarded_for {
+                    log_forwarded_for = v
+                }
+                if let Some(v) = general.trusted_proxies {
+                    trusted_proxies = v
                 }
                 if let Some(v) = general.redirect_trailing_slash {
                     redirect_trailing_slash = v
@@ -651,6 +659,8 @@ impl Settings {
                 #[cfg(feature = "fallback-page")]
                 page_fallback,
                 log_remote_address,
+                log_forwarded_for,
+                trusted_proxies,
                 redirect_trailing_slash,
                 ignore_hidden_files,
                 disable_symlinks,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -94,6 +94,8 @@ pub mod fixtures {
             #[cfg(feature = "basic-auth")]
             basic_auth: general.basic_auth,
             log_remote_address: general.log_remote_address,
+            log_forwarded_for: general.log_forwarded_for,
+            trusted_proxies: general.trusted_proxies,
             redirect_trailing_slash: general.redirect_trailing_slash,
             ignore_hidden_files: general.ignore_hidden_files,
             disable_symlinks: general.disable_symlinks,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes but try to be as concise as possible -->
Adds two new options to configure logging of X-Forwarded-IP addresses.
 - `log-forward-for`: is a boolean to enable logging of the header in the first place. Logging is done in the same manner as log-remote-address, meaning it will only show with log-level info or higher  
 - `trusted-proxies`: is an optional list of IP addresses from which to accept the x-forwarded-for header. If unspecified or an empty string, all IP addresses are allowed
Both of the options are optional and log-forward-for defaults to false. This means that existing uses of log_remote_address will silently stop logging from the x-forwarded-for header.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #494 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #494 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
I have tested all combinations of `log-remote-addr`, `log-forwarded-for` and `trusted-proxies` with both CLI options and a config file. I confirmed that they output the expected logs.
## Screenshots (if appropriate):
Some config snippets and what they output. The requests are all sent from `::1` with `X-Forwarded-For: 1.1.1.1`
 
### Example 1:
```toml
log-remote-address = true
log-forwarded-for = false
```

```
INFO static_web_server::info: log requests with remote IP addresses: enabled=true
INFO static_web_server::info: log X-Forwarded-For real remote IP addresses: enabled=false
INFO static_web_server::info: trusted IPs for X-Forwarded-For: all
INFO static_web_server::log_addr: incoming request: method=GET uri=/ remote_addr=[::1]:56232
```

### Example 2 (this would reflect the old behavior):
```toml
log-remote-address = true
log-forwarded-for = true
```

```
INFO static_web_server::info: log requests with remote IP addresses: enabled=true
INFO static_web_server::info: log X-Forwarded-For real remote IP addresses: enabled=true
INFO static_web_server::info: trusted IPs for X-Forwarded-For: all
INFO static_web_server::log_addr: incoming request: method=GET uri=/ remote_addr=[::1]:48046 real_remote_ip=1.1.1.1
```

### Example 3:
```toml
log-remote-address = false
log-forwarded-for = true
trusted-proxies = ["::1"]
```

```
INFO static_web_server::info: log requests with remote IP addresses: enabled=false
INFO static_web_server::info: log X-Forwarded-For real remote IP addresses: enabled=true
INFO static_web_server::info: trusted IPs for X-Forwarded-For: [::1]
INFO static_web_server::log_addr: incoming request: method=GET uri=/ real_remote_ip=1.1.1.1
```

### Example 4:
```toml
log-remote-address = true
log-forwarded-for = true
trusted-proxies = ["1.1.1.1", "127.0.0.1"]
```

```
INFO static_web_server::info: log requests with remote IP addresses: enabled=true
INFO static_web_server::info: log X-Forwarded-For real remote IP addresses: enabled=true
INFO static_web_server::info: trusted IPs for X-Forwarded-For: [1.1.1.1, 127.0.0.1]
INFO static_web_server::log_addr: incoming request: method=GET uri=/ remote_addr=[::1]:57270
```