### PR TITLE
ci: build and push devel image on master

### DIFF
--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -11,15 +11,15 @@ on:
       - Cargo.lock
       - Cargo.toml
       - src/**
+
+env:
+  TARGET_DIR: ./target
+
 jobs:
   build-release:
     runs-on: ubuntu-22.04
     env:
       CARGO_BIN: cargo
-      # When CARGO_BIN is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS: ""
-      # When CARGO_BIN is set to CROSS, TARGET_DIR includes matrix.target.
-      TARGET_DIR: ./target
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
       # SWS features for Cargo build
@@ -42,16 +42,27 @@ jobs:
           echo "target flag is: ${{ env.TARGET_FLAGS }}"
           echo "target dir is: ${{ env.TARGET_DIR }}"
       - name: Build release binary
-        run: ${{ env.CARGO_BIN }} build --bin static-web-server -vv --release ${{ env.CARGO_FEATURES }} ${{ env.TARGET_FLAGS }}
-      - name: Test
-        run: ls -la .
+        run: |
+          ${{ env.CARGO_BIN }} build --bin static-web-server -vv --release ${{ env.CARGO_FEATURES }}
+      - name: Cache binary
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TARGET_DIR }}
+          # short-lived cache: https://github.com/actions/cache/blob/main/caching-strategies.md#creating-a-short-lived-cache
+          key: cache-${{ github.sha }}
+
 
   docker-image-debian:
     needs: ['build-release']
     runs-on: ubuntu-22.04
     steps:
+      - name: Restore cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.TARGET_DIR }}
+          key: cache-${{ github.sha }}
       - name: Test
-        run: ls -la .
+        run: ls -la . && ls -la ./target
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -79,10 +90,6 @@ jobs:
       #  with:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Prepare Docker envs
-        shell: bash
-        run: |
-          echo "SERVER_VERSION=devel" >> $GITHUB_ENV
       - name: Build and push (debian)
         uses: docker/build-push-action@v4
         with:
@@ -91,13 +98,18 @@ jobs:
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.debian
           tags: devel
-          build-args: |
-            SERVER_VERSION=${{ env.SERVER_VERSION }}
 
   docker-image-scratch:
     needs: ['docker-image-debian']
     runs-on: ubuntu-22.04
     steps:
+      - name: Restore cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.TARGET_DIR }}
+          key: cache-${{ github.sha }}
+      - name: Test
+        run: ls -la . && ls -la ./target
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -122,10 +134,6 @@ jobs:
       #  with:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Prepare Docker envs
-        shell: bash
-        run: |
-          echo "SERVER_VERSION=devel" >> $GITHUB_ENV
       - name: Build and push (scratch)
         uses: docker/build-push-action@v4
         with:
@@ -134,5 +142,3 @@ jobs:
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.scratch
           tags: devel
-          build-args: |
-            SERVER_VERSION=devel

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -52,8 +52,10 @@ jobs:
 
 
   docker-image-debian:
-    # needs: ['build-release']
-    needs: ['docker-image-scratch']
+    needs: ['build-release']
+    permissions: 
+      contents: read
+      packages: write
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -69,29 +71,13 @@ jobs:
         run: ls -la . && ls -la ./target/release
       - name: Move binary
         run: mv ${{ env.TARGET_DIR }}/release/static-web-server ./docker/devel/
-      - name: Docker meta debian
-        id: meta_debian
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            # joseluisq/static-web-server
-            ghcr.io/static-web-server/static-web-server
-          flavor: |
-            latest=false
-            suffix=-debian
-          tags: |
-            type=edge,branch=master
+
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      #- name: Login to DockerHub
-      #  uses: docker/login-action@v3
-      #  with:
-      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #    password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push (debian)
         uses: docker/build-push-action@v6
         with:
@@ -99,11 +85,10 @@ jobs:
           context: .
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.debian
-          tags: devel
+          tags: ghcr.io/static-web-server/static-web-server:devel-debian
 
   docker-image-scratch:
-    # needs: ['docker-image-debian']
-    needs: ['build-release']
+    needs: ['docker-image-debian']
     permissions: 
       contents: read
       packages: write
@@ -120,27 +105,12 @@ jobs:
           key: cache-${{ github.sha }}
       - name: Move binary
         run: mv ${{ env.TARGET_DIR }}/release/static-web-server ./docker/devel/
-      - name: Docker meta scratch
-        id: meta_scratch
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            # joseluisq/static-web-server
-            ghcr.io/static-web-server/static-web-server
-          tags: |
-            type=edge,branch=$repo.default_branch
-            type=ref,event=pr
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      #- name: Login to DockerHub
-      #  uses: docker/login-action@v3
-      #  with:
-      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #    password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push (scratch)
         uses: docker/build-push-action@v6
         with:
@@ -148,5 +118,4 @@ jobs:
           context: .
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.scratch
-          # tags: devel
-          tags: ${{ steps.meta_scratch.outputs.tags }}
+          tags: ghcr.io/static-web-server/static-web-server:devel

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -50,6 +50,8 @@ jobs:
     needs: ['build-release']
     runs-on: ubuntu-22.04
     steps:
+      - name: Test
+        run: ls -la .
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -88,7 +90,7 @@ jobs:
           context: .
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.debian
-          tags: ${{ steps.meta_debian.outputs.tags }}
+          tags: devel
           build-args: |
             SERVER_VERSION=${{ env.SERVER_VERSION }}
 
@@ -131,6 +133,6 @@ jobs:
           context: .
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.scratch
-          tags: ${{ steps.meta_scratch.outputs.tags }}
+          tags: devel
           build-args: |
             SERVER_VERSION=devel

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -26,7 +26,7 @@ jobs:
       CARGO_FEATURES: "--features=all"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Install Linux/BSD tools
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Restore cache
@@ -70,7 +70,7 @@ jobs:
         run: mv ${{ env.TARGET_DIR }}/release/static-web-server ./docker/devel/
       - name: Docker meta debian
         id: meta_debian
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             joseluisq/static-web-server
@@ -81,18 +81,18 @@ jobs:
           tags: |
             type=edge,branch=master
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       #- name: Login to DockerHub
-      #  uses: docker/login-action@v2
+      #  uses: docker/login-action@v3
       #  with:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push (debian)
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: .
@@ -101,11 +101,12 @@ jobs:
           tags: devel
 
   docker-image-scratch:
-    needs: ['docker-image-debian']
+    # needs: ['docker-image-debian']
+    needs: ['build-release']
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Restore cache
@@ -117,7 +118,7 @@ jobs:
         run: mv ${{ env.TARGET_DIR }}/release/static-web-server ./docker/devel/
       - name: Docker meta scratch
         id: meta_scratch
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             joseluisq/static-web-server
@@ -125,18 +126,18 @@ jobs:
           tags: |
             type=edge,branch=master
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       #- name: Login to DockerHub
-      #  uses: docker/login-action@v2
+      #  uses: docker/login-action@v3
       #  with:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push (scratch)
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
           context: .

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -104,6 +104,9 @@ jobs:
   docker-image-scratch:
     # needs: ['docker-image-debian']
     needs: ['build-release']
+    permissions: 
+      contents: read
+      packages: write
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -1,8 +1,16 @@
-name: release-docker
-on:
-  push:
-    branches: [master]
+name: release-docker-devel
 
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    paths:
+      - release.docker.devel.yml
+      - .cargo/config.toml
+      - Cargo.lock
+      - Cargo.toml
+      - src/**
 jobs:
   docker-image-alpine:
     runs-on: ubuntu-22.04
@@ -57,7 +65,7 @@ jobs:
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64
           file: ./docker/alpine/Dockerfile
           tags: ${{ steps.meta_alpine.outputs.tags }}
           build-args: |

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -136,6 +136,10 @@ jobs:
       #  with:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Test
+        run: |
+          echo ${{ steps.meta_scratch.outputs.tags }}
+          echo ${{ steps.meta_scratch.outputs.images }}
       - name: Build and push (scratch)
         uses: docker/build-push-action@v6
         with:
@@ -144,3 +148,4 @@ jobs:
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.scratch
           tags: devel
+          # tags: ${{ steps.meta_alpine.outputs.images }}

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -67,8 +67,6 @@ jobs:
         with:
           path: ${{ env.TARGET_DIR }}/release
           key: cache-${{ github.sha }}
-      - name: Test
-        run: ls -la . && ls -la ./target/release
       - name: Move binary
         run: mv ${{ env.TARGET_DIR }}/release/static-web-server ./docker/devel/
 

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Show command used for Cargo
         run: |
           echo "cargo command is: ${{ env.CARGO_BIN }}"
-          echo "target flag is: ${{ env.TARGET_FLAGS }}"
           echo "target dir is: ${{ env.TARGET_DIR }}"
       - name: Build release binary
         run: |
@@ -47,7 +46,7 @@ jobs:
       - name: Cache binary
         uses: actions/cache@v4
         with:
-          path: ${{ env.TARGET_DIR }}
+          path: ${{ env.TARGET_DIR }}/release
           # short-lived cache: https://github.com/actions/cache/blob/main/caching-strategies.md#creating-a-short-lived-cache
           key: cache-${{ github.sha }}
 
@@ -59,10 +58,10 @@ jobs:
       - name: Restore cache
         uses: actions/cache/restore@v4
         with:
-          path: ${{ env.TARGET_DIR }}
+          path: ${{ env.TARGET_DIR }}/release
           key: cache-${{ github.sha }}
       - name: Test
-        run: ls -la . && ls -la ./target
+        run: ls -la . && ls -la ./target/release
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -106,10 +105,8 @@ jobs:
       - name: Restore cache
         uses: actions/cache/restore@v4
         with:
-          path: ${{ env.TARGET_DIR }}
+          path: ${{ env.TARGET_DIR }}/release
           key: cache-${{ github.sha }}
-      - name: Test
-        run: ls -la . && ls -la ./target
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -121,10 +121,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            joseluisq/static-web-server
+            # joseluisq/static-web-server
             ghcr.io/static-web-server/static-web-server
           tags: |
-            type=edge,branch=master
+            # type=edge,branch=$repo.default_branch
+            type=ref,event=branch
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:
@@ -136,10 +137,6 @@ jobs:
       #  with:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Test
-        run: |
-          echo ${{ steps.meta_scratch.outputs.tags }}
-          echo ${{ steps.meta_scratch.outputs.images }}
       - name: Build and push (scratch)
         uses: docker/build-push-action@v6
         with:
@@ -147,5 +144,5 @@ jobs:
           context: .
           platforms: linux/amd64
           file: ./docker/devel/Dockerfile.scratch
-          tags: devel
-          # tags: ${{ steps.meta_alpine.outputs.images }}
+          # tags: devel
+          tags: ${{ steps.meta_scratch.outputs.tags }}

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -73,7 +73,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            joseluisq/static-web-server
+            # joseluisq/static-web-server
             ghcr.io/static-web-server/static-web-server
           flavor: |
             latest=false

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -12,6 +12,37 @@ on:
       - Cargo.toml
       - src/**
 jobs:
+  build-release:
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_BIN: cargo
+      # When CARGO_BIN is set to CROSS, this is set to `--target matrix.target`.
+      TARGET_FLAGS: ""
+      # When CARGO_BIN is set to CROSS, TARGET_DIR includes matrix.target.
+      TARGET_DIR: ./target
+      # Emit backtraces on panics.
+      RUST_BACKTRACE: 1
+      # SWS features for Cargo build
+      CARGO_FEATURES: "--features=all"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Install Linux/BSD tools
+        run: scripts/ci/install_tools.sh --target=x86_64-unknown-linux-gnu
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+      - name: Show command used for Cargo
+        run: |
+          echo "cargo command is: ${{ env.CARGO_BIN }}"
+          echo "target flag is: ${{ env.TARGET_FLAGS }}"
+          echo "target dir is: ${{ env.TARGET_DIR }}"
+      - name: Build release binary
+        run: ${{ env.CARGO_BIN }} build --bin static-web-server -vv --release ${{ env.CARGO_FEATURES }} ${{ env.TARGET_FLAGS }}
   docker-image-alpine:
     runs-on: ubuntu-22.04
     steps:
@@ -35,9 +66,7 @@ jobs:
             latest=false
             suffix=-alpine
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            devel
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -72,11 +72,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      #- name: Login to DockerHub
+      #  uses: docker/login-action@v2
+      #  with:
+      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #    password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Prepare Docker envs
         shell: bash
         run: |
@@ -115,11 +115,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      #- name: Login to DockerHub
+      #  uses: docker/login-action@v2
+      #  with:
+      #    username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #    password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Prepare Docker envs
         shell: bash
         run: |

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -55,6 +55,10 @@ jobs:
     needs: ['build-release']
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
       - name: Restore cache
         uses: actions/cache/restore@v4
         with:
@@ -62,10 +66,8 @@ jobs:
           key: cache-${{ github.sha }}
       - name: Test
         run: ls -la . && ls -la ./target/release
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
+      - name: Move binary
+        run: mv ${{ env.TARGET_DIR }}/release/static-web-server ./docker/devel/
       - name: Docker meta debian
         id: meta_debian
         uses: docker/metadata-action@v4
@@ -102,15 +104,17 @@ jobs:
     needs: ['docker-image-debian']
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
       - name: Restore cache
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.TARGET_DIR }}/release
           key: cache-${{ github.sha }}
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
+      - name: Move binary
+        run: mv ${{ env.TARGET_DIR }}/release/static-web-server ./docker/devel/
       - name: Docker meta scratch
         id: meta_scratch
         uses: docker/metadata-action@v4

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -52,7 +52,8 @@ jobs:
 
 
   docker-image-debian:
-    needs: ['build-release']
+    # needs: ['build-release']
+    needs: ['docker-image-scratch']
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -124,8 +125,8 @@ jobs:
             # joseluisq/static-web-server
             ghcr.io/static-web-server/static-web-server
           tags: |
-            # type=edge,branch=$repo.default_branch
-            type=ref,event=branch
+            type=edge,branch=$repo.default_branch
+            type=ref,event=pr
       - name: Login to ghcr.io
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -1,10 +1,9 @@
 name: release-docker-devel
 
 on:
-  pull_request:
   push:
     branches:
-      - master
+      - master-ci
     paths:
       - release.docker.devel.yml
       - .cargo/config.toml
@@ -29,8 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Install Linux/BSD tools
-        run: scripts/ci/install_tools.sh --target=x86_64-unknown-linux-gnu
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -1,0 +1,181 @@
+name: release-docker
+on:
+  push:
+    branches: [master]
+
+jobs:
+  docker-image-alpine:
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Docker meta alpine
+        id: meta_alpine
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
+          flavor: |
+            latest=false
+            suffix=-alpine
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Prepare Docker envs
+        shell: bash
+        run: |
+          echo "SERVER_VERSION=devel" >> $GITHUB_ENV
+      -
+        name: Build and push (alpine)
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          file: ./docker/alpine/Dockerfile
+          tags: ${{ steps.meta_alpine.outputs.tags }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+
+  docker-image-debian:
+    needs: ['docker-image-alpine']
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Docker meta debian
+        id: meta_debian
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
+          flavor: |
+            latest=false
+            suffix=-debian
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Prepare Docker envs
+        shell: bash
+        run: |
+          echo "SERVER_VERSION=devel" >> $GITHUB_ENV
+      -
+        name: Build and push (debian)
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x
+          file: ./docker/debian/Dockerfile
+          tags: ${{ steps.meta_debian.outputs.tags }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+
+  docker-image-scratch:
+    needs: ['docker-image-alpine']
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Docker meta scratch
+        id: meta_scratch
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Prepare Docker envs
+        shell: bash
+        run: |
+          echo "SERVER_VERSION=devel" >> $GITHUB_ENV
+      -
+        name: Build and push (scratch)
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          file: ./docker/scratch/Dockerfile
+          tags: ${{ steps.meta_scratch.outputs.tags }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}

--- a/.github/workflows/release.docker.devel.yml
+++ b/.github/workflows/release.docker.devel.yml
@@ -43,77 +43,18 @@ jobs:
           echo "target dir is: ${{ env.TARGET_DIR }}"
       - name: Build release binary
         run: ${{ env.CARGO_BIN }} build --bin static-web-server -vv --release ${{ env.CARGO_FEATURES }} ${{ env.TARGET_FLAGS }}
-  docker-image-alpine:
-    runs-on: ubuntu-22.04
-    steps:
-      -
-        name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Docker meta alpine
-        id: meta_alpine
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            joseluisq/static-web-server
-            ghcr.io/static-web-server/static-web-server
-          flavor: |
-            latest=false
-            suffix=-alpine
-          tags: |
-            devel
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to ghcr.io
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Prepare Docker envs
-        shell: bash
-        run: |
-          echo "SERVER_VERSION=devel" >> $GITHUB_ENV
-      -
-        name: Build and push (alpine)
-        uses: docker/build-push-action@v4
-        with:
-          push: true
-          context: .
-          platforms: linux/amd64,linux/arm64
-          file: ./docker/alpine/Dockerfile
-          tags: ${{ steps.meta_alpine.outputs.tags }}
-          build-args: |
-            SERVER_VERSION=${{ env.SERVER_VERSION }}
+      - name: Test
+        run: ls -la .
 
   docker-image-debian:
-    needs: ['docker-image-alpine']
+    needs: ['build-release']
     runs-on: ubuntu-22.04
     steps:
-      -
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Docker meta debian
+      - name: Docker meta debian
         id: meta_debian
         uses: docker/metadata-action@v4
         with:
@@ -124,56 +65,42 @@ jobs:
             latest=false
             suffix=-debian
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to ghcr.io
+            type=edge,branch=master
+      - name: Login to ghcr.io
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Prepare Docker envs
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Prepare Docker envs
         shell: bash
         run: |
           echo "SERVER_VERSION=devel" >> $GITHUB_ENV
-      -
-        name: Build and push (debian)
+      - name: Build and push (debian)
         uses: docker/build-push-action@v4
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x
-          file: ./docker/debian/Dockerfile
+          platforms: linux/amd64
+          file: ./docker/devel/Dockerfile.debian
           tags: ${{ steps.meta_debian.outputs.tags }}
           build-args: |
             SERVER_VERSION=${{ env.SERVER_VERSION }}
 
   docker-image-scratch:
-    needs: ['docker-image-alpine']
+    needs: ['docker-image-debian']
     runs-on: ubuntu-22.04
     steps:
-      -
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Docker meta scratch
+      - name: Docker meta scratch
         id: meta_scratch
         uses: docker/metadata-action@v4
         with:
@@ -181,38 +108,29 @@ jobs:
             joseluisq/static-web-server
             ghcr.io/static-web-server/static-web-server
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to ghcr.io
+            type=edge,branch=master
+      - name: Login to ghcr.io
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Prepare Docker envs
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Prepare Docker envs
         shell: bash
         run: |
           echo "SERVER_VERSION=devel" >> $GITHUB_ENV
-      -
-        name: Build and push (scratch)
+      - name: Build and push (scratch)
         uses: docker/build-push-action@v4
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
-          file: ./docker/scratch/Dockerfile
+          platforms: linux/amd64
+          file: ./docker/devel/Dockerfile.scratch
           tags: ${{ steps.meta_scratch.outputs.tags }}
           build-args: |
-            SERVER_VERSION=${{ env.SERVER_VERSION }}
+            SERVER_VERSION=devel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description

Build and push the `devel` tag for new commits on `master`. Further work is completed at https://github.com/static-web-server/static-web-server/pull/512.

## Related Issue

As discussed in https://github.com/static-web-server/static-web-server/pull/504#discussion_r1863743715

## Motivation and Context

I wanted to run the latest version locally and struggled to get it done. Since we discussed doing it in CI I went ahead and added another workflow based on a copy of `release.docker.yml`.

## How Has This Been Tested?

Not yet since it only runs on `master`. We could temporarily add `pull_request` to `on` to see if it runs successfully.

## Screenshots (if appropriate):
