### PR TITLE
Add support for downloading a directory as a compressed tarball

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +150,155 @@ dependencies = [
  "zstd",
  "zstd-safe",
 ]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.0",
+ "futures-lite",
+ "rustix 0.38.44",
+ "tracing",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.44",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-tar"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42f905d4f623faf634bbd1e001e84e0efc24694afa64be9ad239bf6ca49e1f8"
+dependencies = [
+ "async-std",
+ "filetime",
+ "libc",
+ "pin-project",
+ "redox_syscall 0.2.16",
+ "xattr",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -176,6 +348,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -187,6 +365,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -461,6 +652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,10 +798,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "flate2"
@@ -642,6 +881,25 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -725,7 +983,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -750,6 +1008,18 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
  "serde",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -812,6 +1082,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "http"
@@ -1101,6 +1377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1410,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "redox_syscall 0.5.10",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1431,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1174,6 +1476,9 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "maud"
@@ -1310,6 +1615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,7 +1638,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.10",
  "smallvec",
  "windows-targets",
 ]
@@ -1371,10 +1682,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 0.38.44",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1444,7 +1781,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "memchr",
  "unicase",
 ]
@@ -1466,11 +1803,20 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1530,14 +1876,27 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -1816,6 +2175,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "async-compression",
+ "async-tar",
  "bcrypt",
  "bytes",
  "chrono",
@@ -1912,7 +2272,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -2111,6 +2471,7 @@ checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -2318,6 +2679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,6 +2757,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2799,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2479,7 +2869,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "widestring",
  "windows-sys 0.52.0",
 ]
@@ -2581,7 +2971,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2595,6 +2985,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "directory-listing", "basic-auth", "fallback-page"]
+default = ["compression", "http2", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page"]
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
 # HTTP2
@@ -51,6 +51,8 @@ compression-gzip = ["async-compression/deflate"]
 compression-zstd = ["async-compression/zstd"]
 # Directory listing
 directory-listing = ["chrono", "maud"]
+# Directory listing download
+directory-listing-download = ["async-tar",  "compression-gzip", "directory-listing"]
 # Basic HTTP Authorization
 basic-auth = ["bcrypt"]
 # Fallback Page
@@ -63,7 +65,7 @@ experimental = ["tokio-metrics-collector", "prometheus", "compact_str", "mini-mo
 aho-corasick = "1.1"
 anyhow = "1.0"
 async-compression = { version = "0.4", default-features = false, optional = true, features = ["brotli", "deflate", "gzip", "zstd", "tokio"] }
-async-tar = "0.5"
+async-tar = { version = "0.5", optional = true }
 bcrypt = { version = "0.17", optional = true }
 bytes = "1.10"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ experimental = ["tokio-metrics-collector", "prometheus", "compact_str", "mini-mo
 aho-corasick = "1.1"
 anyhow = "1.0"
 async-compression = { version = "0.4", default-features = false, optional = true, features = ["brotli", "deflate", "gzip", "zstd", "tokio"] }
+async-tar = "0.5"
 bcrypt = { version = "0.17", optional = true }
 bytes = "1.10"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"], optional = true }
@@ -92,7 +93,7 @@ serde_repr = "0.1"
 shadow-rs = "1.1.1"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"] }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "tls12", "ring"] }
-tokio-util = { version = "0.7", default-features = false, features = ["io"] }
+tokio-util = { version = "0.7", default-features = false, features = ["compat", "io"] }
 toml = "0.8"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "registry", "parking_lot", "fmt", "ansi", "tracing-log"] }

--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -72,6 +72,8 @@ Options:
           Specify a default code number to order directory listing entries per `Name`, `Last modified` or `Size` attributes (columns). Code numbers supported: 0 (Name asc), 1 (Name desc), 2 (Last modified asc), 3 (Last modified desc), 4 (Size asc), 5 (Size desc). Default 6 (unordered) [env: SERVER_DIRECTORY_LISTING_ORDER=] [default: 6]
       --directory-listing-format <DIRECTORY_LISTING_FORMAT>
           Specify a content format for directory listing entries. Formats supported: "html" or "json". Default "html" [env: SERVER_DIRECTORY_LISTING_FORMAT=] [default: html] [possible values: html, json]
+      --directory-listing-download=<DIRECTORY_LISTING_DOWNLOAD>
+          Specify list of enabled format(s) for directory download. Format supported: `targz`. Default to empty list (disabled) [env: SERVER_DIRECTORY_LISTING_DOWNLOAD=] [possible values: targz]
       --security-headers [<SECURITY_HEADERS>]
           Enable security headers by default when HTTP/2 feature is activated. Headers included: "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age), "X-Frame-Options: DENY" and "Content-Security-Policy: frame-ancestors 'self'" [env: SERVER_SECURITY_HEADERS=] [default: false] [possible values: true, false]
   -e, --cache-control-headers [<CACHE_CONTROL_HEADERS>]

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -57,6 +57,9 @@ directory-listing-order = 1
 #### Directory listing content format
 directory-listing-format = "html"
 
+#### Directory listing download format
+directory-listing-download = []
+
 #### Basic Authentication
 # basic-auth = ""
 

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -107,6 +107,9 @@ Specify a default code number to order directory listing entries per `Name`, `La
 ### SERVER_DIRECTORY_LISTING_FORMAT
 Specify a content format for the directory listing entries. Formats supported: `html` or `json`. Default `html`.
 
+### SERVER_DIRECTORY_LISTING_DOWNLOAD
+Specify list of enabled format(s) for directory download. Format supported: `targz`. Default to empty list (disabled).
+
 ### SERVER_SECURITY_HEADERS
 Enable security headers by default when the HTTP/2 feature is activated. Headers included: `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2 years max-age), `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'self'`. Default `false` (disabled).
 

--- a/docs/content/features/directory-listing.md
+++ b/docs/content/features/directory-listing.md
@@ -126,3 +126,15 @@ curl -iH "content-type: application/json" http://localhost:8787
 
 # [{"name":"spécial directöry","type":"directory","mtime":"2022-10-07T00:53:50Z"},{"name":"index.html.gz","type":"file","mtime":"2022-09-27T22:44:34Z","size":332}]⏎
 ```
+
+## Directory Download
+**`SWS`** supports downloading the content of a directory as a single file when **Directory Listing** feature is enabled. To activate, specify the list of download format to enable using the `--directory-listing-download` flag or the equivalent [SERVER_DIRECTORY_LISTING_DOWNLOAD](./../configuration/environment-variables.md#server_directory_listing_download) env. Currently, `targz` format is supported.
+
+```sh
+static-web-server \
+    --directory-listing=true \
+    --directory-listing-download=targz
+```
+
+When **Directory Download** is enabled, append `?download` to a directory URL to download it. A link will also be added to the top part of **HTML** output format.
+

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -17,6 +17,9 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::Path;
 
+#[cfg(feature = "directory-listing-download")]
+use crate::directory_listing_download::DOWNLOAD_PARAM_KEY;
+
 use crate::{handler::RequestHandlerOpts, http_ext::MethodExt, Context, Result};
 
 /// Non-alphanumeric characters to be percent-encoded
@@ -394,6 +397,15 @@ fn html_auto_index<'a>(
     let sort_attrs = sort_file_entries(entries, order_code);
     let current_path = percent_decode_str(base_path).decode_utf8_lossy();
 
+    #[cfg(feature = "directory-listing-download")]
+    let download_directory_elem = html! {
+        ",  " a href={ "?" (DOWNLOAD_PARAM_KEY) } {
+            "download .tar.gz"
+        }
+    };
+    #[cfg(not(feature = "directory-listing-download"))]
+    let download_directory_elem = html! {};
+
     html! {
         (DOCTYPE)
         html {
@@ -413,11 +425,7 @@ fn html_auto_index<'a>(
                 }
                 p {
                     small {
-                        "directories: " (dirs_count) ", files: " (files_count)
-                        // TODO: check enable dir-archive feature/opt
-                        "  " a href="?download-archive=1" {
-                            "(download all as .tar.gz)"
-                        }
+                        "directories: " (dirs_count) ", files: " (files_count) (download_directory_elem)
                     }
                 }
                 hr;

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -294,16 +294,6 @@ fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Body>> {
         file_entries.push(entry);
     }
 
-    // TODO: check enable dir-archive feature
-    // TODO: make this post process
-    file_entries.push(FileEntry {
-        name: "(download as .tar.gz)".into(),
-        mtime: None,
-        size: None,
-        r#type: FileType::File, // TODO: do we need special handling?
-        uri: "?download-archive=1".into(),
-    });
-
     // Check the query request uri for a sorting type. E.g https://blah/?sort=5
     if let Some(q) = opt.uri_query {
         let mut parts = form_urlencoded::parse(q.as_bytes());
@@ -424,6 +414,10 @@ fn html_auto_index<'a>(
                 p {
                     small {
                         "directories: " (dirs_count) ", files: " (files_count)
+                        // TODO: check enable dir-archive feature/opt
+                        "  " a href="?download-archive=1" {
+                            "(download all as .tar.gz)"
+                        }
                     }
                 }
                 hr;

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -295,12 +295,13 @@ fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Body>> {
     }
 
     // TODO: check enable dir-archive feature
+    // TODO: make this post process
     file_entries.push(FileEntry {
         name: "(download as .tar.gz)".into(),
         mtime: None,
         size: None,
         r#type: FileType::File, // TODO: do we need special handling?
-        uri: ".tar.gz".into(),
+        uri: "?download-archive=1".into(),
     });
 
     // Check the query request uri for a sorting type. E.g https://blah/?sort=5

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -294,6 +294,15 @@ fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Body>> {
         file_entries.push(entry);
     }
 
+    // TODO: check enable dir-archive feature
+    file_entries.push(FileEntry {
+        name: "(download as .tar.gz)".into(),
+        mtime: None,
+        size: None,
+        r#type: FileType::File, // TODO: do we need special handling?
+        uri: ".tar.gz".into(),
+    });
+
     // Check the query request uri for a sorting type. E.g https://blah/?sort=5
     if let Some(q) = opt.uri_query {
         let mut parts = form_urlencoded::parse(q.as_bytes());

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -411,7 +411,7 @@ fn html_auto_index<'a>(
     let download_directory_elem = match download.is_empty() {
         true => html! {},
         false => html! {
-            ",  " a href={ "?" (DOWNLOAD_PARAM_KEY) } {
+            ", " a href={ "?" (DOWNLOAD_PARAM_KEY) } {
                 "download tar.gz"
             }
         },

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -17,9 +17,8 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::Path;
 
-use crate::directory_listing_download::DirDownloadFmt;
 #[cfg(feature = "directory-listing-download")]
-use crate::directory_listing_download::DOWNLOAD_PARAM_KEY;
+use crate::directory_listing_download::{DirDownloadFmt, DOWNLOAD_PARAM_KEY};
 
 use crate::{handler::RequestHandlerOpts, http_ext::MethodExt, Context, Result};
 
@@ -348,6 +347,7 @@ fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Body>> {
                 files_count,
                 &mut file_entries,
                 opt.order_code,
+                #[cfg(feature = "directory-listing-download")]
                 opt.download,
             )
         }

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -58,7 +58,7 @@ pub struct DirListOpts<'a> {
     pub dir_listing_format: &'a DirListFmt,
     #[cfg(feature = "directory-listing-download")]
     /// Directory listing download.
-    pub dir_listing_download: &'a Vec<DirDownloadFmt>,
+    pub dir_listing_download: &'a [DirDownloadFmt],
     /// Ignore hidden files (dotfiles).
     pub ignore_hidden_files: bool,
     /// Prevent following symlinks for files and directories.
@@ -194,7 +194,7 @@ struct DirEntryOpts<'a> {
     ignore_hidden_files: bool,
     disable_symlinks: bool,
     #[cfg(feature = "directory-listing-download")]
-    download: &'a Vec<DirDownloadFmt>,
+    download: &'a [DirDownloadFmt],
 }
 
 /// It reads a list of directory entries and create an index page content.

--- a/src/directory_listing.rs
+++ b/src/directory_listing.rs
@@ -412,7 +412,7 @@ fn html_auto_index<'a>(
         true => html! {},
         false => html! {
             ",  " a href={ "?" (DOWNLOAD_PARAM_KEY) } {
-                "download .tar.gz"
+                "download tar.gz"
             }
         },
     };

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -68,7 +68,7 @@ impl tokio::io::AsyncWrite for ChannelBuffer {
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
         buf: &[u8],
-    ) -> std::task::Poll<std::result::Result<usize, std::io::Error>> {
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
         let this = self.get_mut();
         let b = BytesMut::from(buf);
         match this.s.poll_ready(cx) {
@@ -86,14 +86,14 @@ impl tokio::io::AsyncWrite for ChannelBuffer {
     fn poll_flush(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::result::Result<(), std::io::Error>> {
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
         std::task::Poll::Ready(Ok(()))
     }
 
     fn poll_shutdown(
         self: std::pin::Pin<&mut Self>,
         _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<std::result::Result<(), std::io::Error>> {
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
         std::task::Poll::Ready(Ok(()))
     }
 }
@@ -117,7 +117,7 @@ async fn archive(
     // adapted from async_tar::Builder::append_dir_all
     let mut stack = vec![(src_path.to_path_buf(), true, false)];
     while let Some((src, is_dir, is_symlink)) = stack.pop() {
-        let dest = path.join(src.strip_prefix(&src_path).unwrap());
+        let dest = path.join(src.strip_prefix(&src_path)?);
 
         // In case of a symlink pointing to a directory, is_dir is false, but src.is_dir() will return true
         if is_dir || (is_symlink && follow_symlinks && src.is_dir()) {
@@ -177,7 +177,7 @@ where
         Err(err) => {
             // not fatal, most browser is able to handle the download since
             // content-type is set
-            tracing::error!("cant make content disposition from {}: {:?}", hvals, err);
+            tracing::error!("can't make content disposition from {}: {:?}", hvals, err);
         }
     }
 

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -33,8 +33,6 @@ pub const DOWNLOAD_PARAM_KEY: &str = "download";
 #[derive(Debug, Serialize, Deserialize, Clone, ValueEnum, Eq, Hash, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum DirDownloadFmt {
-    /// Disable directory download
-    None,
     /// Gunzip-compressed tarball (.tar.gz)
     Targz,
 }
@@ -51,15 +49,7 @@ pub struct DirDownloadOpts<'a> {
 
 /// Initializes directory listing download
 pub fn init(formats: &Vec<DirDownloadFmt>, handler_opts: &mut RequestHandlerOpts) {
-    let mut is_none = false;
     for fmt in formats {
-        if *fmt == DirDownloadFmt::None {
-            is_none = true;
-            continue;
-        }
-        if is_none {
-            panic!("Setting directory-listing-download to {:?} when None is also specified is not allowed", *fmt);
-        }
         // Use naive implementation since the list is not expected to be long
         if !handler_opts.dir_listing_download.contains(fmt) {
             handler_opts.dir_listing_download.push(fmt.to_owned());

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -14,6 +14,7 @@ use headers::{ContentType, HeaderMapExt};
 use http::{HeaderValue, Method, Response};
 use hyper::{body::Sender, Body};
 use mime_guess::Mime;
+use std::fmt::Display;
 use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -38,6 +39,12 @@ pub enum DirDownloadFmt {
     Targz,
 }
 
+impl Display for DirDownloadFmt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
 /// Directory download options.
 pub struct DirDownloadOpts<'a> {
     /// Request method.
@@ -53,6 +60,7 @@ pub fn init(formats: &Vec<DirDownloadFmt>, handler_opts: &mut RequestHandlerOpts
     for fmt in formats {
         // Use naive implementation since the list is not expected to be long
         if !handler_opts.dir_listing_download.contains(fmt) {
+            tracing::info!("directory listing download: enabled format {}", &fmt);
             handler_opts.dir_listing_download.push(fmt.to_owned());
         }
     }

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -62,8 +62,7 @@ impl tokio::io::AsyncWrite for ChannelBuffer {
     }
 }
 
-/// archive reply
-pub fn archive_dir<P, Q>(path: P, src_path: Q) -> Body
+fn archive_dir<P, Q>(path: P, src_path: Q) -> Body
 where
     P: AsRef<Path>,
     Q: AsRef<Path>,
@@ -94,7 +93,11 @@ where
     body
 }
 
-/// archive reply
+/// Reply with archived directory content in compressed tarball format.
+/// The content from `src_path` on server filesystem will be stored to `path`
+/// within the tarball.
+/// An async task will be spawned to asynchronously write compressed data to the
+/// response body.
 pub fn archive_reply<P, Q>(path: P, src_path: Q) -> Response<Body>
 where
     P: AsRef<Path>,
@@ -109,8 +112,6 @@ where
     resp.headers_mut().typed_insert(ContentType::from(
         Mime::from_str("application/gzip").unwrap(),
     ));
-    // TODO: investigate ContentDisposition from headers crate
-    // TODO: investigate HeaderValue from_maybe_shared
     match HeaderValue::from_str(hvals.as_str()) {
         Ok(hval) => {
             resp.headers_mut()

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -148,19 +148,23 @@ where
 {
     let archive_name = path.as_ref().with_extension("tar.gz");
     let mut resp = Response::new(Body::empty());
+
+    resp.headers_mut().typed_insert(ContentType::from(
+        // since this satisfies the required format: `*/*`, it should not fail
+        Mime::from_str("application/gzip").unwrap(),
+    ));
     let hvals = format!(
         "attachment; filename=\"{}\"",
         archive_name.to_string_lossy()
     );
-    resp.headers_mut().typed_insert(ContentType::from(
-        Mime::from_str("application/gzip").unwrap(),
-    ));
     match HeaderValue::from_str(hvals.as_str()) {
         Ok(hval) => {
             resp.headers_mut()
                 .insert(hyper::header::CONTENT_DISPOSITION, hval);
         }
         Err(err) => {
+            // not fatal, most browser is able to handle the download since
+            // content-type is set
             tracing::error!("cant make content disposition from {}: {:?}", hvals, err);
         }
     }

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -64,6 +64,10 @@ pub fn init(formats: &Vec<DirDownloadFmt>, handler_opts: &mut RequestHandlerOpts
             handler_opts.dir_listing_download.push(fmt.to_owned());
         }
     }
+    tracing::info!(
+        "directory listing download: enabled={}",
+        !handler_opts.dir_listing_download.is_empty()
+    );
 }
 
 /// impl AsyncWrite for hyper::Body::Sender

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -72,7 +72,6 @@ impl tokio::io::AsyncWrite for ChannelBuffer {
         cx: &mut std::task::Context<'_>,
         buf: &[u8],
     ) -> std::task::Poll<std::result::Result<usize, std::io::Error>> {
-        // TODO: what kind of error may be encountered?
         let this = self.get_mut();
         let b = BytesMut::from(buf);
         match this.s.poll_ready(cx) {

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -9,6 +9,7 @@
 use async_compression::tokio::write::GzipEncoder;
 use async_tar::Builder;
 use bytes::BytesMut;
+use clap::ValueEnum;
 use headers::{ContentType, HeaderMapExt};
 use http::{HeaderValue, Response};
 use hyper::{body::Sender, Body};
@@ -18,8 +19,38 @@ use std::{ffi::OsString, path::Path};
 use tokio::io::{self, AsyncWriteExt};
 use tokio_util::compat::TokioAsyncWriteCompatExt;
 
+use crate::handler::RequestHandlerOpts;
+
 /// query parameter key to download directory as tar.gz
 pub const DOWNLOAD_PARAM_KEY: &str = "download";
+
+/// Download format for directory
+#[derive(Debug, Serialize, Deserialize, Clone, ValueEnum, Eq, Hash, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum DirDownloadFmt {
+    /// Disable directory download
+    None,
+    /// Gunzip-compressed tarball (.tar.gz)
+    Targz,
+}
+
+/// Initializes directory listing download
+pub fn init(formats: &Vec<DirDownloadFmt>, handler_opts: &mut RequestHandlerOpts) {
+    let mut is_none = false;
+    for fmt in formats {
+        if *fmt == DirDownloadFmt::None {
+            is_none = true;
+            continue;
+        }
+        if is_none {
+            panic!("Setting directory-listing-download to {:?} when None is also specified is not allowed", *fmt);
+        }
+        // Use naive implementation since the list is not expected to be long
+        if !handler_opts.dir_listing_download.contains(fmt) {
+            handler_opts.dir_listing_download.push(fmt.to_owned());
+        }
+    }
+}
 
 /// impl AsyncWrite for hyper::Body::Sender
 pub struct ChannelBuffer {

--- a/src/fs/meta.rs
+++ b/src/fs/meta.rs
@@ -72,4 +72,3 @@ pub(crate) fn try_metadata_with_html_suffix(
 
     (file_path, None)
 }
-

--- a/src/fs/meta.rs
+++ b/src/fs/meta.rs
@@ -73,26 +73,3 @@ pub(crate) fn try_metadata_with_html_suffix(
     (file_path, None)
 }
 
-pub(crate) fn try_metadata_without_dir_archive_suffix(
-    file_path: &mut PathBuf,
-) -> (&mut PathBuf, Option<Metadata>) {
-    tracing::debug!("file: removing .tar.gz part from path");
-
-    let cfp = file_path.to_owned();
-    if let Some(filename) = cfp.file_name() {
-        file_path.pop();
-
-        if let Ok(meta_res) = try_metadata(file_path) {
-            let (meta, _) = meta_res;
-            if meta.is_dir() {
-                return (file_path, Some(meta));
-            }
-        }
-
-        tracing::debug!("file: the dir of the .tar.gz suffixed path doesn't exist, falling back to the original");
-
-        file_path.push(filename);
-    }
-
-    (file_path, None)
-}

--- a/src/fs/meta.rs
+++ b/src/fs/meta.rs
@@ -72,3 +72,27 @@ pub(crate) fn try_metadata_with_html_suffix(
 
     (file_path, None)
 }
+
+pub(crate) fn try_metadata_without_dir_archive_suffix(
+    file_path: &mut PathBuf,
+) -> (&mut PathBuf, Option<Metadata>) {
+    tracing::debug!("file: removing .tar.gz part from path");
+
+    let cfp = file_path.to_owned();
+    if let Some(filename) = cfp.file_name() {
+        file_path.pop();
+
+        if let Ok(meta_res) = try_metadata(file_path) {
+            let (meta, _) = meta_res;
+            if meta.is_dir() {
+                return (file_path, Some(meta));
+            }
+        }
+
+        tracing::debug!("file: the dir of the .tar.gz suffixed path doesn't exist, falling back to the original");
+
+        file_path.push(filename);
+    }
+
+    (file_path, None)
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -157,6 +157,7 @@ impl Default for RequestHandlerOpts {
             dir_listing_order: 6, // unordered
             #[cfg(feature = "directory-listing")]
             dir_listing_format: DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
             dir_listing_download: Vec::new(),
             cors: None,
             #[cfg(feature = "experimental")]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -47,6 +47,9 @@ use crate::{
 #[cfg(feature = "directory-listing")]
 use crate::directory_listing::DirListFmt;
 
+#[cfg(feature = "directory-listing-download")]
+use crate::directory_listing_download::DirDownloadFmt;
+
 /// It defines options for a request handler.
 pub struct RequestHandlerOpts {
     // General options
@@ -80,6 +83,10 @@ pub struct RequestHandlerOpts {
     #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing")))]
     /// Directory listing format feature.
     pub dir_listing_format: DirListFmt,
+    /// Directory listing download feature.
+    #[cfg(feature = "directory-listing-download")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing-download")))]
+    pub dir_listing_download: Vec<DirDownloadFmt>,
     /// CORS feature.
     pub cors: Option<cors::Configured>,
     /// Security headers feature.
@@ -150,6 +157,7 @@ impl Default for RequestHandlerOpts {
             dir_listing_order: 6, // unordered
             #[cfg(feature = "directory-listing")]
             dir_listing_format: DirListFmt::Html,
+            dir_listing_download: Vec::new(),
             cors: None,
             #[cfg(feature = "experimental")]
             memory_cache: None,
@@ -200,6 +208,8 @@ impl RequestHandler {
         let dir_listing_order = self.opts.dir_listing_order;
         #[cfg(feature = "directory-listing")]
         let dir_listing_format = &self.opts.dir_listing_format;
+        #[cfg(feature = "directory-listing-download")]
+        let dir_listing_download = &self.opts.dir_listing_download;
         let redirect_trailing_slash = self.opts.redirect_trailing_slash;
         let compression_static = self.opts.compression_static;
         let ignore_hidden_files = self.opts.ignore_hidden_files;
@@ -286,6 +296,8 @@ impl RequestHandler {
                 dir_listing_order,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download,
                 redirect_trailing_slash,
                 compression_static,
                 ignore_hidden_files,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,9 @@ pub mod custom_headers;
 #[cfg(feature = "directory-listing")]
 #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing")))]
 pub mod directory_listing;
+#[cfg(feature = "directory-listing-download")]
+#[cfg_attr(docsrs, doc(cfg(feature = "directory-listing-download")))]
+pub mod directory_listing_download;
 pub mod error_page;
 #[cfg(feature = "fallback-page")]
 #[cfg_attr(docsrs, doc(cfg(feature = "fallback-page")))]

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,6 +29,10 @@ use {
 
 #[cfg(feature = "directory-listing")]
 use crate::directory_listing;
+
+#[cfg(feature = "directory-listing-download")]
+use crate::directory_listing_download;
+
 #[cfg(feature = "fallback-page")]
 use crate::fallback_page;
 
@@ -48,7 +52,7 @@ use crate::basic_auth;
 use crate::mem_cache;
 
 use crate::{
-    control_headers, cors, directory_listing_download, health, helpers, log_addr, maintenance_mode,
+    control_headers, cors, health, helpers, log_addr, maintenance_mode,
     security_headers, Settings,
 };
 use crate::{service::RouterService, Context, Result};

--- a/src/server.rs
+++ b/src/server.rs
@@ -52,8 +52,7 @@ use crate::basic_auth;
 use crate::mem_cache;
 
 use crate::{
-    control_headers, cors, health, helpers, log_addr, maintenance_mode,
-    security_headers, Settings,
+    control_headers, cors, health, helpers, log_addr, maintenance_mode, security_headers, Settings,
 };
 use crate::{service::RouterService, Context, Result};
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -48,7 +48,8 @@ use crate::basic_auth;
 use crate::mem_cache;
 
 use crate::{
-    control_headers, cors, health, helpers, log_addr, maintenance_mode, security_headers, Settings,
+    control_headers, cors, directory_listing_download, health, helpers, log_addr, maintenance_mode,
+    security_headers, Settings,
 };
 use crate::{service::RouterService, Context, Result};
 
@@ -289,6 +290,10 @@ impl Server {
             general.directory_listing_format,
             &mut handler_opts,
         );
+
+        // Directory listing download options
+        #[cfg(feature = "directory-listing-download")]
+        directory_listing_download::init(&general.directory_listing_download, &mut handler_opts);
 
         // Fallback page option
         #[cfg(feature = "fallback-page")]

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -382,7 +382,6 @@ pub struct General {
     /// Specify list of directory download format to be enabled, empty list disables the feature. Formats supported: "none" or "targz". Default "none".
     pub directory_listing_download: Vec<DirDownloadFmt>,
 
-
     #[arg(
         long,
         default_value = "false",

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -373,7 +373,9 @@ pub struct General {
         value_enum,
         default_value = "none",
         default_missing_value("none"),
-        requires_if("true", "directory_listing"),
+        requires_ifs([
+            ("targz", "directory_listing"),
+        ]),
         require_equals(true),
         action = clap::ArgAction::Set,
         env = "SERVER_DIRECTORY_LISTING_DOWNLOAD",

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -11,6 +11,10 @@ use std::{net::IpAddr, path::PathBuf};
 
 #[cfg(feature = "directory-listing")]
 use crate::directory_listing::DirListFmt;
+
+#[cfg(feature = "directory-listing-download")]
+use crate::directory_listing_download::DirDownloadFmt;
+
 use crate::Result;
 
 /// General server configuration available in CLI and config file options.
@@ -360,6 +364,24 @@ pub struct General {
     )]
     /// Specify a content format for directory listing entries. Formats supported: "html" or "json". Default "html".
     pub directory_listing_format: DirListFmt,
+
+    #[cfg(feature = "directory-listing-download")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing-download")))]
+    #[arg(
+        long,
+        value_delimiter(','),
+        value_enum,
+        default_value = "none",
+        default_missing_value("none"),
+        requires_if("true", "directory_listing"),
+        require_equals(true),
+        action = clap::ArgAction::Set,
+        env = "SERVER_DIRECTORY_LISTING_DOWNLOAD",
+        ignore_case(true)
+    )]
+    /// Specify list of directory download format to be enabled, empty list disables the feature. Formats supported: "none" or "targz". Default "none".
+    pub directory_listing_download: Vec<DirDownloadFmt>,
+
 
     #[arg(
         long,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -379,7 +379,7 @@ pub struct General {
         env = "SERVER_DIRECTORY_LISTING_DOWNLOAD",
         ignore_case(true)
     )]
-    /// Specify list of directory download format to be enabled, empty list disables the feature. Formats supported: "none" or "targz". Default "none".
+    /// Specify list of enabled format(s) for directory download. Format supported: `targz`. Default to empty list (disabled).
     pub directory_listing_download: Vec<DirDownloadFmt>,
 
     #[arg(

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -371,8 +371,6 @@ pub struct General {
         long,
         value_delimiter(','),
         value_enum,
-        default_value = "none",
-        default_missing_value("none"),
         requires_ifs([
             ("targz", "directory_listing"),
         ]),

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -15,6 +15,9 @@ use std::{collections::BTreeSet, path::PathBuf};
 #[cfg(feature = "directory-listing")]
 use crate::directory_listing::DirListFmt;
 
+#[cfg(feature = "directory-listing-download")]
+use crate::directory_listing_download::DirDownloadFmt;
+
 use crate::{helpers, Context, Result};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -333,6 +336,11 @@ pub struct General {
     #[cfg(feature = "directory-listing")]
     #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing")))]
     pub directory_listing_format: Option<DirListFmt>,
+
+    /// Directory listing download feature.
+    #[cfg(feature = "directory-listing-download")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing-download")))]
+    pub directory_listing_download: Option<Vec<DirDownloadFmt>>,
 
     /// Basic Authentication feature.
     #[cfg(feature = "basic-auth")]

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -186,6 +186,9 @@ impl Settings {
         #[cfg(feature = "directory-listing")]
         let mut directory_listing_format = opts.directory_listing_format;
 
+        #[cfg(feature = "directory-listing-download")]
+        let mut directory_listing_download = opts.directory_listing_download;
+
         #[cfg(feature = "basic-auth")]
         let mut basic_auth = opts.basic_auth;
 
@@ -346,6 +349,10 @@ impl Settings {
                 #[cfg(feature = "directory-listing")]
                 if let Some(v) = general.directory_listing_format {
                     directory_listing_format = v
+                }
+                #[cfg(feature = "directory-listing-download")]
+                if let Some(v) = general.directory_listing_download {
+                    directory_listing_download = v
                 }
                 #[cfg(feature = "basic-auth")]
                 if let Some(ref v) = general.basic_auth {
@@ -663,6 +670,8 @@ impl Settings {
                 directory_listing_order,
                 #[cfg(feature = "directory-listing")]
                 directory_listing_format,
+                #[cfg(feature = "directory-listing-download")]
+                directory_listing_download,
                 #[cfg(feature = "basic-auth")]
                 basic_auth,
                 fd,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -188,46 +188,47 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
         });
     }
 
-    // Directory listing download
-    // Check if "directory listing download" feature is enabled,
-    // if current path is a valid directory and
-    // if query string has parameter "download" set
-    #[cfg(feature = "directory-listing-download")]
-    if is_dir && !opts.dir_listing_download.is_empty() {
-        if let Some((_k, _dl_archive_opt)) =
-            form_urlencoded::parse(opts.uri_query.unwrap_or("").as_bytes())
-                .find(|(k, _v)| k == DOWNLOAD_PARAM_KEY)
-        {
-            // file path is index.html, need pop
-            let mut fp = file_path.clone();
-            fp.pop();
-            if let Some(filename) = fp.file_name() {
-                let resp = archive_reply(
-                    filename,
-                    &fp,
-                    DirDownloadOpts {
-                        method,
-                        disable_symlinks: opts.disable_symlinks,
-                        ignore_hidden_files: opts.ignore_hidden_files,
-                    },
-                );
-                return Ok(StaticFileResponse {
-                    resp,
-                    file_path: resp_file_path,
-                });
-            } else {
-                tracing::error!("Unable to get filename from {}", fp.to_string_lossy());
-                return Err(StatusCode::INTERNAL_SERVER_ERROR);
-            }
-        }
-    }
-
     // Directory listing
     // Check if "directory listing" feature is enabled,
     // if current path is a valid directory and
     // if it does not contain an `index.html` file (if a proper auto index is generated)
     #[cfg(feature = "directory-listing")]
     if is_dir && opts.dir_listing && !file_path.exists() {
+
+        // Directory listing download
+        // Check if "directory listing download" feature is enabled,
+        // if current path is a valid directory and
+        // if query string has parameter "download" set
+        #[cfg(feature = "directory-listing-download")]
+        if !opts.dir_listing_download.is_empty() {
+            if let Some((_k, _dl_archive_opt)) =
+                form_urlencoded::parse(opts.uri_query.unwrap_or("").as_bytes())
+                    .find(|(k, _v)| k == DOWNLOAD_PARAM_KEY)
+            {
+                // file path is index.html, need pop
+                let mut fp = file_path.clone();
+                fp.pop();
+                if let Some(filename) = fp.file_name() {
+                    let resp = archive_reply(
+                        filename,
+                        &fp,
+                        DirDownloadOpts {
+                            method,
+                            disable_symlinks: opts.disable_symlinks,
+                            ignore_hidden_files: opts.ignore_hidden_files,
+                        },
+                    );
+                    return Ok(StaticFileResponse {
+                        resp,
+                        file_path: resp_file_path,
+                    });
+                } else {
+                    tracing::error!("Unable to get filename from {}", fp.to_string_lossy());
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+            }
+        }
+
         let resp = directory_listing::auto_index(DirListOpts {
             method,
             current_path: uri_path,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -16,7 +16,6 @@ use std::io;
 use std::path::PathBuf;
 
 use crate::conditional_headers::ConditionalHeaders;
-use crate::directory_listing_download::DirDownloadOpts;
 use crate::fs::meta::{try_metadata, try_metadata_with_html_suffix, FileMetadata};
 use crate::fs::path::{sanitize_path, PathExt};
 use crate::http_ext::{MethodExt, HTTP_SUPPORTED_METHODS};
@@ -42,7 +41,7 @@ use crate::{
 };
 
 #[cfg(feature = "directory-listing-download")]
-use crate::directory_listing_download::{archive_reply, DirDownloadFmt, DOWNLOAD_PARAM_KEY};
+use crate::directory_listing_download::{archive_reply, DirDownloadFmt, DirDownloadOpts, DOWNLOAD_PARAM_KEY};
 
 const DEFAULT_INDEX_FILES: &[&str; 1] = &["index.html"];
 

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -16,6 +16,7 @@ use std::io;
 use std::path::PathBuf;
 
 use crate::conditional_headers::ConditionalHeaders;
+use crate::directory_listing_download::DirDownloadOpts;
 use crate::fs::meta::{try_metadata, try_metadata_with_html_suffix, FileMetadata};
 use crate::fs::path::{sanitize_path, PathExt};
 use crate::http_ext::{MethodExt, HTTP_SUPPORTED_METHODS};
@@ -200,7 +201,13 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
             let mut fp = file_path.clone();
             fp.pop();
             if let Some(filename) = fp.file_name() {
-                let resp = archive_reply(filename, &fp);
+                let resp = archive_reply(
+                    filename,
+                    &fp,
+                    DirDownloadOpts {
+                        disable_symlinks: opts.disable_symlinks,
+                    },
+                );
                 return Ok(StaticFileResponse {
                     resp,
                     file_path: resp_file_path,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -208,6 +208,7 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
                     DirDownloadOpts {
                         method,
                         disable_symlinks: opts.disable_symlinks,
+                        ignore_hidden_files: opts.ignore_hidden_files,
                     },
                 );
                 return Ok(StaticFileResponse {

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -205,6 +205,7 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
                     filename,
                     &fp,
                     DirDownloadOpts {
+                        method,
                         disable_symlinks: opts.disable_symlinks,
                     },
                 );

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -194,7 +194,6 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
     // if it does not contain an `index.html` file (if a proper auto index is generated)
     #[cfg(feature = "directory-listing")]
     if is_dir && opts.dir_listing && !file_path.exists() {
-
         // Directory listing download
         // Check if "directory listing download" feature is enabled,
         // if current path is a valid directory and

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -41,7 +41,9 @@ use crate::{
 };
 
 #[cfg(feature = "directory-listing-download")]
-use crate::directory_listing_download::{archive_reply, DirDownloadFmt, DirDownloadOpts, DOWNLOAD_PARAM_KEY};
+use crate::directory_listing_download::{
+    archive_reply, DirDownloadFmt, DirDownloadOpts, DOWNLOAD_PARAM_KEY,
+};
 
 const DEFAULT_INDEX_FILES: &[&str; 1] = &["index.html"];
 
@@ -213,7 +215,8 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
                     file_path: resp_file_path,
                 });
             } else {
-                panic!("unexpected error {}", file_path.to_string_lossy());
+                tracing::error!("Unable to get filename from {}", fp.to_string_lossy());
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
         }
     }

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -78,7 +78,7 @@ pub struct HandleOpts<'a> {
     /// Directory listing download feature.
     #[cfg(feature = "directory-listing-download")]
     #[cfg_attr(docsrs, doc(cfg(feature = "directory-listing-download")))]
-    pub dir_listing_download: &'a Vec<DirDownloadFmt>,
+    pub dir_listing_download: &'a [DirDownloadFmt],
     /// Redirect trailing slash feature.
     pub redirect_trailing_slash: bool,
     /// Compression static feature.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -85,6 +85,8 @@ pub mod fixtures {
             dir_listing_order: general.directory_listing_order,
             #[cfg(feature = "directory-listing")]
             dir_listing_format: general.directory_listing_format,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: general.directory_listing_download,
             // TODO: add support or `cors` when required
             cors: None,
             security_headers: general.security_headers,

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -57,7 +57,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -94,7 +94,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -141,7 +141,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -188,7 +188,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -225,7 +225,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -283,7 +283,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -359,7 +359,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -408,7 +408,7 @@ mod tests {
                 disable_symlinks: false,
                 index_files: &[],
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {
@@ -456,7 +456,7 @@ mod tests {
                 ignore_hidden_files: true,
                 disable_symlinks: false,
                 index_files: &[],
-                dir_listing_download: &vec![DirDownloadFmt::Targz],
+                dir_listing_download: &[DirDownloadFmt::Targz],
             })
             .await
             {
@@ -504,7 +504,7 @@ mod tests {
                 ignore_hidden_files: true,
                 disable_symlinks: false,
                 index_files: &[],
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
             })
             .await
             {

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -53,6 +53,8 @@ mod tests {
                 ignore_hidden_files: false,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {
@@ -88,6 +90,8 @@ mod tests {
                 ignore_hidden_files: false,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {
@@ -133,6 +137,8 @@ mod tests {
                 ignore_hidden_files: false,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {
@@ -178,6 +184,8 @@ mod tests {
                 ignore_hidden_files: false,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {
@@ -213,6 +221,8 @@ mod tests {
                 ignore_hidden_files: false,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {
@@ -269,6 +279,8 @@ mod tests {
                 ignore_hidden_files: true,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {
@@ -343,6 +355,8 @@ mod tests {
                 ignore_hidden_files: false,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {
@@ -390,6 +404,8 @@ mod tests {
                 ignore_hidden_files: true,
                 disable_symlinks: false,
                 index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
             })
             .await
             {

--- a/tests/dir_listing_download.rs
+++ b/tests/dir_listing_download.rs
@@ -1,0 +1,304 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(dead_code)]
+
+#[cfg(feature = "directory-listing-download")]
+#[cfg(test)]
+mod tests {
+    use async_compression::tokio::bufread::GzipDecoder;
+    use async_tar::Archive;
+    use futures_util::StreamExt;
+    use headers::HeaderMap;
+    use http::{Method, StatusCode};
+    use std::{
+        collections::HashSet,
+        path::{Path, PathBuf},
+        pin::Pin,
+    };
+    use tokio_util::compat::TokioAsyncReadCompatExt;
+
+    use static_web_server::{
+        directory_listing::DirListFmt,
+        directory_listing_download::DirDownloadOpts,
+        static_files::{self, HandleOpts},
+    };
+
+    use static_web_server::directory_listing_download::{DirDownloadFmt, DOWNLOAD_PARAM_KEY};
+
+    const METHODS: [Method; 8] = [
+        Method::CONNECT,
+        Method::DELETE,
+        Method::GET,
+        Method::HEAD,
+        Method::PATCH,
+        Method::POST,
+        Method::PUT,
+        Method::TRACE,
+    ];
+
+    fn root_dir<P: AsRef<Path>>(dir: P) -> PathBuf
+    where
+        PathBuf: From<P>,
+    {
+        PathBuf::from(dir)
+    }
+
+    async fn get_tarball_content(body: hyper::body::Bytes) -> HashSet<PathBuf> {
+        let reader = Archive::new(GzipDecoder::new(&body as &[u8]).compat());
+
+        let mut content = HashSet::new();
+        // adapted from async_tar::Archive::unpack
+        let mut entries = reader.entries().unwrap();
+        let mut pinned = Pin::new(&mut entries);
+        while let Some(entry) = pinned.next().await {
+            let file = entry.unwrap();
+            content.insert(file.header().path().unwrap().to_path_buf().into());
+        }
+        content
+    }
+
+    // Remove rprefix from path (used when converting from fs-space path to
+    // tar-space path), and optionally add aprefix to path (used when converting
+    // symlinked path to tar-space path).
+    fn adjust_path<P, Q, R>(path: P, rprefix: Q, aprefix: Option<R>) -> PathBuf
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+        R: AsRef<Path>,
+    {
+        if let Some(add_prefix) = aprefix {
+            add_prefix
+                .as_ref()
+                .to_path_buf()
+                .join(path.as_ref().strip_prefix(&rprefix).unwrap())
+        } else {
+            path.as_ref().strip_prefix(&rprefix).unwrap().to_path_buf()
+        }
+    }
+
+    fn _add_dir_content(
+        content: &mut HashSet<PathBuf>,
+        path: PathBuf,
+        rprefix: PathBuf,
+        aprefix: Option<PathBuf>,
+        opts: &DirDownloadOpts<'_>,
+    ) {
+        // add self
+        content.insert(adjust_path(&path, &rprefix, aprefix.as_ref()));
+
+        for entry in std::fs::read_dir(&path).unwrap() {
+            let file = entry.unwrap();
+            let fp = file.path();
+            content.insert(adjust_path(&fp, &rprefix, aprefix.as_ref()));
+            let meta = file.metadata().unwrap();
+            if meta.is_dir() {
+                _add_dir_content(content, fp.clone(), rprefix.clone(), aprefix.clone(), &opts);
+            }
+            if meta.is_symlink() {
+                let link = std::fs::canonicalize(&fp).unwrap();
+                let meta = std::fs::metadata(&link).unwrap();
+                if meta.is_dir() && !opts.disable_symlinks {
+                    _add_dir_content(
+                        content,
+                        link.clone(),
+                        link,
+                        Some(adjust_path(&fp, &rprefix, aprefix.as_ref())),
+                        opts,
+                    );
+                }
+            }
+        }
+    }
+
+    fn get_dir_content<P>(src_path: P, opts: DirDownloadOpts<'_>) -> HashSet<PathBuf>
+    where
+        P: AsRef<Path>,
+    {
+        let mut content = HashSet::new();
+        let mut prefix = PathBuf::from(src_path.as_ref());
+        prefix.pop();
+
+        _add_dir_content(
+            &mut content,
+            src_path.as_ref().to_path_buf().to_owned(),
+            prefix,
+            None,
+            &opts,
+        );
+        content
+    }
+
+    #[tokio::test]
+    async fn dir_listing_download_targz() {
+        let base_path = root_dir("tests/fixtures/public");
+        let disable_symlinks = false;
+        for method in METHODS {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &HeaderMap::new(),
+                base_path: &base_path,
+                uri_path: "/",
+                uri_query: Some(DOWNLOAD_PARAM_KEY),
+                #[cfg(feature = "experimental")]
+                memory_cache: None,
+                dir_listing: true,
+                dir_listing_order: 1,
+                dir_listing_format: &DirListFmt::Html,
+                redirect_trailing_slash: true,
+                compression_static: false,
+                ignore_hidden_files: true,
+                disable_symlinks,
+                index_files: &[],
+                dir_listing_download: &vec![DirDownloadFmt::Targz],
+            })
+            .await
+            {
+                Ok(result) => {
+                    let mut res = result.resp;
+                    assert_eq!(res.status(), 200);
+                    assert_eq!(res.headers()["content-type"], "application/gzip");
+                    assert!(res.headers()["content-disposition"]
+                        .to_str()
+                        .unwrap()
+                        .starts_with("attachment"));
+
+                    let body = hyper::body::to_bytes(res.body_mut())
+                        .await
+                        .expect("unexpected bytes error during `body` conversion");
+
+                    if method == Method::GET {
+                        let left = get_tarball_content(body).await;
+                        let right = get_dir_content(
+                            &base_path,
+                            DirDownloadOpts {
+                                method: &method,
+                                disable_symlinks,
+                            },
+                        );
+
+                        if left != right {
+                            eprintln!("left - right {:?}", (left.difference(&right)));
+                            eprintln!("right - left {:?}", (right.difference(&left)));
+                        }
+
+                        assert_eq!(left, right);
+                    } else {
+                        assert!(body.len() == 0);
+                    }
+                }
+                Err(status) => {
+                    assert!(method != Method::GET && method != Method::HEAD);
+                    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn dir_listing_download_targz_no_symlinks() {
+        let base_path = root_dir("tests/fixtures/public");
+        let disable_symlinks = true;
+        for method in METHODS {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &HeaderMap::new(),
+                base_path: &base_path,
+                uri_path: "/",
+                uri_query: Some(DOWNLOAD_PARAM_KEY),
+                #[cfg(feature = "experimental")]
+                memory_cache: None,
+                dir_listing: true,
+                dir_listing_order: 1,
+                dir_listing_format: &DirListFmt::Html,
+                redirect_trailing_slash: true,
+                compression_static: false,
+                ignore_hidden_files: true,
+                disable_symlinks,
+                index_files: &[],
+                dir_listing_download: &vec![DirDownloadFmt::Targz],
+            })
+            .await
+            {
+                Ok(result) => {
+                    let mut res = result.resp;
+                    assert_eq!(res.status(), 200);
+                    assert_eq!(res.headers()["content-type"], "application/gzip");
+                    assert!(res.headers()["content-disposition"]
+                        .to_str()
+                        .unwrap()
+                        .starts_with("attachment"));
+
+                    let body = hyper::body::to_bytes(res.body_mut())
+                        .await
+                        .expect("unexpected bytes error during `body` conversion");
+
+                    if method == Method::GET {
+                        let left = get_tarball_content(body).await;
+                        let right = get_dir_content(
+                            &base_path,
+                            DirDownloadOpts {
+                                method: &method,
+                                disable_symlinks,
+                            },
+                        );
+
+                        if left != right {
+                            eprintln!("left - right {:?}", (left.difference(&right)));
+                            eprintln!("right - left {:?}", (right.difference(&left)));
+                        }
+
+                        assert_eq!(left, right);
+                    } else {
+                        assert!(body.len() == 0);
+                    }
+                }
+                Err(status) => {
+                    assert!(method != Method::GET && method != Method::HEAD);
+                    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn dir_listing_download_when_disabled() {
+        for method in METHODS {
+            match static_files::handle(&HandleOpts {
+                method: &method,
+                headers: &HeaderMap::new(),
+                base_path: &root_dir("tests/fixtures/public"),
+                uri_path: "/",
+                uri_query: Some(DOWNLOAD_PARAM_KEY),
+                #[cfg(feature = "experimental")]
+                memory_cache: None,
+                dir_listing: true,
+                dir_listing_order: 1,
+                dir_listing_format: &DirListFmt::Html,
+                redirect_trailing_slash: true,
+                compression_static: false,
+                ignore_hidden_files: true,
+                disable_symlinks: false,
+                index_files: &[],
+                dir_listing_download: &vec![],
+            })
+            .await
+            {
+                Ok(result) => {
+                    let res = result.resp;
+                    assert_eq!(res.status(), 200);
+                    assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
+                    assert!(res
+                        .headers()
+                        .iter()
+                        .find(|(k, _v)| *k == "content-disposition")
+                        .is_none());
+                }
+                Err(status) => {
+                    assert!(method != Method::GET && method != Method::HEAD);
+                    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+                }
+            }
+        }
+    }
+}

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -56,7 +56,7 @@ mod tests {
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             #[cfg(feature = "directory-listing-download")]
-            dir_listing_download: &vec![],
+            dir_listing_download: &[],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -104,7 +104,7 @@ mod tests {
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             #[cfg(feature = "directory-listing-download")]
-            dir_listing_download: &vec![],
+            dir_listing_download: &[],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -153,7 +153,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -189,7 +189,7 @@ mod tests {
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             #[cfg(feature = "directory-listing-download")]
-            dir_listing_download: &vec![],
+            dir_listing_download: &[],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -227,7 +227,7 @@ mod tests {
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             #[cfg(feature = "directory-listing-download")]
-            dir_listing_download: &vec![],
+            dir_listing_download: &[],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -264,7 +264,7 @@ mod tests {
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
             #[cfg(feature = "directory-listing-download")]
-            dir_listing_download: &vec![],
+            dir_listing_download: &[],
             redirect_trailing_slash: false,
             compression_static: false,
             ignore_hidden_files: false,
@@ -306,7 +306,7 @@ mod tests {
                     #[cfg(feature = "directory-listing")]
                     dir_listing_format: &DirListFmt::Html,
                     #[cfg(feature = "directory-listing-download")]
-                    dir_listing_download: &vec![],
+                    dir_listing_download: &[],
                     redirect_trailing_slash: true,
                     compression_static: false,
                     ignore_hidden_files: false,
@@ -363,7 +363,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -402,7 +402,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -443,7 +443,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -485,7 +485,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -530,7 +530,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -573,7 +573,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -614,7 +614,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -654,7 +654,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -698,7 +698,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -785,7 +785,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -860,7 +860,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -914,7 +914,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -968,7 +968,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1023,7 +1023,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1070,7 +1070,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1127,7 +1127,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1181,7 +1181,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1235,7 +1235,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1292,7 +1292,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1339,7 +1339,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1385,7 +1385,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1446,7 +1446,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1499,7 +1499,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,
@@ -1543,7 +1543,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,
@@ -1589,7 +1589,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,
@@ -1625,7 +1625,7 @@ mod tests {
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
                 #[cfg(feature = "directory-listing-download")]
-                dir_listing_download: &vec![],
+                dir_listing_download: &[],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -55,6 +55,8 @@ mod tests {
             dir_listing_order: 6,
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &vec![],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -101,6 +103,8 @@ mod tests {
             dir_listing_order: 6,
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &vec![],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -148,6 +152,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -182,6 +188,8 @@ mod tests {
             dir_listing_order: 0,
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &vec![],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -218,6 +226,8 @@ mod tests {
             dir_listing_order: 0,
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &vec![],
             redirect_trailing_slash: true,
             compression_static: false,
             ignore_hidden_files: false,
@@ -253,6 +263,8 @@ mod tests {
             dir_listing_order: 0,
             #[cfg(feature = "directory-listing")]
             dir_listing_format: &DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &vec![],
             redirect_trailing_slash: false,
             compression_static: false,
             ignore_hidden_files: false,
@@ -293,6 +305,8 @@ mod tests {
                     dir_listing_order: 6,
                     #[cfg(feature = "directory-listing")]
                     dir_listing_format: &DirListFmt::Html,
+                    #[cfg(feature = "directory-listing-download")]
+                    dir_listing_download: &vec![],
                     redirect_trailing_slash: true,
                     compression_static: false,
                     ignore_hidden_files: false,
@@ -348,6 +362,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -385,6 +401,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -424,6 +442,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -464,6 +484,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -507,6 +529,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -548,6 +572,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -587,6 +613,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -625,6 +653,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -667,6 +697,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -752,6 +784,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -825,6 +859,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -877,6 +913,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -929,6 +967,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -982,6 +1022,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1027,6 +1069,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1082,6 +1126,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1134,6 +1180,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1186,6 +1234,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1241,6 +1291,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1286,6 +1338,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1330,6 +1384,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1389,6 +1445,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: false,
                 ignore_hidden_files: false,
@@ -1440,6 +1498,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,
@@ -1482,6 +1542,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,
@@ -1526,6 +1588,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,
@@ -1560,6 +1624,8 @@ mod tests {
                 dir_listing_order: 6,
                 #[cfg(feature = "directory-listing")]
                 dir_listing_format: &DirListFmt::Html,
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &vec![],
                 redirect_trailing_slash: true,
                 compression_static: true,
                 ignore_hidden_files: true,


### PR DESCRIPTION
## Description
Support downloading a directory as a compressed tarball.

- Respond with compressed tarball when requested file is a directory and query has `download-archive` parameter set.
- When listing said `<directory>`, add a link with href `?download-archive=1` for user to download all content in directory as compressed tarball (see screenshot).

### Discussion & other notes

- ~~Is the "virtual file" approach appropriate? What should the server do when there is an existing `.tar.gz` file?~~
    - ~~A radical alternative is to introduce an `/api/` group, which may also be used by other non-static-file features such as health endpoint~~
    - ~~Query param seems to be a more versatile and robust solution, e.g. `/<directory>/?download-archive=gzip`~~
    - UPDATE: I feel like query param is the sanest way to go, unless I missed any other caveats or considerations.
- Since this will technically "list directory", if an option is used to toggle this feature, it should respect the directory listing option and possibly warn user/error on conflicting combination. 
- [x] TODO: set `follow_symlinks()` option for tar builder accordingly
- [x] TODO: refactor and cleanup
- [x] TODO: feature flag and runtime options (WIP)
- [x] TODO: test: dir list index - download link follows dir download opt
- [x] TODO: test: dir download - normal, no follow_symlinks
- [x] TODO: verify config file
- [x] TODO: handle ignore hidden file
    - [x] handle recursive append dir ourselves
- [x] TODO: polish testcase 
- ~~TODO: content disposition unicode handling~~ Apparently, non-ASCII is allowed by standard, and coincidentally there is a bug that does not validate the string the way it is documented, so everything works! see: https://github.com/hyperium/http/issues/519

## Related Issue
implement #67 

## Motivation and Context
This feature allows user to download the content of the entire directory all at once.

## How Has This Been Tested?
- Added `download_targz`, `download_targz_no_symlinks` testcase to check downloaded tarball content against directory content
- Added test to ensure download link exists when option is enabled, and ensure it doesnt exists when disabled

## Screenshots (if appropriate):
(Final implementation)
![image](https://github.com/user-attachments/assets/8071faa4-5ff3-4926-ae20-4e5be044e955)

(Previous POC)
![image](https://github.com/user-attachments/assets/af8a87a1-6fee-40f3-abf7-9756b9bb9ba8)

### Interface of this feature on other system

**Github**
A button in dropdown menu.
![image](https://github.com/user-attachments/assets/2a639ef6-e732-41e7-9257-ce45a4192a34)

**Jenkins**
A link below list of files, separated from the list itself
![image](https://github.com/user-attachments/assets/f8fdd2a3-bf05-4cf6-a6ff-60f1b2a1b19c)




