### PR TITLE
Add missing `Origin` to the `Vary` header value when CORS enabled

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -104,10 +104,16 @@ pub(crate) fn post_process<T>(
     }
 
     // Compression content encoding varies so use a `Vary` header
-    resp.headers_mut().insert(
-        hyper::header::VARY,
+    let value = resp.headers().get(hyper::header::VARY).map_or(
         HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
+        |h| {
+            let mut s = h.to_str().unwrap_or_default().to_owned();
+            s.push(',');
+            s.push_str(hyper::header::ACCEPT_ENCODING.as_str());
+            HeaderValue::from_str(s.as_str()).unwrap()
+        },
     );
+    resp.headers_mut().insert(hyper::header::VARY, value);
 
     // Auto compression based on the `Accept-Encoding` header
     match auto(req.method(), req.headers(), opts.compression_level, resp) {

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -45,10 +45,16 @@ pub(crate) fn post_process<T>(
     }
 
     // Compression content encoding varies so use a `Vary` header
-    resp.headers_mut().insert(
-        hyper::header::VARY,
+    let value = resp.headers().get(hyper::header::VARY).map_or(
         HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
+        |h| {
+            let mut s = h.to_str().unwrap_or_default().to_owned();
+            s.push(',');
+            s.push_str(hyper::header::ACCEPT_ENCODING.as_str());
+            HeaderValue::from_str(s.as_str()).unwrap()
+        },
     );
+    resp.headers_mut().insert(hyper::header::VARY, value);
 
     Ok(resp)
 }

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -429,6 +429,10 @@ pub(crate) fn post_process<T>(
                 for (k, v) in headers.iter() {
                     resp.headers_mut().insert(k, v.to_owned());
                 }
+                resp.headers_mut().insert(
+                    hyper::header::VARY,
+                    HeaderValue::from_name(hyper::header::ORIGIN),
+                );
                 resp.headers_mut().remove(http::header::ALLOW);
             }
         }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -29,8 +29,11 @@ pub mod fixtures {
         Settings::get_unparsed(false).unwrap()
     }
 
-    /// Create a `RequestHandler` from a custom TOML config file (fixture).
-    pub fn fixture_req_handler(general: General, advanced: Option<Advanced>) -> RequestHandler {
+    /// Create a `RequestHandlerOpts` from the given options (fixture).
+    pub fn fixture_req_handler_opts(
+        general: General,
+        advanced: Option<Advanced>,
+    ) -> RequestHandlerOpts {
         #[cfg(not(any(
             feature = "compression",
             feature = "compression-gzip",
@@ -64,7 +67,7 @@ pub mod fixtures {
         ))]
         let compression_static = general.compression_static;
 
-        let req_handler_opts = RequestHandlerOpts {
+        RequestHandlerOpts {
             root_dir: general.root,
             compression,
             compression_static,
@@ -110,8 +113,11 @@ pub mod fixtures {
             #[cfg(feature = "experimental")]
             memory_cache: None,
             advanced_opts: advanced,
-        };
+        }
+    }
 
+    /// Create a `RequestHandler` from a custom TOML config file (fixture).
+    pub fn fixture_req_handler(req_handler_opts: RequestHandlerOpts) -> RequestHandler {
         RequestHandler {
             opts: Arc::from(req_handler_opts),
         }

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -13,329 +13,251 @@
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use headers::HeaderMap;
-    use http::Method;
+    use hyper::Request;
+    use std::net::SocketAddr;
     use std::path::PathBuf;
 
     #[cfg(feature = "directory-listing")]
     use static_web_server::directory_listing::DirListFmt;
-    use static_web_server::static_files::{self, HandleOpts};
-
-    fn public_dir() -> PathBuf {
-        PathBuf::from("docker/public/")
-    }
+    use static_web_server::{
+        settings::cli::General,
+        testing::fixtures::{
+            fixture_req_handler, fixture_req_handler_opts, fixture_settings, REMOTE_ADDR,
+        },
+    };
 
     #[tokio::test]
     async fn compression_static_file_exists() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
+        let archive_path = PathBuf::from("tests/fixtures/public/index.html.gz");
+        let archive_buf =
+            std::fs::read(&archive_path).expect("unexpected error when reading archive file");
+        let archive_buf = Bytes::from(archive_buf);
+
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression_static: true,
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/index.html".parse().unwrap();
+        req.headers_mut().insert(
             http::header::ACCEPT_ENCODING,
             "gzip, deflate, br".parse().unwrap(),
         );
 
-        let index_gz_path = PathBuf::from("tests/fixtures/public/index.html.gz");
-        let index_gz_path_public = public_dir().join("index.html.gz");
-        std::fs::copy(&index_gz_path, &index_gz_path_public)
-            .expect("unexpected error copying fixture file");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(mut res) => {
+                let headers = res.headers();
 
-        let result = static_files::handle(&HandleOpts {
-            method: &Method::GET,
-            headers: &headers,
-            base_path: &public_dir(),
-            uri_path: "index.html",
-            uri_query: None,
-            #[cfg(feature = "experimental")]
-            memory_cache: None,
-            #[cfg(feature = "directory-listing")]
-            dir_listing: false,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_order: 6,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_format: &DirListFmt::Html,
-            redirect_trailing_slash: true,
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-deflate",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd"
-            ))]
-            compression_static: true,
-            ignore_hidden_files: false,
-            disable_symlinks: false,
-            index_files: &[],
-        })
-        .await
-        .expect("unexpected error response on `handle` function");
-        let mut res = result.resp;
+                assert_eq!(res.status(), 200);
+                assert!(!headers.contains_key("content-length"));
+                assert_eq!(headers["content-encoding"], "gzip");
+                assert_eq!(headers["accept-ranges"], "bytes");
+                assert!(!headers["last-modified"].is_empty());
+                assert_eq!(
+                    &headers["content-type"], "text/html",
+                    "content-type is not html"
+                );
+                assert_eq!(headers["vary"], "accept-encoding");
 
-        let index_gz_buf =
-            std::fs::read(&index_gz_path).expect("unexpected error when reading index.html.gz");
-        let index_gz_buf = Bytes::from(index_gz_buf);
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
 
-        std::fs::remove_file(index_gz_path_public).unwrap();
-
-        let headers = res.headers();
-
-        assert_eq!(res.status(), 200);
-        assert!(!headers.contains_key("content-length"));
-        assert_eq!(headers["content-encoding"], "gzip");
-        assert_eq!(headers["accept-ranges"], "bytes");
-        assert!(!headers["last-modified"].is_empty());
-        assert_eq!(
-            &headers["content-type"], "text/html",
-            "content-type is not html"
-        );
-
-        let body = hyper::body::to_bytes(res.body_mut())
-            .await
-            .expect("unexpected bytes error during `body` conversion");
-
-        assert_eq!(
-            body, index_gz_buf,
-            "body and index_gz_buf are not equal in length"
-        );
+                assert_eq!(
+                    body, archive_buf,
+                    "body and archive_buf are not equal in length"
+                );
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        };
     }
 
     #[tokio::test]
     async fn compression_static_suboptimal_file_exists() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
+        let archive_path = PathBuf::from("tests/fixtures/public/404.html.br");
+        let archive_buf =
+            std::fs::read(&archive_path).expect("unexpected error when reading archive file");
+        let archive_buf = Bytes::from(archive_buf);
+
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression_static: true,
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/404.html".parse().unwrap();
+        req.headers_mut().insert(
             http::header::ACCEPT_ENCODING,
             "gzip, deflate, br, zstd".parse().unwrap(),
         );
 
-        let index_br_path = PathBuf::from("tests/fixtures/public/404.html.br");
-        let index_br_path_public = public_dir().join("404.html.br");
-        std::fs::copy(&index_br_path, &index_br_path_public)
-            .expect("unexpected error copying fixture file");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(mut res) => {
+                let headers = res.headers();
 
-        let result = static_files::handle(&HandleOpts {
-            method: &Method::GET,
-            headers: &headers,
-            base_path: &public_dir(),
-            uri_path: "404.html",
-            uri_query: None,
-            #[cfg(feature = "experimental")]
-            memory_cache: None,
-            #[cfg(feature = "directory-listing")]
-            dir_listing: false,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_order: 6,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_format: &DirListFmt::Html,
-            redirect_trailing_slash: true,
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-deflate",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd"
-            ))]
-            compression_static: true,
-            ignore_hidden_files: false,
-            disable_symlinks: false,
-            index_files: &[],
-        })
-        .await
-        .expect("unexpected error response on `handle` function");
-        let mut res = result.resp;
+                assert_eq!(res.status(), 200);
+                assert!(!headers.contains_key("content-length"));
+                assert_eq!(headers["content-encoding"], "br");
+                assert_eq!(headers["accept-ranges"], "bytes");
+                assert!(!headers["last-modified"].is_empty());
+                assert_eq!(
+                    &headers["content-type"], "text/html",
+                    "content-type is not html"
+                );
+                assert_eq!(headers["vary"], "accept-encoding");
 
-        let index_br_buf =
-            std::fs::read(&index_br_path).expect("unexpected error when reading index.html.br");
-        let index_br_buf = Bytes::from(index_br_buf);
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
 
-        std::fs::remove_file(index_br_path_public).unwrap();
-
-        let headers = res.headers();
-
-        assert_eq!(res.status(), 200);
-        assert!(!headers.contains_key("content-length"));
-        assert_eq!(headers["content-encoding"], "br");
-        assert_eq!(headers["accept-ranges"], "bytes");
-        assert!(!headers["last-modified"].is_empty());
-        assert_eq!(
-            &headers["content-type"], "text/html",
-            "content-type is not html"
-        );
-
-        let body = hyper::body::to_bytes(res.body_mut())
-            .await
-            .expect("unexpected bytes error during `body` conversion");
-
-        assert_eq!(
-            body, index_br_buf,
-            "body and index_br_buf are not equal in length"
-        );
+                assert_eq!(
+                    body, archive_buf,
+                    "body and archive_buf are not equal in length"
+                );
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
     }
 
     #[tokio::test]
     async fn compression_static_file_does_not_exist() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            http::header::ACCEPT_ENCODING,
-            "gzip, deflate, br".parse().unwrap(),
-        );
-
-        let index_path_public = public_dir().join("assets/index.html");
-
-        let result = static_files::handle(&HandleOpts {
-            method: &Method::GET,
-            headers: &headers,
-            base_path: &public_dir().join("assets/"),
-            uri_path: "index.html",
-            uri_query: None,
-            #[cfg(feature = "experimental")]
-            memory_cache: None,
-            #[cfg(feature = "directory-listing")]
-            dir_listing: false,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_order: 6,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_format: &DirListFmt::Html,
-            redirect_trailing_slash: true,
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-deflate",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd"
-            ))]
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression: false,
             compression_static: true,
-            ignore_hidden_files: false,
-            disable_symlinks: false,
-            index_files: &[],
-        })
-        .await
-        .expect("unexpected error response on `handle` function");
-        let mut res = result.resp;
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
-        let index_buf =
-            std::fs::read(&index_path_public).expect("unexpected error when reading index.html");
-        let index_buf = Bytes::from(index_buf);
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/index.htm".parse().unwrap();
+        req.headers_mut()
+            .insert(http::header::ACCEPT_ENCODING, "br".parse().unwrap());
 
-        let headers = res.headers();
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                let headers = res.headers();
 
-        assert_eq!(res.status(), 200);
-        assert!(headers.contains_key("content-length"));
-        assert_eq!(headers["accept-ranges"], "bytes");
-        assert!(!headers["last-modified"].is_empty());
-        assert_eq!(
-            &headers["content-type"], "text/html",
-            "content-type is not html"
-        );
-
-        let body = hyper::body::to_bytes(res.body_mut())
-            .await
-            .expect("unexpected bytes error during `body` conversion");
-
-        assert_eq!(
-            body, index_buf,
-            "body and index_gz_buf are not equal in length"
-        );
+                assert_eq!(res.status(), 200);
+                assert!(headers.contains_key("content-length"));
+                assert_eq!(headers["accept-ranges"], "bytes");
+                assert!(!headers.contains_key("content-encoding"));
+                assert!(!headers["last-modified"].is_empty());
+                assert_eq!(
+                    &headers["content-type"], "text/html",
+                    "content-type is not html"
+                );
+                assert_eq!(headers["vary"], "accept-encoding");
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
     }
 
     #[cfg(feature = "directory-listing")]
     #[tokio::test]
-    async fn compression_static_base_path_as_dot() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            http::header::ACCEPT_ENCODING,
-            "gzip, deflate, br".parse().unwrap(),
-        );
-
-        let base_path = PathBuf::from(".");
-
-        static_files::handle(&HandleOpts {
-            method: &Method::GET,
-            headers: &headers,
-            base_path: &base_path,
-            uri_path: "/",
-            uri_query: None,
-            #[cfg(feature = "experimental")]
-            memory_cache: None,
-            dir_listing: true,
-            dir_listing_order: 6,
-            dir_listing_format: &DirListFmt::Html,
-            redirect_trailing_slash: true,
+    async fn compression_static_index_file() {
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression: false,
             compression_static: true,
+            directory_listing: true,
+            directory_listing_format: DirListFmt::Html,
             ignore_hidden_files: false,
             disable_symlinks: false,
-            index_files: &[],
-        })
-        .await
-        .expect("unexpected error response on `handle` function");
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost".parse().unwrap();
+        req.headers_mut()
+            .insert(http::header::ACCEPT_ENCODING, "zstd, gzip".parse().unwrap());
+
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                let headers = res.headers();
+
+                assert_eq!(res.status(), 200);
+                assert_eq!(headers["accept-ranges"], "bytes");
+                assert_eq!(headers["content-encoding"], "gzip");
+                assert!(!headers["last-modified"].is_empty());
+                assert_eq!(
+                    &headers["content-type"], "text/html",
+                    "content-type is not html"
+                );
+                assert_eq!(headers["vary"], "accept-encoding");
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
     }
 
     #[tokio::test]
     async fn compression_static_zstd_file_exists() {
-        let mut headers = HeaderMap::new();
-        headers.insert(
+        let archive_path = PathBuf::from("tests/fixtures/public/main.js.zst");
+        let archive_buf =
+            std::fs::read(&archive_path).expect("unexpected error when reading archive file");
+        let archive_buf = Bytes::from(archive_buf);
+
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression: false,
+            compression_static: true,
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/main.js".parse().unwrap();
+        req.headers_mut().insert(
             http::header::ACCEPT_ENCODING,
             "gzip, deflate, br, zstd".parse().unwrap(),
         );
 
-        let mainjs_zst_path = PathBuf::from("tests/fixtures/public/main.js.zst");
-        let mainjs_zst_path_public = public_dir().join("main.js.zst");
-        std::fs::copy(&mainjs_zst_path, &mainjs_zst_path_public)
-            .expect("unexpected error copying fixture file");
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(mut res) => {
+                let headers = res.headers();
 
-        let result = static_files::handle(&HandleOpts {
-            method: &Method::GET,
-            headers: &headers,
-            base_path: &public_dir(),
-            uri_path: "main.js",
-            uri_query: None,
-            #[cfg(feature = "experimental")]
-            memory_cache: None,
-            #[cfg(feature = "directory-listing")]
-            dir_listing: false,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_order: 6,
-            #[cfg(feature = "directory-listing")]
-            dir_listing_format: &DirListFmt::Html,
-            redirect_trailing_slash: true,
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-deflate",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd"
-            ))]
-            compression_static: true,
-            ignore_hidden_files: false,
-            disable_symlinks: false,
-            index_files: &[],
-        })
-        .await
-        .expect("unexpected error response on `handle` function");
-        let mut res = result.resp;
+                assert_eq!(res.status(), 200);
+                assert!(!headers.contains_key("content-length"));
+                assert_eq!(headers["content-encoding"], "zstd");
+                assert_eq!(headers["accept-ranges"], "bytes");
+                assert!(!headers["last-modified"].is_empty());
+                assert_eq!(
+                    &headers["content-type"], "text/javascript",
+                    "content-type is not javascript"
+                );
+                assert_eq!(headers["vary"], "accept-encoding");
 
-        let mainjs_zst_buf =
-            std::fs::read(&mainjs_zst_path).expect("unexpected error when reading index.html.gz");
-        let mainjs_zst_buf = Bytes::from(mainjs_zst_buf);
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
 
-        std::fs::remove_file(mainjs_zst_path_public).unwrap();
-
-        let headers = res.headers();
-
-        assert_eq!(res.status(), 200);
-        assert!(!headers.contains_key("content-length"));
-        assert_eq!(headers["content-encoding"], "zstd");
-        assert_eq!(headers["accept-ranges"], "bytes");
-        assert!(!headers["last-modified"].is_empty());
-        assert_eq!(
-            &headers["content-type"], "text/javascript",
-            "content-type is not javascript"
-        );
-
-        let body = hyper::body::to_bytes(res.body_mut())
-            .await
-            .expect("unexpected bytes error during `body` conversion");
-
-        assert_eq!(
-            body, mainjs_zst_buf,
-            "body and mainjs_zst_buf are not equal in length"
-        );
+                assert_eq!(
+                    body, archive_buf,
+                    "body and archive_buf are not equal in length"
+                );
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
     }
 }

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -11,13 +11,14 @@ pub mod tests {
 
     use static_web_server::http_ext::MethodExt;
     use static_web_server::testing::fixtures::{
-        fixture_req_handler, fixture_settings, REMOTE_ADDR,
+        fixture_req_handler, fixture_req_handler_opts, fixture_settings, REMOTE_ADDR,
     };
 
     #[tokio::test]
     async fn custom_headers_apply_for_dir() {
         let opts = fixture_settings("toml/handler.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -38,10 +39,12 @@ pub mod tests {
                     feature = "compression-brotli",
                     feature = "compression-zstd"
                 ))]
+                #[cfg(feature = "compression")]
                 assert_eq!(
                     res.headers().get("vary"),
                     Some(&HeaderValue::from_static("accept-encoding"))
                 );
+
                 assert_eq!(
                     res.headers().get("server"),
                     Some(&HeaderValue::from_static("Static Web Server"))
@@ -56,7 +59,8 @@ pub mod tests {
     #[tokio::test]
     async fn custom_headers_apply_for_file() {
         let opts = fixture_settings("toml/handler.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -77,10 +81,12 @@ pub mod tests {
                     feature = "compression-brotli",
                     feature = "compression-zstd"
                 ))]
+                #[cfg(feature = "compression")]
                 assert_eq!(
                     res.headers().get("vary"),
                     Some(&HeaderValue::from_static("accept-encoding"))
                 );
+
                 assert_eq!(
                     res.headers().get("cache-control"),
                     Some(&HeaderValue::from_static("public, max-age=86400"))
@@ -98,8 +104,9 @@ pub mod tests {
 
     #[tokio::test]
     async fn check_allowed_methods() {
-        let settings = fixture_settings("toml/handler.toml");
-        let req_handler = fixture_req_handler(settings.general, settings.advanced);
+        let opts = fixture_settings("toml/handler.toml");
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let methods = [
@@ -118,19 +125,26 @@ pub mod tests {
             *req.uri_mut() = "http://localhost/assets/index.html".parse().unwrap();
 
             match req_handler.handle(&mut req, remote_addr).await {
-                Ok(resp) => {
+                Ok(res) => {
                     if method.is_allowed() {
-                        assert_eq!(resp.status(), 200);
+                        assert_eq!(res.status(), 200);
                         assert_eq!(
-                            resp.headers().get("content-type"),
+                            res.headers().get("content-type"),
                             Some(&HeaderValue::from_static("text/html"))
                         );
+
+                        #[cfg(feature = "compression")]
                         assert_eq!(
-                            resp.headers().get("server"),
+                            res.headers().get("vary"),
+                            Some(&HeaderValue::from_static("accept-encoding"))
+                        );
+
+                        assert_eq!(
+                            res.headers().get("server"),
                             Some(&HeaderValue::from_static("Static Web Server"))
                         );
                     } else {
-                        assert_eq!(resp.status(), 405);
+                        assert_eq!(res.status(), 405);
                     }
                 }
                 Err(err) => {

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -9,18 +9,19 @@ pub mod tests {
     use std::net::SocketAddr;
 
     use static_web_server::testing::fixtures::{
-        fixture_req_handler, fixture_settings, REMOTE_ADDR,
+        fixture_req_handler, fixture_req_handler_opts, fixture_settings, REMOTE_ADDR,
     };
 
     #[tokio::test]
     async fn redirects_skipped() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 200);
@@ -35,7 +36,8 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_host() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -55,12 +57,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_1() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/assets/main.css".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 301);
@@ -78,12 +81,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_2() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/style.css".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 301);
@@ -101,12 +105,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_3() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/rust-lang.rs".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
@@ -124,12 +129,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_4() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/assets/main.js".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
@@ -147,12 +153,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_5() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/old/images/avatar.jpeg".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
@@ -170,12 +177,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_6() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/old/fonts/title.ttf".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 302);
@@ -193,12 +201,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_generic_1() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/generic-page.html".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 301);
@@ -216,12 +225,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_generic_2() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/2024/11/".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 301);
@@ -239,12 +249,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_generic_2_literal_separator() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/archive/2024/11/".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 404);
@@ -258,12 +269,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_ranges_1() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/2/a/random/".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 301);
@@ -281,12 +293,13 @@ pub mod tests {
     #[tokio::test]
     async fn redirects_glob_groups_ranges_2() {
         let opts = fixture_settings("toml/redirects.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
-        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
 
         let mut req = Request::default();
         *req.uri_mut() = "http://localhost/crop-x/image.png".parse().unwrap();
 
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 301);

--- a/tests/rewrites.rs
+++ b/tests/rewrites.rs
@@ -9,13 +9,14 @@ pub mod tests {
     use std::net::SocketAddr;
 
     use static_web_server::testing::fixtures::{
-        fixture_req_handler, fixture_settings, REMOTE_ADDR,
+        fixture_req_handler, fixture_req_handler_opts, fixture_settings, REMOTE_ADDR,
     };
 
     #[tokio::test]
     async fn rewrites_skipped() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -35,7 +36,8 @@ pub mod tests {
     #[tokio::test]
     async fn rewrites_glob_groups_1() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -61,7 +63,8 @@ pub mod tests {
     #[tokio::test]
     async fn rewrites_glob_groups_2() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -87,7 +90,8 @@ pub mod tests {
     #[tokio::test]
     async fn rewrites_glob_groups_3() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -113,7 +117,8 @@ pub mod tests {
     #[tokio::test]
     async fn rewrites_glob_groups_4() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -139,7 +144,8 @@ pub mod tests {
     #[tokio::test]
     async fn rewrites_glob_groups_5() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -159,7 +165,8 @@ pub mod tests {
     #[tokio::test]
     async fn rewrites_glob_groups_6() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();
@@ -182,7 +189,8 @@ pub mod tests {
     #[tokio::test]
     async fn rewrites_glob_groups_generic_1() {
         let opts = fixture_settings("toml/rewrites.toml");
-        let req_handler = fixture_req_handler(opts.general, opts.advanced);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
         let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
 
         let mut req = Request::default();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR includes the missing `Origin` header to the resulting `Vary` header value when the CORS feature is enabled according to https://fetch.spec.whatwg.org/#example-vary-origin.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It resolves #533

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

```sh
static-web-server -p 8788 -d ./docker/public/ -g trace -z true '-c=*'
```

**Before**

```sh
$ curl -I -H "Origin: http://devel.local:8788" http://localhost:8788/assets/main.js
# HTTP/1.1 200 OK
# content-length: 52
# content-type: text/javascript
# accept-ranges: bytes
# last-modified: Mon, 10 Feb 2025 21:00:47 GMT
# access-control-allow-headers: content-type, origin, authorization
# access-control-expose-headers: origin, content-type
# access-control-allow-methods: OPTIONS, GET, HEAD
# access-control-allow-origin: http://devel.local:8788
# vary: accept-encoding
# cache-control: public, max-age=31536000
# date: Mon, 24 Mar 2025 03:20:15 GMT
```

**After**

```sh
$ curl -I -H "Origin: http://devel.local:8788" http://localhost:8788/assets/main.js
# HTTP/1.1 200 OK
# content-length: 52
# content-type: text/javascript
# accept-ranges: bytes
# last-modified: Mon, 10 Feb 2025 21:00:47 GMT
# access-control-allow-headers: content-type, origin, authorization
# access-control-expose-headers: origin, content-type
# access-control-allow-methods: GET, HEAD, OPTIONS
# access-control-allow-origin: http://devel.local:8788
# vary: origin,accept-encoding
# cache-control: public, max-age=31536000
# date: Mon, 24 Mar 2025 03:22:44 GM
```

Preflight request

```sh
$ curl http://localhost:8788/assets/main.js \
    -I -X OPTIONS \
    -H "Access-Control-Request-Method: HEAD" \
    -H "Access-Control-Request-Headers: content-type" \
    -H "Origin: http://localhost:8787"
# HTTP/1.1 204 No Content
# vary: origin,accept-encoding
# accept-ranges: bytes
# access-control-allow-headers: origin, content-type, authorization
# access-control-expose-headers: content-type, origin
# access-control-allow-methods: HEAD, OPTIONS, GET
# access-control-allow-origin: http://localhost:8787
# cache-control: public, max-age=31536000
# date: Mon, 24 Mar 2025 03:36:53 GMT
```

Without CORS:

```sh
$ static-web-server -p 8788 -d ./docker/public/ -g trace

$ curl -I -H "Origin: http://devel.local:8788" http://localhost:8788/assets/main.js
# HTTP/1.1 200 OK
# content-length: 52
# content-type: text/javascript
# accept-ranges: bytes
# last-modified: Mon, 10 Feb 2025 21:00:47 GMT
# vary: accept-encoding
# cache-control: public, max-age=31536000
# date: Mon, 24 Mar 2025 03:27:08 GMT
```

## Screenshots (if appropriate):
