### PR TITLE
Prevent single wildcards from matching path separators for URL Redirects

### DIFF
--- a/docs/content/features/url-redirects.md
+++ b/docs/content/features/url-redirects.md
@@ -34,6 +34,12 @@ The glob pattern functionality is powered by the [globset](https://docs.rs/globs
 !!! tip "Glob pattern syntax"
     For more details about the Glob pattern syntax check out https://docs.rs/globset/latest/globset/#syntax
 
+!!! warning "Matching of path separator in `*`"
+    Up to version 2.33.1 the wildcard `*` was matching the path separator.
+    For example, `/{*}/{*}/` matched `/assets/images/logo/`.
+
+    In later versions, the default has changed such that `*` does not match the path separator.
+
 ### Destination
 
 The value can be either a local file path that maps to an existing file on the system or an external URL.
@@ -104,7 +110,7 @@ Then the server logs should look something like this:
 ```log
 2023-07-11T21:11:22.217358Z  INFO static_web_server::handler: incoming request: method=HEAD uri=/abcdef.jpeg
 2023-07-11T21:11:22.217974Z DEBUG static_web_server::handler: url redirects glob pattern: ["$0", "$1", "$2"]
-2023-07-11T21:11:22.217992Z DEBUG static_web_server::handler: url redirects regex equivalent: (?-u:\b)(?:/?|.*/)(.*)\.(jpeg|jpg)$
+2023-07-11T21:11:22.217992Z DEBUG static_web_server::handler: url redirects regex equivalent: (?-u)^(?:/?|.*/)(?:[^/]*)\.(?:svg|jpeg|jpg)$
 2023-07-11T21:11:22.218002Z DEBUG static_web_server::handler: url redirects glob pattern captures: ["abcdef.jpeg", "abcdef", "jpeg"]
 2023-07-11T21:11:22.218076Z DEBUG static_web_server::handler: url redirects glob pattern destination: "http://localhost/assets/$1.$2"
 2023-07-11T21:11:22.218712Z DEBUG static_web_server::handler: url redirects glob pattern destination replaced: "http://localhost/assets/abcdef.jpeg"

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -7,7 +7,7 @@
 //!
 
 use clap::Parser;
-use globset::{Glob, GlobMatcher};
+use globset::{Glob, GlobBuilder, GlobMatcher};
 use headers::HeaderMap;
 use hyper::StatusCode;
 use regex::Regex;
@@ -506,7 +506,9 @@ impl Settings {
 
                         // Compile a glob pattern for each redirect sources entry
                         for redirects_entry in redirects_entries.iter() {
-                            let source = Glob::new(&redirects_entry.source)
+                            let source = GlobBuilder::new(&redirects_entry.source)
+                                .literal_separator(true)
+                                .build()
                                 .with_context(|| {
                                     format!(
                                         "can not compile glob pattern for redirect source: {}",

--- a/tests/fixtures/toml/redirects.toml
+++ b/tests/fixtures/toml/redirects.toml
@@ -52,3 +52,9 @@ kind = 302
 source = "**/{*}.{*}"
 destination = "http://localhost/new-generic/$2.$3"
 kind = 301
+
+# Glob groups generic 2
+[[advanced.redirects]]
+source = "/{*}/{*}/"
+destination = "http://localhost/archive/$1/$2/"
+kind = 301

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -151,14 +151,14 @@ pub mod tests {
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/images/avatar.jpeg".parse().unwrap();
+        *req.uri_mut() = "http://localhost/old/images/avatar.jpeg".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
                 assert_eq!(
                     res.headers()["location"],
-                    "http://localhost/new-images/images/avatar.jpeg"
+                    "http://localhost/new-images/avatar.jpeg"
                 );
             }
             Err(err) => {
@@ -174,14 +174,14 @@ pub mod tests {
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/fonts/title.ttf".parse().unwrap();
+        *req.uri_mut() = "http://localhost/old/fonts/title.ttf".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
                 assert_eq!(
                     res.headers()["location"],
-                    "http://localhost/new-fonts/fonts/title.woff"
+                    "http://localhost/new-fonts/title.woff"
                 );
             }
             Err(err) => {

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -212,4 +212,46 @@ pub mod tests {
             }
         };
     }
+
+    #[tokio::test]
+    async fn redirects_glob_groups_generic_2() {
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/2024/11/".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 301);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost/archive/2024/11/"
+                );
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
+
+    #[tokio::test]
+    async fn redirects_glob_groups_generic_2_literal_separator() {
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.uri_mut() = "http://localhost/archive/2024/11/".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 404);
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description

`globset` by default has `literal_separator(false)` leading to `*` matching the path separator.
This PR ensures that `*` does not match the path separator in redirects.

See: https://docs.rs/globset/0.4.15/globset/#syntax

## Related Issue

See the documentation here: https://github.com/orgs/static-web-server/discussions/498

## Motivation and Context

As per the discussion, the default of not matching the path separator is in line with how it works on Unix.

See also: https://en.wikipedia.org/wiki/Glob_(programming) and https://man7.org/linux/man-pages/man7/glob.7.html#:~:text=A%20'/'%20in%20a%20pathname%20cannot%20be%20matched

## How Has This Been Tested?

Via test cases and manually.

## Screenshots (if appropriate):

<img width="710" alt="image" src="https://github.com/user-attachments/assets/cfb3cde4-855b-4b42-9819-09646782c7e8">

