### PR TITLE
chore: gate metrics under 'metrics' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page"]
+default = ["compression", "http2", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
 # HTTP2
@@ -57,9 +57,10 @@ directory-listing-download = ["async-tar",  "compression-gzip", "directory-listi
 basic-auth = ["bcrypt"]
 # Fallback Page
 fallback-page = []
+# Metrics endpoint with Prometheus integration
+metrics = ["prometheus"]
 # Experimental features (requires: `RUSTFLAGS="--cfg tokio_unstable"`)
-# --experimental-metrics
-experimental = ["tokio-metrics-collector", "prometheus", "compact_str", "mini-moka"]
+experimental = ["metrics", "tokio-metrics-collector", "compact_str", "mini-moka"]
 
 [dependencies]
 aho-corasick = "1.1.4"
@@ -85,6 +86,7 @@ mime_guess = "2.0"
 mini-moka = { version = "0.10.3", optional = true }
 percent-encoding = "2.3"
 pin-project = "1.1"
+prometheus = { version = "0.14.0", default-features = false, optional = true }
 regex-lite = "0.1.8"
 rustls-pki-types = { version = "1.13.2", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -106,7 +108,6 @@ version = "0.1.48"
 signal-hook = { version = "0.4.1", features = ["extended-siginfo"] }
 signal-hook-tokio = { version = "0.4.0", features = ["futures-v0_3"], default-features = false }
 tokio-metrics-collector = { version = "0.3.1", optional = true }
-prometheus = { version = "0.14.0", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Cross-platform and available for `Linux`, `macOS`, `Windows`, `FreeBSD`, `NetBSD
 - Default and custom error pages.
 - Built-in HTTP to HTTPS redirect.
 - GET/HEAD Health check endpoint.
+- [Prometheus metrics endpoint](https://static-web-server.net/features/metrics/) for HTTP request counts, latency histograms, and connection tracking.
 - Support for serving pre-compressed (Gzip/Brotli/Zstd) files directly from disk.
 - Custom URL rewrites and redirects via glob patterns with replacements.
 - Virtual hosting support.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -352,8 +352,7 @@ impl RequestHandler {
                 let resp = cors::post_process(&self.opts, req, resp)?;
 
                 // Set Content-Type for markdown files
-                let resp =
-                    crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
+                let resp = crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
 
                 // Add a `Vary` header if static compression is used
                 let resp = compression_static::post_process(&self.opts, req, resp)?;
@@ -375,8 +374,7 @@ impl RequestHandler {
                 let resp = security_headers::post_process(&self.opts, req, resp)?;
 
                 // Add/update custom headers
-                let resp =
-                    custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
+                let resp = custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
 
                 Ok(resp)
             }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -227,145 +227,196 @@ impl RequestHandler {
         log_addr::pre_process(&self.opts, req, remote_addr);
 
         async move {
-            // Reject if the HTTP request method is not allowed
-            if !req.method().is_allowed() {
-                return error_page::error_response(
-                    req.uri(),
-                    req.method(),
-                    &StatusCode::METHOD_NOT_ALLOWED,
-                    &self.opts.page404,
-                    &self.opts.page50x,
-                );
-            }
-
-            // Health endpoint check
-            if let Some(result) = health::pre_process(&self.opts, req) {
-                return result;
-            }
-
-            // Metrics endpoint check
             #[cfg(all(unix, feature = "experimental"))]
-            if let Some(result) = metrics::pre_process(&self.opts, req) {
-                return result;
+            let req_start = std::time::Instant::now();
+            #[cfg(all(unix, feature = "experimental"))]
+            let req_method = req.method().clone();
+            #[cfg(all(unix, feature = "experimental"))]
+            let req_host = req
+                .headers()
+                .get(hyper::header::HOST)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_owned();
+            #[cfg(all(unix, feature = "experimental"))]
+            let is_metrics_path = req.uri().path() == "/metrics";
+            #[cfg(all(unix, feature = "experimental"))]
+            let metrics_enabled = self.opts.experimental_metrics;
+
+            #[cfg(all(unix, feature = "experimental"))]
+            if metrics_enabled {
+                metrics::inc_requests_inflight();
             }
 
-            // CORS
-            if let Some(result) = cors::pre_process(&self.opts, req) {
-                return result;
-            }
+            let result: Result<Response<Body>, Error> = async {
+                // Reject if the HTTP request method is not allowed
+                if !req.method().is_allowed() {
+                    return error_page::error_response(
+                        req.uri(),
+                        req.method(),
+                        &StatusCode::METHOD_NOT_ALLOWED,
+                        &self.opts.page404,
+                        &self.opts.page50x,
+                    );
+                }
 
-            // `Basic` HTTP Authorization Schema
-            #[cfg(feature = "basic-auth")]
-            if let Some(response) = basic_auth::pre_process(&self.opts, req) {
-                return response;
-            }
+                // Health endpoint check
+                if let Some(result) = health::pre_process(&self.opts, req) {
+                    return result;
+                }
 
-            // Maintenance Mode
-            if let Some(response) = maintenance_mode::pre_process(&self.opts, req) {
-                return response;
-            }
+                // Metrics endpoint check
+                #[cfg(all(unix, feature = "experimental"))]
+                if let Some(result) = metrics::pre_process(&self.opts, req) {
+                    return result;
+                }
 
-            // Redirects
-            if let Some(result) = redirects::pre_process(&self.opts, req) {
-                return result;
-            }
+                // CORS
+                if let Some(result) = cors::pre_process(&self.opts, req) {
+                    return result;
+                }
 
-            // Rewrites
-            if let Some(result) = rewrites::pre_process(&self.opts, req) {
-                return result;
-            }
+                // `Basic` HTTP Authorization Schema
+                #[cfg(feature = "basic-auth")]
+                if let Some(response) = basic_auth::pre_process(&self.opts, req) {
+                    return response;
+                }
 
-            // Advanced options
-            if let Some(advanced) = &self.opts.advanced_opts {
-                // If the "Host" header matches any virtual_host, change the root directory
-                if let Some(root) =
-                    virtual_hosts::get_real_root(req, advanced.virtual_hosts.as_deref())
+                // Maintenance Mode
+                if let Some(response) = maintenance_mode::pre_process(&self.opts, req) {
+                    return response;
+                }
+
+                // Redirects
+                if let Some(result) = redirects::pre_process(&self.opts, req) {
+                    return result;
+                }
+
+                // Rewrites
+                if let Some(result) = rewrites::pre_process(&self.opts, req) {
+                    return result;
+                }
+
+                // Advanced options
+                if let Some(advanced) = &self.opts.advanced_opts {
+                    // If the "Host" header matches any virtual_host, change the root directory
+                    if let Some(root) =
+                        virtual_hosts::get_real_root(req, advanced.virtual_hosts.as_deref())
+                    {
+                        base_path = root;
+                    }
+                }
+
+                let index_files = index_files.as_ref();
+
+                // Check for markdown content negotiation (only if enabled)
+                let uri_path_md = if self.opts.accept_markdown {
+                    crate::markdown::pre_process(req, base_path, req.uri().path())
+                } else {
+                    None
+                };
+                let uri_path = uri_path_md.as_deref().unwrap_or(req.uri().path());
+
+                // Static files
+                let (resp, file_path) = match static_files::handle(&HandleOpts {
+                    method: req.method(),
+                    headers: req.headers(),
+                    #[cfg(feature = "experimental")]
+                    memory_cache,
+                    base_path,
+                    uri_path,
+                    uri_query: req.uri().query(),
+                    #[cfg(feature = "directory-listing")]
+                    dir_listing,
+                    #[cfg(feature = "directory-listing")]
+                    dir_listing_order,
+                    #[cfg(feature = "directory-listing")]
+                    dir_listing_format,
+                    #[cfg(feature = "directory-listing-download")]
+                    dir_listing_download,
+                    redirect_trailing_slash,
+                    compression_static,
+                    ignore_hidden_files,
+                    index_files,
+                    disable_symlinks,
+                })
+                .await
                 {
-                    base_path = root;
+                    Ok(result) => (result.resp, Some(result.file_path)),
+                    Err(status) => (
+                        error_page::error_response(
+                            req.uri(),
+                            req.method(),
+                            &status,
+                            &self.opts.page404,
+                            &self.opts.page50x,
+                        )?,
+                        None,
+                    ),
+                };
+
+                // Check for a fallback response
+                #[cfg(feature = "fallback-page")]
+                let resp = fallback_page::post_process(&self.opts, req, resp)?;
+
+                // Append CORS headers if they are present
+                let resp = cors::post_process(&self.opts, req, resp)?;
+
+                // Set Content-Type for markdown files
+                let resp =
+                    crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
+
+                // Add a `Vary` header if static compression is used
+                let resp = compression_static::post_process(&self.opts, req, resp)?;
+
+                // Auto compression based on the `Accept-Encoding` header
+                #[cfg(any(
+                    feature = "compression",
+                    feature = "compression-gzip",
+                    feature = "compression-brotli",
+                    feature = "compression-zstd",
+                    feature = "compression-deflate"
+                ))]
+                let resp = compression::post_process(&self.opts, req, resp)?;
+
+                // Append `Cache-Control` headers for web assets
+                let resp = control_headers::post_process(&self.opts, req, resp)?;
+
+                // Append security headers
+                let resp = security_headers::post_process(&self.opts, req, resp)?;
+
+                // Add/update custom headers
+                let resp =
+                    custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
+
+                Ok(resp)
+            }
+            .await;
+
+            // Record HTTP metrics
+            #[cfg(all(unix, feature = "experimental"))]
+            if metrics_enabled {
+                metrics::dec_requests_inflight();
+                if !is_metrics_path {
+                    if let Ok(ref resp) = result {
+                        let bytes = resp
+                            .headers()
+                            .get(hyper::header::CONTENT_LENGTH)
+                            .and_then(|v| v.to_str().ok())
+                            .and_then(|v| v.parse::<u64>().ok())
+                            .unwrap_or(0);
+                        metrics::record_request(
+                            &req_method,
+                            resp.status(),
+                            &req_host,
+                            bytes,
+                            req_start.elapsed().as_secs_f64(),
+                        );
+                    }
                 }
             }
 
-            let index_files = index_files.as_ref();
-
-            // Check for markdown content negotiation (only if enabled)
-            let uri_path_md = if self.opts.accept_markdown {
-                crate::markdown::pre_process(req, base_path, req.uri().path())
-            } else {
-                None
-            };
-            let uri_path = uri_path_md.as_deref().unwrap_or(req.uri().path());
-
-            // Static files
-            let (resp, file_path) = match static_files::handle(&HandleOpts {
-                method: req.method(),
-                headers: req.headers(),
-                #[cfg(feature = "experimental")]
-                memory_cache,
-                base_path,
-                uri_path,
-                uri_query: req.uri().query(),
-                #[cfg(feature = "directory-listing")]
-                dir_listing,
-                #[cfg(feature = "directory-listing")]
-                dir_listing_order,
-                #[cfg(feature = "directory-listing")]
-                dir_listing_format,
-                #[cfg(feature = "directory-listing-download")]
-                dir_listing_download,
-                redirect_trailing_slash,
-                compression_static,
-                ignore_hidden_files,
-                index_files,
-                disable_symlinks,
-            })
-            .await
-            {
-                Ok(result) => (result.resp, Some(result.file_path)),
-                Err(status) => (
-                    error_page::error_response(
-                        req.uri(),
-                        req.method(),
-                        &status,
-                        &self.opts.page404,
-                        &self.opts.page50x,
-                    )?,
-                    None,
-                ),
-            };
-
-            // Check for a fallback response
-            #[cfg(feature = "fallback-page")]
-            let resp = fallback_page::post_process(&self.opts, req, resp)?;
-
-            // Append CORS headers if they are present
-            let resp = cors::post_process(&self.opts, req, resp)?;
-
-            // Set Content-Type for markdown files
-            let resp = crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
-
-            // Add a `Vary` header if static compression is used
-            let resp = compression_static::post_process(&self.opts, req, resp)?;
-
-            // Auto compression based on the `Accept-Encoding` header
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd",
-                feature = "compression-deflate"
-            ))]
-            let resp = compression::post_process(&self.opts, req, resp)?;
-
-            // Append `Cache-Control` headers for web assets
-            let resp = control_headers::post_process(&self.opts, req, resp)?;
-
-            // Append security headers
-            let resp = security_headers::post_process(&self.opts, req, resp)?;
-
-            // Add/update custom headers
-            let resp = custom_headers::post_process(&self.opts, req, resp, file_path.as_ref())?;
-
-            Ok(resp)
+            result
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@
 //! `basic-auth` | Activates the Basic HTTP Authorization Schema feature.
 //! [**Fallback Page**](./features/error-pages.md#fallback-page-for-use-with-client-routers) |
 //! `fallback-page` | Activates the Fallback Page feature.
+//! **Metrics** |
+//! `metrics` | Activates the Prometheus metrics endpoint (`/metrics`). Enabled by default but requires the `--metrics` flag at runtime. Tokio runtime metrics are additionally available via the `experimental` feature.
 //!
 
 #![deny(missing_docs)]
@@ -158,7 +160,7 @@ pub mod maintenance_mode;
 pub(crate) mod markdown;
 #[cfg(feature = "experimental")]
 pub(crate) mod mem_cache;
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 pub(crate) mod metrics;
 pub mod redirects;
 pub(crate) mod response;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -20,8 +20,8 @@ use crate::{Error, handler::RequestHandlerOpts, http_ext::MethodExt};
 // Histogram buckets tuned for static file serving (50µs to 10s).
 // Sub-millisecond range captures cache hits and small in-memory responses.
 const LATENCY_BUCKETS: &[f64] = &[
-    0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-    1.0, 2.5, 5.0, 10.0,
+    0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
+    2.5, 5.0, 10.0,
 ];
 
 static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -152,9 +152,7 @@ pub fn record_request<T>(req: &Request<T>, status: StatusCode, bytes: u64, elaps
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
     let sc = status_class(status.as_u16());
-    HTTP_REQUESTS_TOTAL
-        .with_label_values(&[m, sc, host])
-        .inc();
+    HTTP_REQUESTS_TOTAL.with_label_values(&[m, sc, host]).inc();
     HTTP_REQUEST_DURATION_SECONDS
         .with_label_values(&[m, sc, host])
         .observe(elapsed);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,30 +3,108 @@
 // See https://static-web-server.net/ for more information
 // Copyright (C) 2019-present Jose Quintana <joseluisq.net>
 
-//! Module providing the experimental metrics endpoint.
+//! Module providing the experimental metrics endpoint and HTTP-level instrumentation.
 //!
 
+use std::sync::LazyLock;
+
 use headers::{ContentType, HeaderMapExt};
-use hyper::{Body, Request, Response};
-use prometheus::{Encoder, TextEncoder, default_registry};
+use hyper::{Body, Method, Request, Response, StatusCode};
+use prometheus::{
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, Opts, TextEncoder,
+    default_registry,
+};
 
 use crate::{Error, handler::RequestHandlerOpts, http_ext::MethodExt};
 
-/// Initializes the metrics endpoint.
+// Histogram buckets tuned for static file serving (50µs to 10s).
+// Sub-millisecond range captures cache hits and small in-memory responses.
+const LATENCY_BUCKETS: &[f64] = &[
+    0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+    1.0, 2.5, 5.0, 10.0,
+];
+
+static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "sws_http_requests_total",
+            "Total HTTP requests by method, status class, and host.",
+        ),
+        &["method", "status", "host"],
+    )
+    .unwrap()
+});
+
+static HTTP_REQUEST_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    HistogramVec::new(
+        HistogramOpts::new(
+            "sws_http_request_duration_seconds",
+            "HTTP request duration in seconds by method, status class, and host.",
+        )
+        .buckets(LATENCY_BUCKETS.to_vec()),
+        &["method", "status", "host"],
+    )
+    .unwrap()
+});
+
+static HTTP_RESPONSE_BYTES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "sws_http_response_bytes_total",
+            "Total HTTP response bytes (Content-Length) by method, status class, and host.",
+        ),
+        &["method", "status", "host"],
+    )
+    .unwrap()
+});
+
+static HTTP_REQUESTS_INFLIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "sws_http_requests_inflight",
+        "Number of HTTP requests currently being processed.",
+    )
+    .unwrap()
+});
+
+static HTTP_CONNECTIONS_ACTIVE: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "sws_http_connections_active",
+        "Number of currently active HTTP connections.",
+    )
+    .unwrap()
+});
+
+/// Initializes the metrics endpoint and registers HTTP-level collectors.
 pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.experimental_metrics = enabled;
     tracing::info!("metrics endpoint (experimental): enabled={enabled}");
 
     if enabled {
-        default_registry()
+        let registry = default_registry();
+        registry
             .register(Box::new(
                 tokio_metrics_collector::default_runtime_collector(),
             ))
             .unwrap();
+        registry
+            .register(Box::new(HTTP_REQUESTS_TOTAL.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_REQUEST_DURATION_SECONDS.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_RESPONSE_BYTES_TOTAL.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_REQUESTS_INFLIGHT.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(HTTP_CONNECTIONS_ACTIVE.clone()))
+            .unwrap();
     }
 }
 
-/// Handles metrics requests
+/// Handles metrics requests.
 pub fn pre_process<T>(
     opts: &RequestHandlerOpts,
     req: &Request<T>,
@@ -62,9 +140,56 @@ pub fn pre_process<T>(
     Some(Ok(resp))
 }
 
+/// Records HTTP request metrics after a response is produced.
+pub fn record_request(method: &Method, status: StatusCode, host: &str, bytes: u64, elapsed: f64) {
+    let m = method.as_str();
+    let sc = status_class(status.as_u16());
+    HTTP_REQUESTS_TOTAL
+        .with_label_values(&[m, sc, host])
+        .inc();
+    HTTP_REQUEST_DURATION_SECONDS
+        .with_label_values(&[m, sc, host])
+        .observe(elapsed);
+    if bytes > 0 {
+        HTTP_RESPONSE_BYTES_TOTAL
+            .with_label_values(&[m, sc, host])
+            .inc_by(bytes);
+    }
+}
+
+/// Increments the inflight requests gauge.
+pub fn inc_requests_inflight() {
+    HTTP_REQUESTS_INFLIGHT.inc();
+}
+
+/// Decrements the inflight requests gauge.
+pub fn dec_requests_inflight() {
+    HTTP_REQUESTS_INFLIGHT.dec();
+}
+
+/// Increments the active connections gauge.
+pub fn inc_connections() {
+    HTTP_CONNECTIONS_ACTIVE.inc();
+}
+
+/// Decrements the active connections gauge.
+pub fn dec_connections() {
+    HTTP_CONNECTIONS_ACTIVE.dec();
+}
+
+fn status_class(code: u16) -> &'static str {
+    match code / 100 {
+        1 => "1xx",
+        2 => "2xx",
+        3 => "3xx",
+        4 => "4xx",
+        _ => "5xx",
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::pre_process;
+    use super::*;
     use crate::handler::RequestHandlerOpts;
     use hyper::{Body, Request};
 
@@ -130,5 +255,59 @@ mod tests {
             )
             .is_some()
         );
+    }
+
+    #[test]
+    fn test_status_class() {
+        assert_eq!(status_class(100), "1xx");
+        assert_eq!(status_class(200), "2xx");
+        assert_eq!(status_class(301), "3xx");
+        assert_eq!(status_class(404), "4xx");
+        assert_eq!(status_class(500), "5xx");
+        assert_eq!(status_class(999), "5xx");
+    }
+
+    #[test]
+    fn test_record_request() {
+        // Force lazy init so metrics exist
+        let before = HTTP_REQUESTS_TOTAL
+            .with_label_values(&["GET", "2xx", "example.com"])
+            .get();
+        let bytes_before = HTTP_RESPONSE_BYTES_TOTAL
+            .with_label_values(&["GET", "2xx", "example.com"])
+            .get();
+
+        record_request(&Method::GET, StatusCode::OK, "example.com", 1024, 0.005);
+
+        assert_eq!(
+            HTTP_REQUESTS_TOTAL
+                .with_label_values(&["GET", "2xx", "example.com"])
+                .get(),
+            before + 1
+        );
+        assert_eq!(
+            HTTP_RESPONSE_BYTES_TOTAL
+                .with_label_values(&["GET", "2xx", "example.com"])
+                .get(),
+            bytes_before + 1024
+        );
+    }
+
+    #[test]
+    fn test_connection_gauge() {
+        let before = HTTP_CONNECTIONS_ACTIVE.get();
+        inc_connections();
+        assert_eq!(HTTP_CONNECTIONS_ACTIVE.get(), before + 1);
+        dec_connections();
+        assert_eq!(HTTP_CONNECTIONS_ACTIVE.get(), before);
+    }
+
+    #[test]
+    fn test_inflight_gauge() {
+        let before = HTTP_REQUESTS_INFLIGHT.get();
+        inc_requests_inflight();
+        assert_eq!(HTTP_REQUESTS_INFLIGHT.get(), before + 1);
+        dec_requests_inflight();
+        assert_eq!(HTTP_REQUESTS_INFLIGHT.get(), before);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,7 @@ use tokio::sync::{Mutex, watch::Receiver};
 
 use crate::handler::{RequestHandler, RequestHandlerOpts};
 
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 use crate::metrics;
 #[cfg(any(unix, windows))]
 use crate::signals;
@@ -323,9 +323,9 @@ impl Server {
         // Log remote address option
         log_addr::init(general.log_remote_address, &mut handler_opts);
 
-        // Metrics endpoint option (experimental)
-        #[cfg(all(unix, feature = "experimental"))]
-        metrics::init(general.experimental_metrics, &mut handler_opts);
+        // Metrics endpoint option
+        #[cfg(feature = "metrics")]
+        metrics::init(general.metrics, &mut handler_opts);
 
         // CORS option
         cors::init(

--- a/src/service.rs
+++ b/src/service.rs
@@ -16,7 +16,7 @@ use std::task::{Context, Poll};
 
 use crate::{Error, handler::RequestHandler, transport::Transport};
 
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 use crate::metrics;
 
 /// It defines the router service which is the main entry point for Hyper Server.
@@ -55,7 +55,7 @@ pub struct RequestService {
 
 impl RequestService {
     fn new(handler: Arc<RequestHandler>, remote_addr: Option<SocketAddr>) -> Self {
-        #[cfg(all(unix, feature = "experimental"))]
+        #[cfg(feature = "metrics")]
         metrics::inc_connections();
         Self {
             handler,
@@ -64,7 +64,7 @@ impl RequestService {
     }
 }
 
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 impl Drop for RequestService {
     fn drop(&mut self) {
         metrics::dec_connections();

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -525,18 +525,18 @@ pub struct General {
     /// This is especially useful with Kubernetes liveness and readiness probes.
     pub health: bool,
 
-    #[cfg(all(unix, feature = "experimental"))]
+    #[cfg(feature = "metrics")]
     #[arg(
-        long = "experimental-metrics",
+        long,
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
         require_equals(false),
         action = clap::ArgAction::Set,
-        env = "SERVER_EXPERIMENTAL_METRICS",
+        env = "SERVER_METRICS",
     )]
-    /// Add a /metrics endpoint that returns a Prometheus metrics response.
-    pub experimental_metrics: bool,
+    /// Enable the /metrics endpoint that exposes Prometheus metrics for HTTP requests, connections, and latency.
+    pub metrics: bool,
 
     #[arg(
         long,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -374,9 +374,9 @@ pub struct General {
     /// Accept markdown content negotiation feature.
     pub accept_markdown: Option<bool>,
 
-    #[cfg(all(unix, feature = "experimental"))]
-    /// Metrics endpoint feature (experimental).
-    pub experimental_metrics: Option<bool>,
+    #[cfg(feature = "metrics")]
+    /// Metrics endpoint feature.
+    pub metrics: Option<bool>,
 
     /// Maintenance mode feature.
     pub maintenance_mode: Option<bool>,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -204,8 +204,8 @@ impl Settings {
         let mut index_files = opts.index_files;
         let mut health = opts.health;
 
-        #[cfg(all(unix, feature = "experimental"))]
-        let mut experimental_metrics = opts.experimental_metrics;
+        #[cfg(feature = "metrics")]
+        let mut metrics = opts.metrics;
 
         let mut maintenance_mode = opts.maintenance_mode;
         let mut maintenance_mode_status = opts.maintenance_mode_status;
@@ -396,9 +396,9 @@ impl Settings {
                 if let Some(v) = general.accept_markdown {
                     accept_markdown = v
                 }
-                #[cfg(all(unix, feature = "experimental"))]
-                if let Some(v) = general.experimental_metrics {
-                    experimental_metrics = v
+                #[cfg(feature = "metrics")]
+                if let Some(v) = general.metrics {
+                    metrics = v
                 }
                 if let Some(v) = general.index_files {
                     index_files = v
@@ -681,8 +681,8 @@ impl Settings {
                 accept_markdown,
                 index_files,
                 health,
-                #[cfg(all(unix, feature = "experimental"))]
-                experimental_metrics,
+                #[cfg(feature = "metrics")]
+                metrics,
                 maintenance_mode,
                 maintenance_mode_status,
                 maintenance_mode_file,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -111,8 +111,8 @@ pub mod fixtures {
             accept_markdown: general.accept_markdown,
             index_files: vec![general.index_files],
             health: general.health,
-            #[cfg(all(unix, feature = "experimental"))]
-            experimental_metrics: general.experimental_metrics,
+            #[cfg(feature = "metrics")]
+            metrics_enabled: general.metrics,
             maintenance_mode: general.maintenance_mode,
             maintenance_mode_status: general.maintenance_mode_status,
             maintenance_mode_file: general.maintenance_mode_file,

--- a/tests/fixtures/toml/experimental_metrics.toml
+++ b/tests/fixtures/toml/experimental_metrics.toml
@@ -2,4 +2,4 @@
 
 root = "docker/public"
 
-experimental-metrics = true
+metrics = true


### PR DESCRIPTION
This gates the metrics under the `metrics` feature.  This feature is built in by default _but not enabled in the server by default._

To enable /metrics, you must run with the `--metrics` argument.