### PR TITLE
Remove `public` from `Cache-Control` header value to prevent conflicts with CDN and Basic Authentication

### DIFF
--- a/docs/content/features/directory-listing.md
+++ b/docs/content/features/directory-listing.md
@@ -121,7 +121,7 @@ curl -iH "content-type: application/json" http://localhost:8787
 # HTTP/1.1 200 OK
 # content-type: application/json
 # content-length: 163
-# cache-control: public, max-age=86400
+# cache-control: max-age=86400
 # date: Tue, 11 Oct 2022 23:24:55 GMT
 
 # [{"name":"spécial directöry","type":"directory","mtime":"2022-10-07T00:53:50Z"},{"name":"index.html.gz","type":"file","mtime":"2022-09-27T22:44:34Z","size":332}]⏎

--- a/docs/content/features/http-methods.md
+++ b/docs/content/features/http-methods.md
@@ -15,7 +15,7 @@ curl -I -X OPTIONS http://localhost:8787/assets/main.js
 # HTTP/1.1 204 No Content
 # allow: OPTIONS, HEAD, GET
 # accept-ranges: bytes
-# cache-control: public, max-age=31536000
+# cache-control: max-age=31536000
 # date: Thu, 10 Mar 2022 21:26:01 GMT
 ```
 
@@ -39,6 +39,6 @@ curl http://localhost:8787/assets/main.js \
 # accept-ranges: bytes
 # access-control-allow-headers: content-type, origin
 # access-control-allow-methods: GET, OPTIONS, HEAD
-# cache-control: public, max-age=31536000
+# cache-control: max-age=31536000
 # date: Thu, 10 Mar 2022 21:45:55 GMT
 ```

--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -47,7 +47,7 @@ pub fn append_headers(uri: &str, resp: &mut Response<Body>) {
     resp.headers_mut().insert(
         "cache-control",
         format!(
-            "public, max-age={}",
+            "max-age={}",
             // It caps value in seconds at ~136 years
             std::cmp::min(max_age, u32::MAX as u64)
         )
@@ -100,7 +100,7 @@ mod tests {
             assert_eq!(resp.status(), StatusCode::OK);
             assert_eq!(
                 cache_control.to_str().unwrap(),
-                format!("public, max-age={MAX_AGE_ONE_HOUR}")
+                format!("max-age={MAX_AGE_ONE_HOUR}")
             );
         }
     }
@@ -116,7 +116,7 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
             cache_control.to_str().unwrap(),
-            format!("public, max-age={MAX_AGE_ONE_DAY}")
+            format!("max-age={MAX_AGE_ONE_DAY}")
         );
     }
 
@@ -132,7 +132,7 @@ mod tests {
             assert_eq!(resp.status(), StatusCode::OK);
             assert_eq!(
                 cache_control.to_str().unwrap(),
-                format!("public, max-age={MAX_AGE_ONE_YEAR}")
+                format!("max-age={MAX_AGE_ONE_YEAR}")
             );
         }
     }

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -60,7 +60,7 @@ pub mod tests {
                 );
                 assert_eq!(
                     res.headers().get("cache-control"),
-                    Some(&HeaderValue::from_static("public, max-age=86400"))
+                    Some(&HeaderValue::from_static("max-age=86400"))
                 );
                 assert_eq!(
                     res.headers().get("server"),

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -89,7 +89,7 @@ pub mod tests {
 
                 assert_eq!(
                     res.headers().get("cache-control"),
-                    Some(&HeaderValue::from_static("public, max-age=86400"))
+                    Some(&HeaderValue::from_static("max-age=86400"))
                 );
                 assert_eq!(
                     res.headers().get("server"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR removes `public` from `Cache-Control` value, leaving `max-age=<VALUE>`, which can prevent CDN and Basic Authentication issues. See details on #560.

It applies to the [Cache-Control Headers](https://static-web-server.net/features/cache-control-headers/) feature with no user breaking changes expected.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It resolves #560.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
