### PR TITLE
Fix NetBSD 9.2 broken source link used by cross tool for cross-compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,11 +134,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 [package.metadata.cross.target.x86_64-unknown-netbsd]
 pre-build = [
     "mkdir -p /tmp/netbsd",
-    "curl https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz -O",
+    "curl -fO https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/amd64/binary/sets/base.tar.xz",
     "tar -C /tmp/netbsd -xJf base.tar.xz",
     "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
-    "rm base.tar.xz",
-    "rm -rf /tmp/netbsd",
+    "rm -rf base.tar.xz /tmp/netbsd",
 ]
 
 # Cross: Linux ARM64 Musl only


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

Recently NetBSD 9.2 source was archived affecting the `base.tar.xz` link used by the `libexecinfo.so` **cross** workaround (https://github.com/cross-rs/cross/issues/1345).

This small patch prefers `NetBSD 9.3` as it is the latest `9.x`.

- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz (broken)
- https://archive.netbsd.org/pub/NetBSD-archive/NetBSD-9.2/amd64/binary/sets/base.tar.xz (archived)
- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/amd64/binary/sets/base.tar.xz (new)

Additionally, a `-f, --fail` was added to curl to fail in case a `4xx` or greater response status happens again.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
