### PR TITLE
Add metrics feature gate for Prometheus metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page"]
+default = ["compression", "http2", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
 # HTTP2
@@ -57,9 +57,10 @@ directory-listing-download = ["async-tar",  "compression-gzip", "directory-listi
 basic-auth = ["bcrypt"]
 # Fallback Page
 fallback-page = []
+# Metrics endpoint with Prometheus integration
+metrics = ["prometheus"]
 # Experimental features (requires: `RUSTFLAGS="--cfg tokio_unstable"`)
-# --experimental-metrics
-experimental = ["tokio-metrics-collector", "prometheus", "compact_str", "mini-moka"]
+experimental = ["metrics", "tokio-metrics-collector", "compact_str", "mini-moka"]
 
 [dependencies]
 aho-corasick = "1.1.4"
@@ -85,6 +86,7 @@ mime_guess = "2.0"
 mini-moka = { version = "0.10.3", optional = true }
 percent-encoding = "2.3"
 pin-project = "1.1"
+prometheus = { version = "0.14.0", default-features = false, optional = true }
 regex-lite = "0.1.8"
 rustls-pki-types = { version = "1.13.2", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -106,7 +108,6 @@ version = "0.1.48"
 signal-hook = { version = "0.4.1", features = ["extended-siginfo"] }
 signal-hook-tokio = { version = "0.4.0", features = ["futures-v0_3"], default-features = false }
 tokio-metrics-collector = { version = "0.3.1", optional = true }
-prometheus = { version = "0.14.0", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Cross-platform and available for `Linux`, `macOS`, `Windows`, `FreeBSD`, `NetBSD
 - Default and custom error pages.
 - Built-in HTTP to HTTPS redirect.
 - GET/HEAD Health check endpoint.
+- [Prometheus metrics endpoint](https://static-web-server.net/features/metrics/) for HTTP request counts, latency histograms, and connection tracking.
 - Support for serving pre-compressed (Gzip/Brotli/Zstd) files directly from disk.
 - Custom URL rewrites and redirects via glob patterns with replacements.
 - Virtual hosting support.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@
 //! `basic-auth` | Activates the Basic HTTP Authorization Schema feature.
 //! [**Fallback Page**](./features/error-pages.md#fallback-page-for-use-with-client-routers) |
 //! `fallback-page` | Activates the Fallback Page feature.
+//! **Metrics** |
+//! `metrics` | Activates the Prometheus metrics endpoint (`/metrics`). Enabled by default but requires the `--metrics` flag at runtime. Tokio runtime metrics are additionally available via the `experimental` feature.
 //!
 
 #![deny(missing_docs)]
@@ -158,7 +160,7 @@ pub mod maintenance_mode;
 pub(crate) mod markdown;
 #[cfg(feature = "experimental")]
 pub(crate) mod mem_cache;
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 pub(crate) mod metrics;
 pub mod redirects;
 pub(crate) mod response;

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,7 @@ use tokio::sync::{Mutex, watch::Receiver};
 
 use crate::handler::{RequestHandler, RequestHandlerOpts};
 
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 use crate::metrics;
 #[cfg(any(unix, windows))]
 use crate::signals;
@@ -323,9 +323,9 @@ impl Server {
         // Log remote address option
         log_addr::init(general.log_remote_address, &mut handler_opts);
 
-        // Metrics endpoint option (experimental)
-        #[cfg(all(unix, feature = "experimental"))]
-        metrics::init(general.experimental_metrics, &mut handler_opts);
+        // Metrics endpoint option
+        #[cfg(feature = "metrics")]
+        metrics::init(general.metrics, &mut handler_opts);
 
         // CORS option
         cors::init(

--- a/src/service.rs
+++ b/src/service.rs
@@ -16,7 +16,7 @@ use std::task::{Context, Poll};
 
 use crate::{Error, handler::RequestHandler, transport::Transport};
 
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 use crate::metrics;
 
 /// It defines the router service which is the main entry point for Hyper Server.
@@ -55,7 +55,7 @@ pub struct RequestService {
 
 impl RequestService {
     fn new(handler: Arc<RequestHandler>, remote_addr: Option<SocketAddr>) -> Self {
-        #[cfg(all(unix, feature = "experimental"))]
+        #[cfg(feature = "metrics")]
         metrics::inc_connections();
         Self {
             handler,
@@ -64,7 +64,7 @@ impl RequestService {
     }
 }
 
-#[cfg(all(unix, feature = "experimental"))]
+#[cfg(feature = "metrics")]
 impl Drop for RequestService {
     fn drop(&mut self) {
         metrics::dec_connections();

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -525,18 +525,18 @@ pub struct General {
     /// This is especially useful with Kubernetes liveness and readiness probes.
     pub health: bool,
 
-    #[cfg(all(unix, feature = "experimental"))]
+    #[cfg(feature = "metrics")]
     #[arg(
-        long = "experimental-metrics",
+        long,
         default_value = "false",
         default_missing_value("true"),
         num_args(0..=1),
         require_equals(false),
         action = clap::ArgAction::Set,
-        env = "SERVER_EXPERIMENTAL_METRICS",
+        env = "SERVER_METRICS",
     )]
-    /// Add a /metrics endpoint that returns a Prometheus metrics response.
-    pub experimental_metrics: bool,
+    /// Enable the /metrics endpoint that exposes Prometheus metrics for HTTP requests, connections, and latency.
+    pub metrics: bool,
 
     #[arg(
         long,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -374,9 +374,9 @@ pub struct General {
     /// Accept markdown content negotiation feature.
     pub accept_markdown: Option<bool>,
 
-    #[cfg(all(unix, feature = "experimental"))]
-    /// Metrics endpoint feature (experimental).
-    pub experimental_metrics: Option<bool>,
+    #[cfg(feature = "metrics")]
+    /// Metrics endpoint feature.
+    pub metrics: Option<bool>,
 
     /// Maintenance mode feature.
     pub maintenance_mode: Option<bool>,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -204,8 +204,8 @@ impl Settings {
         let mut index_files = opts.index_files;
         let mut health = opts.health;
 
-        #[cfg(all(unix, feature = "experimental"))]
-        let mut experimental_metrics = opts.experimental_metrics;
+        #[cfg(feature = "metrics")]
+        let mut metrics = opts.metrics;
 
         let mut maintenance_mode = opts.maintenance_mode;
         let mut maintenance_mode_status = opts.maintenance_mode_status;
@@ -396,9 +396,9 @@ impl Settings {
                 if let Some(v) = general.accept_markdown {
                     accept_markdown = v
                 }
-                #[cfg(all(unix, feature = "experimental"))]
-                if let Some(v) = general.experimental_metrics {
-                    experimental_metrics = v
+                #[cfg(feature = "metrics")]
+                if let Some(v) = general.metrics {
+                    metrics = v
                 }
                 if let Some(v) = general.index_files {
                     index_files = v
@@ -681,8 +681,8 @@ impl Settings {
                 accept_markdown,
                 index_files,
                 health,
-                #[cfg(all(unix, feature = "experimental"))]
-                experimental_metrics,
+                #[cfg(feature = "metrics")]
+                metrics,
                 maintenance_mode,
                 maintenance_mode_status,
                 maintenance_mode_file,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -111,8 +111,8 @@ pub mod fixtures {
             accept_markdown: general.accept_markdown,
             index_files: vec![general.index_files],
             health: general.health,
-            #[cfg(all(unix, feature = "experimental"))]
-            experimental_metrics: general.experimental_metrics,
+            #[cfg(feature = "metrics")]
+            metrics_enabled: general.metrics,
             maintenance_mode: general.maintenance_mode,
             maintenance_mode_status: general.maintenance_mode_status,
             maintenance_mode_file: general.maintenance_mode_file,

--- a/tests/fixtures/toml/experimental_metrics.toml
+++ b/tests/fixtures/toml/experimental_metrics.toml
@@ -2,4 +2,4 @@
 
 root = "docker/public"
 
-experimental-metrics = true
+metrics = true


### PR DESCRIPTION
Jose, sorry about the confusion.  I didn't realize you had merged my first PR when I created that last PR.  Here's a clean one, cherry-picked into a fresh branch.

This gates the Prometheus metrics under a feature called `metrics`.  It is enabled in the build by default but the endpoint must be enabled with the CLI arg `--metrics`.

Docs in another PR.

Thanks for looking at my work!