### PR TITLE
Add metrics feature documenation page

### DIFF
--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -193,6 +193,10 @@ Provide a custom HTTP status code when entering into maintenance mode. Default `
 
 Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed.
 
+### SERVER_METRICS
+
+Activate the Prometheus metrics endpoint. See [Metrics](../features/metrics.md) for details.
+
 ## Windows
 
 The following options and commands are Windows platform-specific.

--- a/docs/content/features/metrics.md
+++ b/docs/content/features/metrics.md
@@ -7,7 +7,7 @@ This feature is disabled by default and can be controlled by the boolean `--metr
 ## Exposed metrics
 
 | Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| -- | -- | -- | -- |
 | `sws_http_requests_total` | Counter | method, status, host | Total requests by method, status class (2xx, 4xx, etc.), and Host header |
 | `sws_http_request_duration_seconds` | Histogram | method, status, host | Request latency with buckets from 50µs to 10s |
 | `sws_http_response_bytes_total` | Counter | method, status, host | Total response bytes (from Content-Length) |

--- a/docs/content/features/metrics.md
+++ b/docs/content/features/metrics.md
@@ -1,0 +1,47 @@
+# Metrics
+
+SWS provides an optional `/metrics` endpoint that exposes Prometheus-compatible metrics about HTTP traffic. Useful for monitoring request rates, latency, error rates, and connection counts.
+
+This feature is disabled by default and can be controlled by the boolean `--metrics` option or the equivalent [SERVER_METRICS](../configuration/environment-variables.md#server_metrics) env.
+
+## Exposed metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `sws_http_requests_total` | Counter | method, status, host | Total requests by method, status class (2xx, 4xx, etc.), and Host header |
+| `sws_http_request_duration_seconds` | Histogram | method, status, host | Request latency with buckets from 50µs to 10s |
+| `sws_http_response_bytes_total` | Counter | method, status, host | Total response bytes (from Content-Length) |
+| `sws_http_requests_inflight` | Gauge | — | Requests currently being processed |
+| `sws_http_connections_active` | Gauge | — | Active HTTP connections |
+
+When built with the `experimental` feature and `RUSTFLAGS="--cfg tokio_unstable"`, Tokio runtime metrics (worker threads, task scheduling, etc.) are also included in the output.
+
+## Example
+
+```sh
+static-web-server --root /var/www --metrics
+```
+
+```sh
+curl http://localhost/metrics
+```
+
+```text
+# HELP sws_http_requests_total Total HTTP requests by method, status class, and host.
+# TYPE sws_http_requests_total counter
+sws_http_requests_total{host="localhost",method="GET",status="2xx"} 42
+# HELP sws_http_request_duration_seconds HTTP request duration in seconds by method, status class, and host.
+# TYPE sws_http_request_duration_seconds histogram
+sws_http_request_duration_seconds_bucket{host="localhost",method="GET",status="2xx",le="0.001"} 38
+...
+# HELP sws_http_connections_active Number of currently active HTTP connections.
+# TYPE sws_http_connections_active gauge
+sws_http_connections_active 2
+```
+
+## TOML configuration
+
+```toml
+[general]
+metrics = true
+```

--- a/docs/content/features/metrics.md
+++ b/docs/content/features/metrics.md
@@ -39,6 +39,10 @@ sws_http_request_duration_seconds_bucket{host="localhost",method="GET",status="2
 sws_http_connections_active 2
 ```
 
+## Grafana dashboard
+
+An example Grafana dashboard is included in [`contrib/grafana/dashboard.json`](https://github.com/static-web-server/static-web-server/blob/master/contrib/grafana/dashboard.json). Import it into Grafana to get panels for request rates, latency histograms, error rates, and active connections out of the box.
+
 ## TOML configuration
 
 ```toml

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -64,6 +64,7 @@ Cross-platform and available for `Linux`, `macOS`, `Windows`, `FreeBSD`, `NetBSD
 - Default and custom error pages.
 - Built-in HTTP to HTTPS redirect.
 - GET/HEAD Health check endpoint.
+- Prometheus-compatible `/metrics` endpoint for traffic monitoring.
 - Support for serving pre-compressed (Gzip/Brotli/Zstd) files directly from disk.
 - Custom URL rewrites and redirects via glob patterns with replacements.
 - Virtual hosting support.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
     - 'Ignore Files': 'features/ignore-files.md'
     - 'Disable Symlinks': 'features/disable-symlinks.md'
     - 'Health endpoint': 'features/health-endpoint.md'
+    - 'Metrics': 'features/metrics.md'
     - 'Virtual Hosting': 'features/virtual-hosting.md'
     - 'Multiple Index Files': 'features/multiple-index-files.md'
     - 'Maintenance Mode': 'features/maintenance-mode.md'


### PR DESCRIPTION
## Summary
- Add documentation page for the Prometheus metrics endpoint
- Covers exposed metrics, example output, and TOML configuration
- Add nav entry in mkdocs.yml

Companion to https://github.com/static-web-server/static-web-server/pull/631 which stabilizes the metrics feature.