### PR TITLE
Local-time support for logs by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,6 +2506,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tokio-rustls = { version = "0.26", optional = true, default-features = false, fe
 tokio-util = { version = "0.7", default-features = false, features = ["compat", "io"] }
 toml = "0.9"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "registry", "parking_lot", "fmt", "ansi", "tracing-log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "registry", "parking_lot", "fmt", "ansi", "tracing-log", "local-time"] }
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.mimalloc]
 version = "0.1.48"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -7,7 +7,11 @@
 //!
 
 use tracing::Level;
-use tracing_subscriber::{filter::Targets, fmt::format::FmtSpan, prelude::*};
+use tracing_subscriber::{
+    filter::Targets,
+    fmt::{format::FmtSpan, time},
+    prelude::*,
+};
 
 use crate::{Context, Result};
 
@@ -30,6 +34,7 @@ fn configure(level: &str, enable_ansi: bool) -> Result {
         .with_writer(std::io::stderr)
         .with_span_events(FmtSpan::CLOSE)
         .with_ansi(enable_ansi)
+        .with_timer(time::LocalTime::rfc_3339())
         .with_filter(Targets::default().with_default(level));
 
     match tracing_subscriber::registry()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

Date and time of log entries in SWS were always displayed in _UTC_ regardless of the system's time zone.

This PR prefers the local-time (system date and time) for logs by default to respect the user's system time.
It also allows the usage of the POSIX `TZ` environment variable to update the time zone on demand.

Below are some examples.

System defaults (e.g. CET "UTC +1"):

```sh
$ static-web-server -p 8788 -d /var/public/ -g info
# 2026-02-26T22:26:56.369326294+01:00  INFO static_web_server::server: static-web-server 2.41.0
# 2026-02-26T22:26:56.369448665+01:00  INFO static_web_server::server: log level: info
# 2026-02-26T22:26:56.369514676+01:00  INFO static_web_server::server: server bound to tcp socket [::]:8788
# 2026-02-26T22:26:56.369553858+01:00  INFO static_web_server::server: runtime worker threads: 4
# 2026-02-26T22:26:56.369591864+01:00  INFO static_web_server::server: runtime max blocking threads: 512
# ....
```

Custom time zone via `TZ` env (e.g. PET "UTC -5"):

```sh
$ TZ="America/Lima" \
    static-web-server -p 8788 -d /var/public/ -g info
# 2026-02-26T16:25:55.345113713-05:00  INFO static_web_server::server: static-web-server 2.41.0
# 2026-02-26T16:25:55.34955361-05:00  INFO static_web_server::server: log level: info
# 2026-02-26T16:25:55.35031443-05:00  INFO static_web_server::server: server bound to tcp socket [::]:8788
# 2026-02-26T16:25:55.350388002-05:00  INFO static_web_server::server: runtime worker threads: 4
# 2026-02-26T16:25:55.350436754-05:00  INFO static_web_server::server: runtime max blocking threads: 512
# ....
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
