### PR TITLE
Prevent single wildcards from matching path separators for URL Rewrites

### DIFF
--- a/docs/content/features/url-redirects.md
+++ b/docs/content/features/url-redirects.md
@@ -35,7 +35,7 @@ The glob pattern functionality is powered by the [globset](https://docs.rs/globs
     For more details about the Glob pattern syntax check out https://docs.rs/globset/latest/globset/#syntax
 
 !!! warning "Matching of path separator in `*`"
-    Up to version 2.33.1 the wildcard `*` was matching the path separator.
+    Up to version `2.33.1` the wildcard `*` was matching the path separator.
     For example, `/{*}/{*}/` matched `/assets/images/logo/`.
 
     In later versions, the default has changed such that `*` does not match the path separator.

--- a/docs/content/features/url-rewrites.md
+++ b/docs/content/features/url-rewrites.md
@@ -26,6 +26,12 @@ The glob pattern functionality is powered by the [globset](https://docs.rs/globs
 !!! tip "Glob pattern syntax"
     For more details about the Glob pattern syntax check out https://docs.rs/globset/latest/globset/#syntax
 
+!!! warning "Matching of path separator in `*`"
+    Up to version `2.33.1` the wildcard `*` was matching the path separator.
+    For example, `/{*}/{*}/` matched `/assets/images/logo/`.
+
+    In later versions, the default has changed such that `*` does not match the path separator.
+
 ### Destination
 
 The value should be a relative or absolute URL. A relative URL could look like `/some/directory/file.html`. An absolute URL can be `https://external.example.com/` for example.
@@ -119,7 +125,7 @@ Then the server logs should look something like this:
 ```log
 2023-07-08T20:31:36.606035Z  INFO static_web_server::handler: incoming request: method=HEAD uri=/abcdef.png
 2023-07-08T20:31:36.608439Z DEBUG static_web_server::handler: url rewrites glob patterns: ["$0", "$1", "$2"]
-2023-07-08T20:31:36.608491Z DEBUG static_web_server::handler: url rewrites regex equivalent: (?-u:\b)(?:/?|.*/)(.*)\.(gif|png)$
+2023-07-08T20:31:36.608491Z DEBUG static_web_server::handler: url rewrites regex equivalent: (?-u)^(?:/?|.*/)(?:[^/]*)\.(?:jpeg|jpg)$
 2023-07-08T20:31:36.608525Z DEBUG static_web_server::handler: url rewrites glob pattern captures: ["abcdef.png", "abcdef", "png"]
 2023-07-08T20:31:36.608561Z DEBUG static_web_server::handler: url rewrites glob pattern destination: "/assets/$1.$2"
 2023-07-08T20:31:36.609655Z DEBUG static_web_server::handler: url rewrites glob patterns destination replaced: "/assets/abcdef.png"

--- a/docs/content/features/url-rewrites.md
+++ b/docs/content/features/url-rewrites.md
@@ -125,7 +125,7 @@ Then the server logs should look something like this:
 ```log
 2023-07-08T20:31:36.606035Z  INFO static_web_server::handler: incoming request: method=HEAD uri=/abcdef.png
 2023-07-08T20:31:36.608439Z DEBUG static_web_server::handler: url rewrites glob patterns: ["$0", "$1", "$2"]
-2023-07-08T20:31:36.608491Z DEBUG static_web_server::handler: url rewrites regex equivalent: (?-u)^(?:/?|.*/)(?:[^/]*)\.(?:jpeg|jpg)$
+2023-07-08T20:31:36.608491Z DEBUG static_web_server::handler: url rewrites regex equivalent: (?-u)^(?:/?|.*/)(?:[^/]*)\.(?:gif|png)$
 2023-07-08T20:31:36.608525Z DEBUG static_web_server::handler: url rewrites glob pattern captures: ["abcdef.png", "abcdef", "png"]
 2023-07-08T20:31:36.608561Z DEBUG static_web_server::handler: url rewrites glob pattern destination: "/assets/$1.$2"
 2023-07-08T20:31:36.609655Z DEBUG static_web_server::handler: url rewrites glob patterns destination replaced: "/assets/abcdef.png"

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -458,7 +458,9 @@ impl Settings {
 
                         // Compile a glob pattern for each rewrite sources entry
                         for rewrites_entry in rewrites_entries.iter() {
-                            let source = Glob::new(&rewrites_entry.source)
+                            let source = GlobBuilder::new(&rewrites_entry.source)
+                                .literal_separator(true)
+                                .build()
                                 .with_context(|| {
                                     format!(
                                         "can not compile glob pattern for rewrite source: {}",

--- a/tests/rewrites.rs
+++ b/tests/rewrites.rs
@@ -163,14 +163,14 @@ pub mod tests {
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
-        *req.uri_mut() = "http://localhost/fonts/text.ttf".parse().unwrap();
+        *req.uri_mut() = "http://localhost/old/fonts/text.ttf".parse().unwrap();
 
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
                 assert_eq!(
                     res.headers()["location"],
-                    "http://localhost/new-fonts/fonts/text.woff"
+                    "http://localhost/new-fonts/text.woff"
                 );
             }
             Err(err) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description

Following the change for URL redirects in #501 make it consistent for URL Redirects as well.

## Related Issue

#501 

## Motivation and Context

A single `*` wildcard should not match the path separator.

## How Has This Been Tested?

`cargo test`

## Screenshots (if appropriate):
