### PR TITLE
Add missing query string to the URI trailing slash redirect

### DIFF
--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -144,7 +144,8 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
     // Check for a trailing slash on the current directory path
     // and redirect if that path doesn't end with the slash char
     if is_dir && opts.redirect_trailing_slash && !uri_path.ends_with('/') {
-        let uri = [uri_path, "/"].concat();
+        let query = opts.uri_query.map_or(String::new(), |s| ["?", s].concat());
+        let uri = [uri_path, "/", query.as_str()].concat();
         let loc = match HeaderValue::from_str(uri.as_str()) {
             Ok(val) => val,
             Err(err) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR adds the missing query string to the URI when performing a trailing slash redirect only if the feature is enabled.

See feature: https://static-web-server.net/features/trailing-slash-redirect/.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

**Before**

```sh
$ curl -i "http://localhost:8787/assets?param=123"
# HTTP/1.1 308 Permanent Redirect
# location: /assets/
# vary: accept-encoding
# cache-control: public, max-age=86400
# content-length: 0
# date: Mon, 03 Feb 2025 21:19:19 GMT
```

**After**

```sh
$ curl -i "http://localhost:8787/assets?param=123"
# HTTP/1.1 308 Permanent Redirect
# location: /assets/?param=123
# vary: accept-encoding
# cache-control: public, max-age=86400
# content-length: 0
# date: Mon, 03 Feb 2025 21:19:29 GMT
```

## Screenshots (if appropriate):
