### PR TITLE
The closing body tag has been moved right before the closing html tag

### DIFF
--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -411,71 +411,71 @@ fn html_auto_index<'a>(
                 h1 {
                     "Index of " (current_path)
                 }
-            }
-            p {
-                small {
-                    "directories: " (dirs_count) ", files: " (files_count)
+                p {
+                    small {
+                        "directories: " (dirs_count) ", files: " (files_count)
+                    }
                 }
-            }
-            hr;
-            div style="overflow-x: auto;" {
-                table {
-                    thead {
-                        tr {
-                            th {
-                                a href={ "?sort=" (sort_attrs.name) } {
-                                    "Name"
+                hr;
+                div style="overflow-x: auto;" {
+                    table {
+                        thead {
+                            tr {
+                                th {
+                                    a href={ "?sort=" (sort_attrs.name) } {
+                                        "Name"
+                                    }
                                 }
-                            }
-                            th style="width:10rem;" {
-                                a href={ "?sort=" (sort_attrs.last_modified) } {
-                                    "Last modified"
+                                th style="width:10rem;" {
+                                    a href={ "?sort=" (sort_attrs.last_modified) } {
+                                        "Last modified"
+                                    }
                                 }
-                            }
-                            th style="width:6rem;text-align:right;" {
-                                a href={ "?sort=" (sort_attrs.size) } {
-                                    "Size"
-                                }
-                            }
-                        }
-                    }
-
-                    @if base_path != "/" {
-                        tr {
-                            td colspan="3" {
-                                a href="../" {
-                                    "../"
-                                }
-                            }
-                        }
-                    }
-
-                    @for entry in entries {
-                        tr {
-                            td {
-                                a href=(entry.uri) {
-                                    (entry.name.to_string_lossy())
-                                    @if entry.is_dir() {
-                                        "/"
+                                th style="width:6rem;text-align:right;" {
+                                    a href={ "?sort=" (sort_attrs.size) } {
+                                        "Size"
                                     }
                                 }
                             }
-                            td {
-                                (entry.mtime.map_or("-".to_owned(), |local_dt| {
-                                    local_dt.format(DATETIME_FORMAT_LOCAL).to_string()
-                                }))
+                        }
+    
+                        @if base_path != "/" {
+                            tr {
+                                td colspan="3" {
+                                    a href="../" {
+                                        "../"
+                                    }
+                                }
                             }
-                            td align="right" {
-                                (entry.size.map(format_file_size).unwrap_or("-".into()))
+                        }
+    
+                        @for entry in entries {
+                            tr {
+                                td {
+                                    a href=(entry.uri) {
+                                        (entry.name.to_string_lossy())
+                                        @if entry.is_dir() {
+                                            "/"
+                                        }
+                                    }
+                                }
+                                td {
+                                    (entry.mtime.map_or("-".to_owned(), |local_dt| {
+                                        local_dt.format(DATETIME_FORMAT_LOCAL).to_string()
+                                    }))
+                                }
+                                td align="right" {
+                                    (entry.size.map(format_file_size).unwrap_or("-".into()))
+                                }
                             }
                         }
                     }
                 }
-            }
-            hr;
-            footer {
-                small {
-                    "Powered by Static Web Server (SWS) / static-web-server.net"
+                hr;
+                footer {
+                    small {
+                        "Powered by Static Web Server (SWS) / static-web-server.net"
+                    }
                 }
             }
         }

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -438,7 +438,7 @@ fn html_auto_index<'a>(
                                 }
                             }
                         }
-    
+
                         @if base_path != "/" {
                             tr {
                                 td colspan="3" {
@@ -448,7 +448,7 @@ fn html_auto_index<'a>(
                                 }
                             }
                         }
-    
+
                         @for entry in entries {
                             tr {
                                 td {


### PR DESCRIPTION
It was a mistake in the html hierarhy: the body contained only h1 tag.

## Description
I moved closing body tag right before closing html tag.

## Related Issue
It is too obvious to create an issue.

## Motivation and Context
Compliance with HTML specification.

## How Has This Been Tested?
I checked source code of directory listing returned by fixed static-web-server using https://validator.w3.org/nu/#textarea