### PR TITLE
Add HTTP-level metrics to experimental metrics endpoint

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -352,8 +352,7 @@ impl RequestHandler {
                 let resp = cors::post_process(&self.opts, req, resp)?;
 
                 // Set Content-Type for markdown files
-                let resp =
-                    crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
+                let resp = crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
 
                 // Add a `Vary` header if static compression is used
                 let resp = compression_static::post_process(&self.opts, req, resp)?;
@@ -375,8 +374,7 @@ impl RequestHandler {
                 let resp = security_headers::post_process(&self.opts, req, resp)?;
 
                 // Add/update custom headers
-                let resp =
-                    custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
+                let resp = custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
 
                 Ok(resp)
             }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -227,145 +227,196 @@ impl RequestHandler {
         log_addr::pre_process(&self.opts, req, remote_addr);
 
         async move {
-            // Reject if the HTTP request method is not allowed
-            if !req.method().is_allowed() {
-                return error_page::error_response(
-                    req.uri(),
-                    req.method(),
-                    &StatusCode::METHOD_NOT_ALLOWED,
-                    &self.opts.page404,
-                    &self.opts.page50x,
-                );
-            }
-
-            // Health endpoint check
-            if let Some(result) = health::pre_process(&self.opts, req) {
-                return result;
-            }
-
-            // Metrics endpoint check
             #[cfg(all(unix, feature = "experimental"))]
-            if let Some(result) = metrics::pre_process(&self.opts, req) {
-                return result;
+            let req_start = std::time::Instant::now();
+            #[cfg(all(unix, feature = "experimental"))]
+            let req_method = req.method().clone();
+            #[cfg(all(unix, feature = "experimental"))]
+            let req_host = req
+                .headers()
+                .get(hyper::header::HOST)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_owned();
+            #[cfg(all(unix, feature = "experimental"))]
+            let is_metrics_path = req.uri().path() == "/metrics";
+            #[cfg(all(unix, feature = "experimental"))]
+            let metrics_enabled = self.opts.experimental_metrics;
+
+            #[cfg(all(unix, feature = "experimental"))]
+            if metrics_enabled {
+                metrics::inc_requests_inflight();
             }
 
-            // CORS
-            if let Some(result) = cors::pre_process(&self.opts, req) {
-                return result;
-            }
+            let result: Result<Response<Body>, Error> = async {
+                // Reject if the HTTP request method is not allowed
+                if !req.method().is_allowed() {
+                    return error_page::error_response(
+                        req.uri(),
+                        req.method(),
+                        &StatusCode::METHOD_NOT_ALLOWED,
+                        &self.opts.page404,
+                        &self.opts.page50x,
+                    );
+                }
 
-            // `Basic` HTTP Authorization Schema
-            #[cfg(feature = "basic-auth")]
-            if let Some(response) = basic_auth::pre_process(&self.opts, req) {
-                return response;
-            }
+                // Health endpoint check
+                if let Some(result) = health::pre_process(&self.opts, req) {
+                    return result;
+                }
 
-            // Maintenance Mode
-            if let Some(response) = maintenance_mode::pre_process(&self.opts, req) {
-                return response;
-            }
+                // Metrics endpoint check
+                #[cfg(all(unix, feature = "experimental"))]
+                if let Some(result) = metrics::pre_process(&self.opts, req) {
+                    return result;
+                }
 
-            // Redirects
-            if let Some(result) = redirects::pre_process(&self.opts, req) {
-                return result;
-            }
+                // CORS
+                if let Some(result) = cors::pre_process(&self.opts, req) {
+                    return result;
+                }
 
-            // Rewrites
-            if let Some(result) = rewrites::pre_process(&self.opts, req) {
-                return result;
-            }
+                // `Basic` HTTP Authorization Schema
+                #[cfg(feature = "basic-auth")]
+                if let Some(response) = basic_auth::pre_process(&self.opts, req) {
+                    return response;
+                }
 
-            // Advanced options
-            if let Some(advanced) = &self.opts.advanced_opts {
-                // If the "Host" header matches any virtual_host, change the root directory
-                if let Some(root) =
-                    virtual_hosts::get_real_root(req, advanced.virtual_hosts.as_deref())
+                // Maintenance Mode
+                if let Some(response) = maintenance_mode::pre_process(&self.opts, req) {
+                    return response;
+                }
+
+                // Redirects
+                if let Some(result) = redirects::pre_process(&self.opts, req) {
+                    return result;
+                }
+
+                // Rewrites
+                if let Some(result) = rewrites::pre_process(&self.opts, req) {
+                    return result;
+                }
+
+                // Advanced options
+                if let Some(advanced) = &self.opts.advanced_opts {
+                    // If the "Host" header matches any virtual_host, change the root directory
+                    if let Some(root) =
+                        virtual_hosts::get_real_root(req, advanced.virtual_hosts.as_deref())
+                    {
+                        base_path = root;
+                    }
+                }
+
+                let index_files = index_files.as_ref();
+
+                // Check for markdown content negotiation (only if enabled)
+                let uri_path_md = if self.opts.accept_markdown {
+                    crate::markdown::pre_process(req, base_path, req.uri().path())
+                } else {
+                    None
+                };
+                let uri_path = uri_path_md.as_deref().unwrap_or(req.uri().path());
+
+                // Static files
+                let (resp, file_path) = match static_files::handle(&HandleOpts {
+                    method: req.method(),
+                    headers: req.headers(),
+                    #[cfg(feature = "experimental")]
+                    memory_cache,
+                    base_path,
+                    uri_path,
+                    uri_query: req.uri().query(),
+                    #[cfg(feature = "directory-listing")]
+                    dir_listing,
+                    #[cfg(feature = "directory-listing")]
+                    dir_listing_order,
+                    #[cfg(feature = "directory-listing")]
+                    dir_listing_format,
+                    #[cfg(feature = "directory-listing-download")]
+                    dir_listing_download,
+                    redirect_trailing_slash,
+                    compression_static,
+                    ignore_hidden_files,
+                    index_files,
+                    disable_symlinks,
+                })
+                .await
                 {
-                    base_path = root;
+                    Ok(result) => (result.resp, Some(result.file_path)),
+                    Err(status) => (
+                        error_page::error_response(
+                            req.uri(),
+                            req.method(),
+                            &status,
+                            &self.opts.page404,
+                            &self.opts.page50x,
+                        )?,
+                        None,
+                    ),
+                };
+
+                // Check for a fallback response
+                #[cfg(feature = "fallback-page")]
+                let resp = fallback_page::post_process(&self.opts, req, resp)?;
+
+                // Append CORS headers if they are present
+                let resp = cors::post_process(&self.opts, req, resp)?;
+
+                // Set Content-Type for markdown files
+                let resp =
+                    crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
+
+                // Add a `Vary` header if static compression is used
+                let resp = compression_static::post_process(&self.opts, req, resp)?;
+
+                // Auto compression based on the `Accept-Encoding` header
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
+                let resp = compression::post_process(&self.opts, req, resp)?;
+
+                // Append `Cache-Control` headers for web assets
+                let resp = control_headers::post_process(&self.opts, req, resp)?;
+
+                // Append security headers
+                let resp = security_headers::post_process(&self.opts, req, resp)?;
+
+                // Add/update custom headers
+                let resp =
+                    custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
+
+                Ok(resp)
+            }
+            .await;
+
+            // Record HTTP metrics
+            #[cfg(all(unix, feature = "experimental"))]
+            if metrics_enabled {
+                metrics::dec_requests_inflight();
+                if !is_metrics_path {
+                    if let Ok(ref resp) = result {
+                        let bytes = resp
+                            .headers()
+                            .get(hyper::header::CONTENT_LENGTH)
+                            .and_then(|v| v.to_str().ok())
+                            .and_then(|v| v.parse::<u64>().ok())
+                            .unwrap_or(0);
+                        metrics::record_request(
+                            &req_method,
+                            resp.status(),
+                            &req_host,
+                            bytes,
+                            req_start.elapsed().as_secs_f64(),
+                        );
+                    }
                 }
             }
 
-            let index_files = index_files.as_ref();
-
-            // Check for markdown content negotiation (only if enabled)
-            let uri_path_md = if self.opts.accept_markdown {
-                crate::markdown::pre_process(req, base_path, req.uri().path())
-            } else {
-                None
-            };
-            let uri_path = uri_path_md.as_deref().unwrap_or(req.uri().path());
-
-            // Static files
-            let (resp, file_path) = match static_files::handle(&HandleOpts {
-                method: req.method(),
-                headers: req.headers(),
-                #[cfg(feature = "experimental")]
-                memory_cache,
-                base_path,
-                uri_path,
-                uri_query: req.uri().query(),
-                #[cfg(feature = "directory-listing")]
-                dir_listing,
-                #[cfg(feature = "directory-listing")]
-                dir_listing_order,
-                #[cfg(feature = "directory-listing")]
-                dir_listing_format,
-                #[cfg(feature = "directory-listing-download")]
-                dir_listing_download,
-                redirect_trailing_slash,
-                compression_static,
-                ignore_hidden_files,
-                index_files,
-                disable_symlinks,
-            })
-            .await
-            {
-                Ok(result) => (result.resp, Some(result.file_path)),
-                Err(status) => (
-                    error_page::error_response(
-                        req.uri(),
-                        req.method(),
-                        &status,
-                        &self.opts.page404,
-                        &self.opts.page50x,
-                    )?,
-                    None,
-                ),
-            };
-
-            // Check for a fallback response
-            #[cfg(feature = "fallback-page")]
-            let resp = fallback_page::post_process(&self.opts, req, resp)?;
-
-            // Append CORS headers if they are present
-            let resp = cors::post_process(&self.opts, req, resp)?;
-
-            // Set Content-Type for markdown files
-            let resp = crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
-
-            // Add a `Vary` header if static compression is used
-            let resp = compression_static::post_process(&self.opts, req, resp)?;
-
-            // Auto compression based on the `Accept-Encoding` header
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd",
-                feature = "compression-deflate"
-            ))]
-            let resp = compression::post_process(&self.opts, req, resp)?;
-
-            // Append `Cache-Control` headers for web assets
-            let resp = control_headers::post_process(&self.opts, req, resp)?;
-
-            // Append security headers
-            let resp = security_headers::post_process(&self.opts, req, resp)?;
-
-            // Add/update custom headers
-            let resp = custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
-
-            Ok(resp)
+            result
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -20,8 +20,8 @@ use crate::{Error, handler::RequestHandlerOpts, http_ext::MethodExt};
 // Histogram buckets tuned for static file serving (50µs to 10s).
 // Sub-millisecond range captures cache hits and small in-memory responses.
 const LATENCY_BUCKETS: &[f64] = &[
-    0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-    1.0, 2.5, 5.0, 10.0,
+    0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
+    2.5, 5.0, 10.0,
 ];
 
 static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -152,9 +152,7 @@ pub fn record_request<T>(req: &Request<T>, status: StatusCode, bytes: u64, elaps
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     let sc = status_class(status.as_u16());
-    HTTP_REQUESTS_TOTAL
-        .with_label_values(&[m, sc, host])
-        .inc();
+    HTTP_REQUESTS_TOTAL.with_label_values(&[m, sc, host]).inc();
     HTTP_REQUEST_DURATION_SECONDS
         .with_label_values(&[m, sc, host])
         .observe(elapsed);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,30 +3,108 @@
 // See https://static-web-server.net/ for more information
 // Copyright (C) 2019-present Jose Quintana <joseluisq.net>
 
-//! Module providing the experimental metrics endpoint.
+//! Module providing the experimental metrics endpoint and HTTP-level instrumentation.
 //!
 
+use std::sync::LazyLock;
+
 use headers::{ContentType, HeaderMapExt};
-use hyper::{Body, Request, Response};
-use prometheus::{Encoder, TextEncoder, default_registry};
+use hyper::{Body, Method, Request, Response, StatusCode};
+use prometheus::{
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, TextEncoder,
+    default_registry,
+};
 
 use crate::{Error, handler::RequestHandlerOpts, http_ext::MethodExt};
 
-/// Initializes the metrics endpoint.
+// Histogram buckets tuned for static file serving (50µs to 10s).
+// Sub-millisecond range captures cache hits and small in-memory responses.
+const LATENCY_BUCKETS: &[f64] = &[
+    0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+    1.0, 2.5, 5.0, 10.0,
+];
+
+static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "sws_http_requests_total",
+            "Total HTTP requests by method, status class, and host.",
+        ),
+        &["method", "status", "host"],
+    )
+    .unwrap()
+});
+
+static HTTP_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "sws_http_request_duration_seconds",
+            "HTTP request duration in seconds by method, status class, and host.",
+        )
+        .buckets(LATENCY_BUCKETS.to_vec()),
+        &["method", "status", "host"],
+    )
+    .unwrap()
+});
+
+static HTTP_RESPONSE_BYTES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "sws_http_response_bytes_total",
+            "Total HTTP response bytes (Content-Length) by method, status class, and host.",
+        ),
+        &["method", "status", "host"],
+    )
+    .unwrap()
+});
+
+static HTTP_REQUESTS_INFLIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "sws_http_requests_inflight",
+        "Number of HTTP requests currently being processed.",
+    )
+    .unwrap()
+});
+
+static HTTP_CONNECTIONS_ACTIVE: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "sws_http_connections_active",
+        "Number of currently active HTTP connections.",
+    )
+    .unwrap()
+});
+
+/// Initializes the metrics endpoint and registers HTTP-level collectors.
 pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.experimental_metrics = enabled;
     tracing::info!("metrics endpoint (experimental): enabled={enabled}");
 
     if enabled {
-        default_registry()
+        let registry = default_registry();
+        registry
             .register(Box::new(
                 tokio_metrics_collector::default_runtime_collector(),
             ))
             .unwrap();
+        registry
+            .register(Box::new(HTTP_REQUESTS_TOTAL.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_REQUEST_DURATION_SECONDS.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_RESPONSE_BYTES_TOTAL.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_REQUESTS_INFLIGHT.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_CONNECTIONS_ACTIVE.clone()))
+            .unwrap();
     }
 }
 
-/// Handles metrics requests
+/// Handles metrics requests.
 pub fn pre_process<T>(
     opts: &RequestHandlerOpts,
     req: &Request<T>,
@@ -62,9 +140,56 @@ pub fn pre_process<T>(
     Some(Ok(resp))
 }
 
+/// Records HTTP request metrics after a response is produced.
+pub fn record_request(method: &Method, status: StatusCode, host: &str, bytes: u64, elapsed: f64) {
+    let m = method.as_str();
+    let sc = status_class(status.as_u16());
+    HTTP_REQUESTS_TOTAL
+        .with_label_values(&[m, sc, host])
+        .inc();
+    HTTP_REQUEST_DURATION_SECONDS
+        .with_label_values(&[m, sc, host])
+        .observe(elapsed);
+    if bytes > 0 {
+        HTTP_RESPONSE_BYTES_TOTAL
+            .with_label_values(&[m, sc, host])
+            .inc_by(bytes);
+    }
+}
+
+/// Increments the inflight requests gauge.
+pub fn inc_requests_inflight() {
+    HTTP_REQUESTS_INFLIGHT.inc();
+}
+
+/// Decrements the inflight requests gauge.
+pub fn dec_requests_inflight() {
+    HTTP_REQUESTS_INFLIGHT.dec();
+}
+
+/// Increments the active connections gauge.
+pub fn inc_connections() {
+    HTTP_CONNECTIONS_ACTIVE.inc();
+}
+
+/// Decrements the active connections gauge.
+pub fn dec_connections() {
+    HTTP_CONNECTIONS_ACTIVE.dec();
+}
+
+fn status_class(code: u16) -> &'static str {
+    match code / 100 {
+        1 => "1xx",
+        2 => "2xx",
+        3 => "3xx",
+        4 => "4xx",
+        _ => "5xx",
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::pre_process;
+    use super::*;
     use crate::handler::RequestHandlerOpts;
     use hyper::{Body, Request};
 
@@ -130,5 +255,59 @@ mod tests {
             )
             .is_some()
         );
+    }
+
+    #[test]
+    fn test_status_class() {
+        assert_eq!(status_class(100), "1xx");
+        assert_eq!(status_class(200), "2xx");
+        assert_eq!(status_class(301), "3xx");
+        assert_eq!(status_class(404), "4xx");
+        assert_eq!(status_class(500), "5xx");
+        assert_eq!(status_class(999), "5xx");
+    }
+
+    #[test]
+    fn test_record_request() {
+        // Force lazy init so metrics exist
+        let before = HTTP_REQUESTS_TOTAL
+            .with_label_values(&["GET", "2xx", "example.com"])
+            .get();
+        let bytes_before = HTTP_RESPONSE_BYTES_TOTAL
+            .with_label_values(&["GET", "2xx", "example.com"])
+            .get();
+
+        record_request(&Method::GET, StatusCode::OK, "example.com", 1024, 0.005);
+
+        assert_eq!(
+            HTTP_REQUESTS_TOTAL
+                .with_label_values(&["GET", "2xx", "example.com"])
+                .get(),
+            before + 1
+        );
+        assert_eq!(
+            HTTP_RESPONSE_BYTES_TOTAL
+                .with_label_values(&["GET", "2xx", "example.com"])
+                .get(),
+            bytes_before + 1024
+        );
+    }
+
+    #[test]
+    fn test_connection_gauge() {
+        let before = HTTP_CONNECTIONS_ACTIVE.get();
+        inc_connections();
+        assert_eq!(HTTP_CONNECTIONS_ACTIVE.get(), before + 1);
+        dec_connections();
+        assert_eq!(HTTP_CONNECTIONS_ACTIVE.get(), before);
+    }
+
+    #[test]
+    fn test_inflight_gauge() {
+        let before = HTTP_REQUESTS_INFLIGHT.get();
+        inc_requests_inflight();
+        assert_eq!(HTTP_REQUESTS_INFLIGHT.get(), before + 1);
+        dec_requests_inflight();
+        assert_eq!(HTTP_REQUESTS_INFLIGHT.get(), before);
     }
 }


### PR DESCRIPTION
This PR adds HTTP request/response metrics to the existing experimental Prometheus `/metrics`
endpoint.

### Metrics added

| Metric | Type | Labels | Description |
|--------|------|--------|-------------|
| `sws_http_requests_total` | Counter | method, status, host | Total HTTP requests |
| `sws_http_request_duration_seconds` | Histogram | method, status, host | Request latency |
| `sws_http_response_bytes_total` | Counter | method, status, host | Response bytes (Content-Length) |
| `sws_http_requests_inflight` | Gauge | — | Requests currently being processed |
| `sws_http_connections_active` | Gauge | — | Active HTTP connections |

### Design decisions

- **Bounded label cardinality**: Status codes are bucketed into classes (`2xx`, `3xx`, etc.) rather than individual codes. The `host` label enables per-site observability in virtual hosting configurations.
- **Self-exclusion**: Requests to `/metrics` are excluded from request metrics to prevent feedback loops from Prometheus scraping.
- **Connection tracking**: Uses an RAII guard (`ConnectionGuard` with `Drop`) in the service layer to ensure the active connections gauge stays accurate even on unexpected disconnects.
- **Histogram buckets**: Tuned for static file serving latency (50µs–10s), with sub-millisecond granularity for cache hits and small in-memory responses.  I'm not certain that we have the right range of buckets here.  50µs might be a little ambitious.  LMK if you think we need to adjust.
- **Zero overhead when disabled**: All instrumentation is gated behind `cfg(all(unix, feature = "experimental"))` at compile time, with an additional runtime check on the `experimental_metrics` flag.

### Testing

New unit tests for `status_class`, `record_request`, connection gauge, and inflight gauge.

### Concerns
- **Cardinality**: I chose to label metrics with `host` because it gives better observability into noisy neighbor situations.  However, if an installation has hundreds or thousands of sites hosted under one SWS instance, this could produce excessive cardinality.  I thought about adding a limit but wanted to see what you all think.  I don't know much about the typical SWS installation.