### PR TITLE
Update mimalloc to v3 for musl targets (statically-linked binaries)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,8 +101,8 @@ toml = "0.9"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "registry", "parking_lot", "fmt", "ansi", "tracing-log", "local-time"] }
 
-[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.mimalloc]
-version = "0.1.48"
+[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies]
+mimalloc = { version = "0.1.48", features = ["v3"] }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { version = "0.4.1", features = ["extended-siginfo"] }


### PR DESCRIPTION
This PR fixes a memory consumption increase since the v1.40.0 release, which dropped jemalloc in favor of mimalloc v2.

According to https://github.com/microsoft/mimalloc/issues/1073#issuecomment-2973066198, mimalloc `v3` is to be considered production-ready and preferable to `v2` (current). `v3` switch improves performance and reduces memory utilization for static binaries, such as musl.

For example, start-up memory consumption of a SWS x86_64 musl binary is `~14.7MiB` using mimalloc v2 and `~9.44MiB` using v3.

This change should benefit static binaries and Docker images using it, such as `scratch` and `alpine` variants. 

<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It resolves #602.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
