### PR TITLE
Fix generic server `INFO` log output entries at startup, even on higher log levels

### DIFF
--- a/src/basic_auth.rs
+++ b/src/basic_auth.rs
@@ -15,7 +15,7 @@ use crate::{error_page, handler::RequestHandlerOpts, http_ext::MethodExt, Error}
 /// Initializes `Basic` HTTP Authorization handling
 pub(crate) fn init(credentials: &str, handler_opts: &mut RequestHandlerOpts) {
     credentials.trim().clone_into(&mut handler_opts.basic_auth);
-    server_info!(
+    tracing::info!(
         "basic authentication: enabled={}",
         !handler_opts.basic_auth.is_empty()
     );

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -25,8 +25,6 @@ fn main() -> Result {
     }
 
     if let Some(commands) = opts.general.commands {
-        use static_web_server::server_info;
-
         match commands {
             #[cfg(windows)]
             Commands::Install {} => {
@@ -45,13 +43,13 @@ fn main() -> Result {
                     let mut comp_dir = out_dir.clone();
                     comp_dir.push("completions");
                     clap_allgen::render_shell_completions::<General>(&comp_dir)?;
-                    server_info!("wrote completions to {}", comp_dir.to_string_lossy());
+                    tracing::info!("wrote completions to {}", comp_dir.to_string_lossy());
                 }
                 if man_pages || !completions {
                     let mut man_dir = out_dir.clone();
                     man_dir.push("man");
                     clap_allgen::render_manpages::<General>(&man_dir)?;
-                    server_info!("wrote man pages to {}", man_dir.to_string_lossy());
+                    tracing::info!("wrote man pages to {}", man_dir.to_string_lossy());
                 }
                 return Ok(());
             }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -82,7 +82,7 @@ pub fn init(enabled: bool, level: CompressionLevel, handler_opts: &mut RequestHa
         #[cfg(any(feature = "compression", feature = "compression-zstd"))]
         "zstd",
     ];
-    server_info!(
+    tracing::info!(
         "auto compression: enabled={enabled}, formats={}, compression level={level:?}",
         FORMATS.join(",")
     );

--- a/src/compression_static.rs
+++ b/src/compression_static.rs
@@ -31,7 +31,7 @@ pub struct CompressedFileVariant {
 /// Initializes static compression.
 pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.compression_static = enabled;
-    server_info!("compression static: enabled={enabled}");
+    tracing::info!("compression static: enabled={enabled}");
 }
 
 /// Post-processing to add Vary header if necessary.

--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -26,7 +26,7 @@ const CACHE_EXT_ONE_YEAR: [&str; 32] = [
 
 pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.cache_control_headers = enabled;
-    server_info!("cache control headers: enabled={enabled}");
+    tracing::info!("cache control headers: enabled={enabled}");
 }
 
 /// Appends `Cache-Control` header to a response if necessary

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -71,7 +71,7 @@ pub fn new(
         };
 
         if cors_res.is_some() {
-            server_info!(
+            tracing::info!(
                     "cors enabled=true, allow_methods=[GET,HEAD,OPTIONS], allow_origins={}, allow_headers=[{}], expose_headers=[{}]",
                     origins_str,
                     allow_headers_str,

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -61,13 +61,13 @@ pub struct DirListOpts<'a> {
 /// Initializes directory listings.
 pub fn init(enabled: bool, order: u8, format: DirListFmt, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.dir_listing = enabled;
-    server_info!("directory listing: enabled={enabled}");
+    tracing::info!("directory listing: enabled={enabled}");
 
     handler_opts.dir_listing_order = order;
-    server_info!("directory listing order code: {order}");
+    tracing::info!("directory listing order code: {order}");
 
     handler_opts.dir_listing_format = format;
-    server_info!(
+    tracing::info!(
         "directory listing format: {:?}",
         handler_opts.dir_listing_format
     );

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -26,7 +26,7 @@ pub(crate) fn init(file_path: &Path, handler_opts: &mut RequestHandlerOpts) {
         tracing::debug!("fallback page path not found or not a regular file");
     }
 
-    server_info!(
+    tracing::info!(
         "fallback page: enabled={}, value=\"{}\"",
         found,
         file_path.display()

--- a/src/health.rs
+++ b/src/health.rs
@@ -14,7 +14,7 @@ use crate::{handler::RequestHandlerOpts, Error};
 /// Initializes the health endpoint.
 pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.health = enabled;
-    server_info!("health endpoint: enabled={enabled}");
+    tracing::info!("health endpoint: enabled={enabled}");
 }
 
 /// Handles health requests.

--- a/src/log_addr.rs
+++ b/src/log_addr.rs
@@ -20,16 +20,16 @@ pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
         format!("{:?}", handler_opts.trusted_proxies)
     };
 
-    server_info!("log requests with remote IP addresses: enabled={enabled}");
-    server_info!(
+    tracing::info!("log requests with remote IP addresses: enabled={enabled}");
+    tracing::info!(
         "log X-Real-IP header: enabled={}",
         handler_opts.log_forwarded_for
     );
-    server_info!(
+    tracing::info!(
         "log X-Forwarded-For header: enabled={}",
         handler_opts.log_forwarded_for
     );
-    server_info!("trusted IPs for X-Forwarded-For: {trusted}");
+    tracing::info!("trusted IPs for X-Forwarded-For: {trusted}");
 }
 
 /// It logs remote and real IP addresses if available.

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -35,12 +35,7 @@ fn configure(level: &str) -> Result {
         .with_writer(std::io::stderr)
         .with_span_events(FmtSpan::CLOSE)
         .with_ansi(enable_ansi)
-        .with_filter(
-            Targets::default()
-                .with_default(level)
-                .with_target("static_web_server::info", Level::INFO)
-                .with_target("static_web_server::warn", Level::WARN),
-        );
+        .with_filter(Targets::default().with_default(level));
 
     match tracing_subscriber::registry()
         .with(filtered_layer)
@@ -49,26 +44,4 @@ fn configure(level: &str) -> Result {
         Err(err) => Err(anyhow!(err)),
         _ => Ok(()),
     }
-}
-
-/// Custom info level macro.
-#[macro_export]
-macro_rules! server_info {
-    ($($arg:tt)*) => {
-        tracing::info!(
-            target: "static_web_server::info",
-            $($arg)*
-        )
-    };
-}
-
-/// Custom warn level macro.
-#[macro_export]
-macro_rules! server_warn {
-    ($($arg:tt)*) => {
-        tracing::warn!(
-            target: "static_web_server::warn",
-            $($arg)*
-        )
-    };
 }

--- a/src/maintenance_mode.rs
+++ b/src/maintenance_mode.rs
@@ -25,15 +25,15 @@ pub(crate) fn init(
     handler_opts.maintenance_mode = maintenance_mode;
     handler_opts.maintenance_mode_status = maintenance_mode_status;
     handler_opts.maintenance_mode_file = maintenance_mode_file;
-    server_info!(
+    tracing::info!(
         "maintenance mode: enabled={}",
         handler_opts.maintenance_mode
     );
-    server_info!(
+    tracing::info!(
         "maintenance mode status: {}",
         handler_opts.maintenance_mode_status.as_str()
     );
-    server_info!(
+    tracing::info!(
         "maintenance mode file: \"{}\"",
         handler_opts.maintenance_mode_file.display()
     );

--- a/src/mem_cache/cache.rs
+++ b/src/mem_cache/cache.rs
@@ -67,7 +67,7 @@ pub(crate) fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
             // Default 8mb
             let max_file_size = opts.max_file_size.unwrap_or(8192);
 
-            server_info!(
+            tracing::info!(
                 "in-memory cache (experimental): enabled=true, capacity={capacity}, ttl={ttl}, tti={tti}, max_file_size={max_file_size}"
             );
 
@@ -91,7 +91,7 @@ pub(crate) fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
         }
     }
 
-    server_info!("in-memory cache (experimental): enabled=false");
+    tracing::info!("in-memory cache (experimental): enabled=false");
 
     Ok(())
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,7 +15,7 @@ use crate::{handler::RequestHandlerOpts, http_ext::MethodExt, Error};
 /// Initializes the metrics endpoint.
 pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.experimental_metrics = enabled;
-    server_info!("metrics endpoint (experimental): enabled={enabled}");
+    tracing::info!("metrics endpoint (experimental): enabled={enabled}");
 
     if enabled {
         default_registry()

--- a/src/security_headers.rs
+++ b/src/security_headers.rs
@@ -15,7 +15,7 @@ use crate::{handler::RequestHandlerOpts, Error};
 
 pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.security_headers = enabled;
-    server_info!("security headers: enabled={enabled}");
+    tracing::info!("security headers: enabled={enabled}");
 }
 
 /// Appends security headers to a response if necessary

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -422,7 +422,7 @@ impl Settings {
             tracing::debug!("config file path resolved: {}", config_file.display());
 
             if !has_general_settings {
-                server_warn!(
+                tracing::warn!(
                     "config file empty or no `general` settings found, using default values"
                 );
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes, but try to be as concise as possible -->

This PR fixes an issue (previously an ad-hoc and inconsistent behavior) where SWS was printing `INFO` level messages at startup despite setting up a higher log level. E.g., `WARN` or `ERROR`.

**Notice:**

For consistency reasons, SWS now won't _persistently_ show server information at startup independently of the log level as it did before. Instead, those info log entries are non-persistent and under the normal server `INFO` log level.

For example. To show those logs again then use the `INFO` log level.

```sh
static-web-server -p 8787 -d public/ -g info
# 2025-05-01T13:34:11.901636Z  INFO static_web_server::server: static-web-server 2.36.1
# 2025-05-01T13:34:11.901867Z  INFO static_web_server::server: log level: info
# 2025-05-01T13:34:11.901975Z  INFO static_web_server::server: server bound to tcp socket [::]:8787
# 2025-05-01T13:34:11.901995Z  INFO static_web_server::server: runtime worker threads: 8
# 2025-05-01T13:34:11.902006Z  INFO static_web_server::server: runtime max blocking threads: 512
# 2025-05-01T13:34:11.902041Z  INFO static_web_server::server: redirect trailing slash: enabled=true
# 2025-05-01T13:34:11.902076Z  INFO static_web_server::server: ignore hidden files: enabled=false
# 2025-05-01T13:34:11.902086Z  INFO static_web_server::server: disable symlinks: enabled=false
# 2025-05-01T13:34:11.902096Z  INFO static_web_server::server: grace period before graceful shutdown: 0s
# 2025-05-01T13:34:11.902268Z  INFO static_web_server::server: index files: index.html
# 2025-05-01T13:34:11.902374Z  INFO static_web_server::directory_listing: directory listing: enabled=false
# 2025-05-01T13:34:11.902386Z  INFO static_web_server::directory_listing: directory listing order code: 6
# 2025-05-01T13:34:11.902395Z  INFO static_web_server::directory_listing: directory listing format: Html
# 2025-05-01T13:34:11.902451Z  INFO static_web_server::fallback_page: fallback page: enabled=false, value=""
# 2025-05-01T13:34:11.902465Z  INFO static_web_server::health: health endpoint: enabled=false
# 2025-05-01T13:34:11.902498Z  INFO static_web_server::log_addr: log requests with remote IP addresses: enabled=false
# 2025-05-01T13:34:11.902530Z  INFO static_web_server::log_addr: log X-Real-IP header: enabled=false
# 2025-05-01T13:34:11.902541Z  INFO static_web_server::log_addr: log X-Forwarded-For header: enabled=false
# 2025-05-01T13:34:11.902551Z  INFO static_web_server::log_addr: trusted IPs for X-Forwarded-For: all
# 2025-05-01T13:34:11.902610Z  INFO static_web_server::basic_auth: basic authentication: enabled=false
# 2025-05-01T13:34:11.902645Z  INFO static_web_server::maintenance_mode: maintenance mode: enabled=false
# 2025-05-01T13:34:11.902700Z  INFO static_web_server::maintenance_mode: maintenance mode status: 503
# 2025-05-01T13:34:11.902710Z  INFO static_web_server::maintenance_mode: maintenance mode file: ""
# 2025-05-01T13:34:11.902764Z  INFO static_web_server::compression_static: compression static: enabled=false
# 2025-05-01T13:34:11.903069Z  INFO static_web_server::compression: auto compression: enabled=true, formats=deflate,gzip,brotli,zstd, compression level=Default
# 2025-05-01T13:34:11.903082Z  INFO static_web_server::control_headers: cache control headers: enabled=true
# 2025-05-01T13:34:11.903092Z  INFO static_web_server::security_headers: security headers: enabled=false
# 2025-05-01T13:34:11.903631Z  INFO Server::start_server{addr_str="[::]:8787" threads=8}: static_web_server::server: close time.busy=0.00ns time.idle=28.2µs
# 2025-05-01T13:34:11.903667Z  INFO static_web_server::server: http1 server is listening on http://[::]:8787
# 2025-05-01T13:34:11.903678Z  INFO static_web_server::server: press ctrl+c to shut down the server
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #541

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
